### PR TITLE
Fix: Repositioned conversation settings button to prevent overlap wit…

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -23,7 +23,7 @@
 
 .smtcmp-chat-input-settings-outer {
   position: absolute;
-  top: -23px;
+  top: 0px;
   right: -3px;
   left: auto !important; /* cancel any left: 0 from other rules */
   z-index: 3;


### PR DESCRIPTION
This commit repositions the conversation settings button to its proper coordinates. Previously, the button's location resulted in it obscuring the "Copy Message" and "View Details" options, leading to a poor user experience.

Before:
<img width="563" height="227" alt="image" src="https://github.com/user-attachments/assets/56b6c46a-be35-4d8d-9e04-91e037acd002" />

After:
<img width="553" height="238" alt="66828A49-65B9-4EFC-8DD8-DCAA949893E3" src="https://github.com/user-attachments/assets/fafa442f-4c1a-4211-917b-3db26178466c" />
