### PR TITLE
fix: escape angle brackets in generated text to prevent HTML interpretation

### DIFF
--- a/src/features/editor/tab-completion/tabCompletionController.ts
+++ b/src/features/editor/tab-completion/tabCompletionController.ts
@@ -3,6 +3,7 @@ import { EditorView } from '@codemirror/view'
 import type { Editor, MarkdownView } from 'obsidian'
 
 import { getChatModelClient } from '../../../core/llm/manager'
+import { escapeMarkdownSpecialChars } from '../../../utils/markdown-escape'
 import {
   DEFAULT_TAB_COMPLETION_OPTIONS,
   DEFAULT_TAB_COMPLETION_SYSTEM_PROMPT,
@@ -588,7 +589,10 @@ export class TabCompletionController {
     }
 
     const cursor = editor.getCursor()
-    const suggestionText = suggestion.text
+    const suggestionText = escapeMarkdownSpecialChars(suggestion.text, {
+      escapeAngleBrackets: true,
+      preserveCodeBlocks: true,
+    })
     this.deps.clearInlineSuggestion()
     editor.replaceRange(suggestionText, cursor, cursor)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ import {
   readMultipleTFiles,
   readTFileContent,
 } from './utils/obsidian'
+import { escapeMarkdownSpecialChars } from './utils/markdown-escape'
 
 const inlineSuggestionExtensionViews = new WeakSet<EditorView>()
 
@@ -748,7 +749,10 @@ export default class SmartComposerPlugin extends Plugin {
       return false
     }
 
-    const insertionText = text
+    const insertionText = escapeMarkdownSpecialChars(text, {
+      escapeAngleBrackets: true,
+      preserveCodeBlocks: true,
+    })
     this.clearInlineSuggestion()
     editor.replaceRange(insertionText, startPos, startPos)
 

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -341,6 +341,7 @@ export const smartComposerSettingsSchema = z.object({
         DEFAULT_CHAT_MODELS[0].id,
       tabCompletionOptions: { ...DEFAULT_TAB_COMPLETION_OPTIONS },
       tabCompletionSystemPrompt: DEFAULT_TAB_COMPLETION_SYSTEM_PROMPT,
+      tabCompletionTriggers: [...DEFAULT_TAB_COMPLETION_TRIGGERS],
       smartSpaceQuickActions: undefined,
       smartSpaceTriggerMode: 'single-space',
       smartSpaceUseWebSearch: false,

--- a/src/utils/markdown-escape.test.ts
+++ b/src/utils/markdown-escape.test.ts
@@ -1,0 +1,114 @@
+import {
+  escapeMarkdownSpecialChars,
+  unescapeMarkdownSpecialChars,
+} from './markdown-escape'
+
+describe('escapeMarkdownSpecialChars', () => {
+  it('should escape angle brackets in simple text', () => {
+    const input = 'Use <keyword> to specify a value'
+    const result = escapeMarkdownSpecialChars(input)
+    expect(result).toBe('Use \\<keyword\\> to specify a value')
+  })
+
+  it('should escape angle brackets in command examples', () => {
+    const input = 'For example, use winget search <keyword> to find packages.'
+    const result = escapeMarkdownSpecialChars(input)
+    expect(result).toBe(
+      'For example, use winget search \\<keyword\\> to find packages.'
+    )
+  })
+
+  it('should escape multiple angle bracket pairs', () => {
+    const input = 'Copy <source> to <destination>'
+    const result = escapeMarkdownSpecialChars(input)
+    expect(result).toBe('Copy \\<source\\> to \\<destination\\>')
+  })
+
+  it('should preserve code blocks when enabled', () => {
+    const input = 'Use `<keyword>` in code or <value> in text'
+    const result = escapeMarkdownSpecialChars(input, {
+      preserveCodeBlocks: true,
+    })
+    expect(result).toBe('Use `<keyword>` in code or \\<value\\> in text')
+  })
+
+  it('should preserve triple backtick code blocks', () => {
+    const input = 'Example:\n```\n<tag>content</tag>\n```\nUse <value> outside'
+    const result = escapeMarkdownSpecialChars(input, {
+      preserveCodeBlocks: true,
+    })
+    expect(result).toBe(
+      'Example:\n```\n<tag>content</tag>\n```\nUse \\<value\\> outside'
+    )
+  })
+
+  it('should not escape when disabled', () => {
+    const input = 'Use <keyword> here'
+    const result = escapeMarkdownSpecialChars(input, {
+      escapeAngleBrackets: false,
+    })
+    expect(result).toBe('Use <keyword> here')
+  })
+
+  it('should handle text without special characters', () => {
+    const input = 'This is plain text without any special characters'
+    const result = escapeMarkdownSpecialChars(input)
+    expect(result).toBe('This is plain text without any special characters')
+  })
+
+  it('should escape opening angle bracket only', () => {
+    const input = 'Start with <incomplete bracket'
+    const result = escapeMarkdownSpecialChars(input)
+    expect(result).toBe('Start with \\<incomplete bracket')
+  })
+
+  it('should escape closing angle bracket only', () => {
+    const input = 'Incomplete bracket> at end'
+    const result = escapeMarkdownSpecialChars(input)
+    expect(result).toBe('Incomplete bracket\\> at end')
+  })
+
+  it('should handle empty string', () => {
+    const input = ''
+    const result = escapeMarkdownSpecialChars(input)
+    expect(result).toBe('')
+  })
+
+  it('should handle text with mixed inline and block code', () => {
+    const input =
+      'Use `<inline>` code and:\n```js\nconst x = <T>()\n```\nThen <value>'
+    const result = escapeMarkdownSpecialChars(input, {
+      preserveCodeBlocks: true,
+    })
+    expect(result).toBe(
+      'Use `<inline>` code and:\n```js\nconst x = <T>()\n```\nThen \\<value\\>'
+    )
+  })
+})
+
+describe('unescapeMarkdownSpecialChars', () => {
+  it('should unescape angle brackets', () => {
+    const input = 'Use \\<keyword\\> to specify a value'
+    const result = unescapeMarkdownSpecialChars(input)
+    expect(result).toBe('Use <keyword> to specify a value')
+  })
+
+  it('should unescape multiple pairs', () => {
+    const input = 'Copy \\<source\\> to \\<destination\\>'
+    const result = unescapeMarkdownSpecialChars(input)
+    expect(result).toBe('Copy <source> to <destination>')
+  })
+
+  it('should handle empty string', () => {
+    const input = ''
+    const result = unescapeMarkdownSpecialChars(input)
+    expect(result).toBe('')
+  })
+
+  it('should be inverse of escape function', () => {
+    const original = 'Use <keyword> in command <value> here'
+    const escaped = escapeMarkdownSpecialChars(original)
+    const unescaped = unescapeMarkdownSpecialChars(escaped)
+    expect(unescaped).toBe(original)
+  })
+})

--- a/src/utils/markdown-escape.ts
+++ b/src/utils/markdown-escape.ts
@@ -1,0 +1,106 @@
+/**
+ * Escapes special Markdown/HTML characters in generated text to prevent formatting issues.
+ * This is particularly important for inline suggestions where angle brackets might be
+ * interpreted as HTML tags.
+ *
+ * @param text - The text to escape
+ * @param options - Escape options
+ * @returns The escaped text
+ */
+export function escapeMarkdownSpecialChars(
+  text: string,
+  options?: {
+    escapeAngleBrackets?: boolean
+    escapeBackslashes?: boolean
+    preserveCodeBlocks?: boolean
+  },
+): string {
+  const {
+    escapeAngleBrackets = true,
+    escapeBackslashes = false,
+    preserveCodeBlocks = true,
+  } = options ?? {}
+
+  if (!text) return text
+
+  // If we want to preserve code blocks, we need to extract them first,
+  // escape the rest, then put them back
+  if (preserveCodeBlocks) {
+    const codeBlockRegex = /(`{1,3})[\s\S]*?\1/g
+    const codeBlocks: string[] = []
+    let index = 0
+
+    // Extract code blocks and replace with placeholders
+    const textWithPlaceholders = text.replace(codeBlockRegex, (match) => {
+      const placeholder = `__CODE_BLOCK_${index}__`
+      codeBlocks[index] = match
+      index++
+      return placeholder
+    })
+
+    // Escape the text (excluding code blocks)
+    let escaped = escapeText(textWithPlaceholders, {
+      escapeAngleBrackets,
+      escapeBackslashes,
+    })
+
+    // Restore code blocks
+    codeBlocks.forEach((block, i) => {
+      escaped = escaped.replace(`__CODE_BLOCK_${i}__`, block)
+    })
+
+    return escaped
+  }
+
+  return escapeText(text, { escapeAngleBrackets, escapeBackslashes })
+}
+
+function escapeText(
+  text: string,
+  options: {
+    escapeAngleBrackets: boolean
+    escapeBackslashes: boolean
+  },
+): string {
+  let result = text
+
+  // Escape backslashes first (if enabled) to avoid double-escaping
+  if (options.escapeBackslashes) {
+    result = result.replace(/\\/g, '\\\\')
+  }
+
+  // Escape angle brackets to prevent HTML interpretation
+  if (options.escapeAngleBrackets) {
+    // Only escape standalone angle brackets that look like they could be HTML tags
+    // Pattern: < followed by word characters (potential tag name)
+    result = result.replace(/<(\w+)>/g, '\\<$1\\>')
+
+    // Also handle cases like <keyword or value> without closing bracket
+    result = result.replace(/(\s|^)<(\w+)/g, '$1\\<$2')
+    result = result.replace(/(\w+)>(\s|$)/g, '$1\\>$2')
+  }
+
+  return result
+}
+
+/**
+ * Removes escape characters that were added by escapeMarkdownSpecialChars.
+ * Useful for reverting escaped text back to original form.
+ *
+ * @param text - The escaped text
+ * @returns The unescaped text
+ */
+export function unescapeMarkdownSpecialChars(text: string): string {
+  if (!text) return text
+
+  let result = text
+
+  // Unescape angle brackets
+  result = result.replace(/\\</g, '<')
+  result = result.replace(/\\>/g, '>')
+
+  // Unescape backslashes (do this last to avoid issues)
+  result = result.replace(/\\\\/g, '\\')
+
+  return result
+}


### PR DESCRIPTION
## Problem
LLM-generated text with angle brackets like `<keyword>` is interpreted as HTML tags in Obsidian, making them invisible to users.

## Solution
- Added `escapeMarkdownSpecialChars()` utility function in `src/utils/markdown-escape.ts`
- Escapes `<` and `>` characters while preserving content inside code blocks
- Applied to both tab completion and continue writing modes

## Testing
- Added 15 comprehensive unit tests (all passing ✅)
- TypeScript type checks passing ✅
- Handles edge cases: paired brackets, unpaired brackets, code blocks, empty strings

## Changes
- `src/utils/markdown-escape.ts` - new utility with escape logic
- `src/utils/markdown-escape.test.ts` - comprehensive test suite
- `src/features/editor/tab-completion/tabCompletionController.ts` - apply escape to tab completions
- `src/main.ts` - apply escape to continue writing mode
- `src/settings/schema/setting.types.ts` - fix missing default value

Fixes the issue where placeholders like `<keyword>` disappear in rendered Markdown content.