### PR TITLE
feat: support native Bedrock dual path

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "yolo",
   "name": "YOLO",
-  "version": "1.5.3.3",
+  "version": "1.5.4.0",
   "minAppVersion": "1.8.0",
   "description": "Agent-native AI assistant — chat, write, search, orchestrate, all in one.",
   "author": "Lapix0x0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "obsidian-yolo",
-  "version": "1.5.3.3",
+  "version": "1.5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-yolo",
-      "version": "1.5.3.3",
+      "version": "1.5.4.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@aws-sdk/client-bedrock": "^3.1020.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1019.0",
         "@codemirror/state": "^6.5.1",
         "@codemirror/view": "^6.36.2",
@@ -296,6 +297,57 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/@aws-sdk/client-bedrock": {
+      "version": "3.1020.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.1020.0.tgz",
+      "integrity": "sha512-OIM38upZjWsi62070cOm2nZAJsIeZC26KhOFDt8T6gmzbfcoz7XgkJ6eK9/JFfFagoFykUvXX0nfbcqtryWY0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-node": "^3.972.28",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.27",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/token-providers": "3.1020.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.13",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.45",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
       "version": "3.1019.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1019.0.tgz",
@@ -360,20 +412,44 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/@aws-sdk/client-bedrock/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1020.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1020.0.tgz",
+      "integrity": "sha512-T61KA/VKl0zVUubdxigr1ut7SEpwE1/4CIKb14JDLyTAOne2yWKtQE1dDCSHl0UqrZNwW/bTt+EBHfQbslZJdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.17",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.25.tgz",
-      "integrity": "sha512-TNrx7eq6nKNOO62HWPqoBqPLXEkW6nLZQGwjL6lq1jZtigWYbK1NbCnT7mKDzbLMHZfuOECUt3n6CzxjUW9HWQ==",
+      "version": "3.973.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
+      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/xml-builder": "^3.972.16",
-        "@smithy/core": "^3.23.12",
+        "@smithy/core": "^3.23.13",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/smithy-client": "^4.12.8",
         "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.12",
@@ -391,12 +467,12 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.23.tgz",
-      "integrity": "sha512-EamaclJcCEaPHp6wiVknNMM2RlsPMjAHSsYSFLNENBM8Wz92QPc6cOn3dif6vPDQt0Oo4IEghDy3NMDCzY/IvA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
+      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/core": "^3.973.26",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/types": "^4.13.1",
@@ -413,20 +489,20 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.25.tgz",
-      "integrity": "sha512-qPymamdPcLp6ugoVocG1y5r69ScNiRzb0hogX25/ij+Wz7c7WnsgjLTaz7+eB5BfRxeyUwuw5hgULMuwOGOpcw==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
+      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/core": "^3.973.26",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/node-http-handler": "^4.5.1",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/smithy-client": "^4.12.8",
         "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-stream": "^4.5.21",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -440,19 +516,19 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.26.tgz",
-      "integrity": "sha512-xKxEAMuP6GYx2y5GET+d3aGEroax3AgGfwBE65EQAUe090lzyJ/RzxPX9s8v7Z6qAk0XwfQl+LrmH05X7YvTeg==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.27.tgz",
+      "integrity": "sha512-Um26EsNSUfVUX0wUXnUA1W3wzKhVy6nviEElsh5lLZUYj9bk6DXOPnpte0gt+WHubcVfVsRk40bbm4KaroTEag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.25",
-        "@aws-sdk/credential-provider-env": "^3.972.23",
-        "@aws-sdk/credential-provider-http": "^3.972.25",
-        "@aws-sdk/credential-provider-login": "^3.972.26",
-        "@aws-sdk/credential-provider-process": "^3.972.23",
-        "@aws-sdk/credential-provider-sso": "^3.972.26",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.26",
-        "@aws-sdk/nested-clients": "^3.996.16",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-env": "^3.972.24",
+        "@aws-sdk/credential-provider-http": "^3.972.26",
+        "@aws-sdk/credential-provider-login": "^3.972.27",
+        "@aws-sdk/credential-provider-process": "^3.972.24",
+        "@aws-sdk/credential-provider-sso": "^3.972.27",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.27",
+        "@aws-sdk/nested-clients": "^3.996.17",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/credential-provider-imds": "^4.2.12",
         "@smithy/property-provider": "^4.2.12",
@@ -471,13 +547,13 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.26.tgz",
-      "integrity": "sha512-EFcM8RM3TUxnZOfMJo++3PnyxFu1fL/huzmn3Vh+8IWRgqZawUD3cRwwOr+/4bE9DpyHaLOWFAjY0lfK5X9ZkQ==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.27.tgz",
+      "integrity": "sha512-t3ehEtHomGZwg5Gixw4fYbYtG9JBnjfAjSDabxhPEu/KLLUp0BB37/APX7MSKXQhX6ZH7pseuACFJ19NrAkNdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.25",
-        "@aws-sdk/nested-clients": "^3.996.16",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.17",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
@@ -496,17 +572,17 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.27.tgz",
-      "integrity": "sha512-jXpxSolfFnPVj6GCTtx3xIdWNoDR7hYC/0SbetGZxOC9UnNmipHeX1k6spVstf7eWJrMhXNQEgXC0pD1r5tXIg==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.28.tgz",
+      "integrity": "sha512-rren+P6k5rShG5PX61iVi40kKdueyuMLBRTctQbyR5LooO9Ygr5L6R7ilG7RF1957NSH3KC3TU206fZuKwjSpQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.23",
-        "@aws-sdk/credential-provider-http": "^3.972.25",
-        "@aws-sdk/credential-provider-ini": "^3.972.26",
-        "@aws-sdk/credential-provider-process": "^3.972.23",
-        "@aws-sdk/credential-provider-sso": "^3.972.26",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.26",
+        "@aws-sdk/credential-provider-env": "^3.972.24",
+        "@aws-sdk/credential-provider-http": "^3.972.26",
+        "@aws-sdk/credential-provider-ini": "^3.972.27",
+        "@aws-sdk/credential-provider-process": "^3.972.24",
+        "@aws-sdk/credential-provider-sso": "^3.972.27",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.27",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/credential-provider-imds": "^4.2.12",
         "@smithy/property-provider": "^4.2.12",
@@ -525,12 +601,12 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.23.tgz",
-      "integrity": "sha512-IL/TFW59++b7MpHserjUblGrdP5UXy5Ekqqx1XQkERXBFJcZr74I7VaSrQT5dxdRMU16xGK4L0RQ5fQG1pMgnA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
+      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/core": "^3.973.26",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/shared-ini-file-loader": "^4.4.7",
@@ -548,14 +624,32 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.26.tgz",
-      "integrity": "sha512-c6ghvRb6gTlMznWhGxn/bpVCcp0HRaz4DobGVD9kI4vwHq186nU2xN/S7QGkm0lo0H2jQU8+dgpUFLxfTcwCOg==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.27.tgz",
+      "integrity": "sha512-CWXeGjlbBuHcm9appZUgXKP2zHDyTti0/+gXpSFJ2J3CnSwf1KWjicjN0qG2ozkMH6blrrzMrimeIOEYNl238Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.25",
-        "@aws-sdk/nested-clients": "^3.996.16",
-        "@aws-sdk/token-providers": "3.1019.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.17",
+        "@aws-sdk/token-providers": "3.1020.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1020.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1020.0.tgz",
+      "integrity": "sha512-T61KA/VKl0zVUubdxigr1ut7SEpwE1/4CIKb14JDLyTAOne2yWKtQE1dDCSHl0UqrZNwW/bTt+EBHfQbslZJdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.17",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/shared-ini-file-loader": "^4.4.7",
@@ -573,13 +667,13 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.26.tgz",
-      "integrity": "sha512-cXcS3+XD3iwhoXkM44AmxjmbcKueoLCINr1e+IceMmCySda5ysNIfiGBGe9qn5EMiQ9Jd7pP0AGFtcd6OV3Lvg==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.27.tgz",
+      "integrity": "sha512-CUY4hQIFswdQNEsRGEzGBUKGMK5KpqmNDdu2ROMgI+45PLFS8H0y3Tm7kvM16uvvw3n1pVxk85tnRVUTgtaa1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.25",
-        "@aws-sdk/nested-clients": "^3.996.16",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.17",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/shared-ini-file-loader": "^4.4.7",
@@ -702,15 +796,15 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.26.tgz",
-      "integrity": "sha512-AilFIh4rI/2hKyyGN6XrB0yN96W2o7e7wyrPWCM6QjZM1mcC/pVkW3IWWRvuBWMpVP8Fg+rMpbzeLQ6dTM4gig==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.27.tgz",
+      "integrity": "sha512-TIRLO5UR2+FVUGmhYoAwVkKhcVzywEDX/5LzR9tjy1h8FQAXOtFg2IqgmwvxU7y933rkTn9rl6AdgcAUgQ1/Kg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/core": "^3.973.26",
         "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-endpoints": "^3.996.5",
-        "@smithy/core": "^3.23.12",
+        "@smithy/core": "^3.23.13",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
         "@smithy/util-retry": "^4.2.12",
@@ -756,44 +850,44 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.16.tgz",
-      "integrity": "sha512-L7Qzoj/qQU1cL5GnYLQP5LbI+wlLCLoINvcykR3htKcQ4tzrPf2DOs72x933BM7oArYj1SKrkb2lGlsJHIic3g==",
+      "version": "3.996.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.17.tgz",
+      "integrity": "sha512-7B0HIX0tEFmOSJuWzdHZj1WhMXSryM+h66h96ZkqSncoY7J6wq61KOu4Kr57b/YnJP3J/EeQYVFulgR281h+7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/core": "^3.973.26",
         "@aws-sdk/middleware-host-header": "^3.972.8",
         "@aws-sdk/middleware-logger": "^3.972.8",
         "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.26",
+        "@aws-sdk/middleware-user-agent": "^3.972.27",
         "@aws-sdk/region-config-resolver": "^3.972.10",
         "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-endpoints": "^3.996.5",
         "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.12",
+        "@aws-sdk/util-user-agent-node": "^3.973.13",
         "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.12",
+        "@smithy/core": "^3.23.13",
         "@smithy/fetch-http-handler": "^5.3.15",
         "@smithy/hash-node": "^4.2.12",
         "@smithy/invalid-dependency": "^4.2.12",
         "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.27",
-        "@smithy/middleware-retry": "^4.4.44",
-        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.45",
+        "@smithy/middleware-serde": "^4.2.16",
         "@smithy/middleware-stack": "^4.2.12",
         "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/node-http-handler": "^4.5.1",
         "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/smithy-client": "^4.12.8",
         "@smithy/types": "^4.13.1",
         "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.43",
-        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
         "@smithy/util-endpoints": "^3.3.3",
         "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-retry": "^4.2.12",
@@ -955,12 +1049,12 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.12.tgz",
-      "integrity": "sha512-8phW0TS8ntENJgDcFewYT/Q8dOmarpvSxEjATu2GUBAutiHr++oEGCiBUwxslCMNvwW2cAPZNT53S/ym8zm/gg==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.13.tgz",
+      "integrity": "sha512-s1dCJ0J9WU9UPkT3FFqhKTSquYTkqWXGRaapHFyWwwJH86ZussewhNST5R5TwXVL1VSHq4aJVl9fWK+svaRVCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.26",
+        "@aws-sdk/middleware-user-agent": "^3.972.27",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/types": "^4.13.1",
@@ -3855,25 +3949,6 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
-      "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/abort-controller/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@smithy/config-resolver": {
       "version": "4.4.13",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
@@ -3898,9 +3973,9 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.12",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
-      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+      "version": "3.23.13",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
+      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.12",
@@ -3909,7 +3984,7 @@
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-stream": "^4.5.21",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -4147,13 +4222,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.27",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
-      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
+      "version": "4.4.28",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz",
+      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-serde": "^4.2.16",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/shared-ini-file-loader": "^4.4.7",
         "@smithy/types": "^4.13.1",
@@ -4172,15 +4247,15 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.44",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
-      "integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
+      "version": "4.4.45",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.45.tgz",
+      "integrity": "sha512-td1PxpwDIaw5/oP/xIRxBGxJKoF1L4DBAwbZ8wjMuXBYOP/r2ZE/Ocou+mBHx/yk9knFEtDBwhSrYVn+Mz4pHw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/smithy-client": "^4.12.8",
         "@smithy/types": "^4.13.1",
         "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-retry": "^4.2.12",
@@ -4198,12 +4273,12 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
-      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz",
+      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
+        "@smithy/core": "^3.23.13",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
@@ -4259,12 +4334,11 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
-      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
+      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/querystring-builder": "^4.2.12",
         "@smithy/types": "^4.13.1",
@@ -4414,17 +4488,17 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
-      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.8.tgz",
+      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-endpoint": "^4.4.28",
         "@smithy/middleware-stack": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-stream": "^4.5.21",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4569,13 +4643,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.43",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
-      "integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
+      "version": "4.3.44",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.44.tgz",
+      "integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/smithy-client": "^4.12.8",
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
@@ -4590,16 +4664,16 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.47",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
-      "integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
+      "version": "4.2.48",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.48.tgz",
+      "integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.13",
         "@smithy/credential-provider-imds": "^4.2.12",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/smithy-client": "^4.12.8",
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
@@ -4691,13 +4765,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.20",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
-      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
+      "version": "4.5.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.21.tgz",
+      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/node-http-handler": "^4.5.1",
         "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "obsidian-yolo",
-  "version": "1.5.3",
+  "version": "1.5.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-yolo",
-      "version": "1.5.3",
+      "version": "1.5.3.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.1019.0",
         "@codemirror/state": "^6.5.1",
         "@codemirror/view": "^6.36.2",
         "@dnd-kit/core": "^6.3.1",
@@ -124,6 +125,893 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1019.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1019.0.tgz",
+      "integrity": "sha512-Wq1uMAZfySYofuwkFMaMM+k7epsGBRcJGE+ZosGB+8jC8Xs1lycbjSEFMt0Mo3z1qhkgEKGCQyjCbPTICMkkVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/credential-provider-node": "^3.972.27",
+        "@aws-sdk/eventstream-handler-node": "^3.972.12",
+        "@aws-sdk/middleware-eventstream": "^3.972.8",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.26",
+        "@aws-sdk/middleware-websocket": "^3.972.14",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/token-providers": "3.1019.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.12",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.25.tgz",
+      "integrity": "sha512-TNrx7eq6nKNOO62HWPqoBqPLXEkW6nLZQGwjL6lq1jZtigWYbK1NbCnT7mKDzbLMHZfuOECUt3n6CzxjUW9HWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.16",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.23.tgz",
+      "integrity": "sha512-EamaclJcCEaPHp6wiVknNMM2RlsPMjAHSsYSFLNENBM8Wz92QPc6cOn3dif6vPDQt0Oo4IEghDy3NMDCzY/IvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.25.tgz",
+      "integrity": "sha512-qPymamdPcLp6ugoVocG1y5r69ScNiRzb0hogX25/ij+Wz7c7WnsgjLTaz7+eB5BfRxeyUwuw5hgULMuwOGOpcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.26.tgz",
+      "integrity": "sha512-xKxEAMuP6GYx2y5GET+d3aGEroax3AgGfwBE65EQAUe090lzyJ/RzxPX9s8v7Z6qAk0XwfQl+LrmH05X7YvTeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/credential-provider-env": "^3.972.23",
+        "@aws-sdk/credential-provider-http": "^3.972.25",
+        "@aws-sdk/credential-provider-login": "^3.972.26",
+        "@aws-sdk/credential-provider-process": "^3.972.23",
+        "@aws-sdk/credential-provider-sso": "^3.972.26",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.26",
+        "@aws-sdk/nested-clients": "^3.996.16",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.26.tgz",
+      "integrity": "sha512-EFcM8RM3TUxnZOfMJo++3PnyxFu1fL/huzmn3Vh+8IWRgqZawUD3cRwwOr+/4bE9DpyHaLOWFAjY0lfK5X9ZkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/nested-clients": "^3.996.16",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.27.tgz",
+      "integrity": "sha512-jXpxSolfFnPVj6GCTtx3xIdWNoDR7hYC/0SbetGZxOC9UnNmipHeX1k6spVstf7eWJrMhXNQEgXC0pD1r5tXIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.23",
+        "@aws-sdk/credential-provider-http": "^3.972.25",
+        "@aws-sdk/credential-provider-ini": "^3.972.26",
+        "@aws-sdk/credential-provider-process": "^3.972.23",
+        "@aws-sdk/credential-provider-sso": "^3.972.26",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.23.tgz",
+      "integrity": "sha512-IL/TFW59++b7MpHserjUblGrdP5UXy5Ekqqx1XQkERXBFJcZr74I7VaSrQT5dxdRMU16xGK4L0RQ5fQG1pMgnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.26.tgz",
+      "integrity": "sha512-c6ghvRb6gTlMznWhGxn/bpVCcp0HRaz4DobGVD9kI4vwHq186nU2xN/S7QGkm0lo0H2jQU8+dgpUFLxfTcwCOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/nested-clients": "^3.996.16",
+        "@aws-sdk/token-providers": "3.1019.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.26.tgz",
+      "integrity": "sha512-cXcS3+XD3iwhoXkM44AmxjmbcKueoLCINr1e+IceMmCySda5ysNIfiGBGe9qn5EMiQ9Jd7pP0AGFtcd6OV3Lvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/nested-clients": "^3.996.16",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.12.tgz",
+      "integrity": "sha512-ruyc/MNR6e+cUrGCth7fLQ12RXBZDy/bV06tgqB9Z5n/0SN/C0m6bsQEV8FF9zPI6VSAOaRd0rNgmpYVnGawrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
+      "integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.26.tgz",
+      "integrity": "sha512-AilFIh4rI/2hKyyGN6XrB0yN96W2o7e7wyrPWCM6QjZM1mcC/pVkW3IWWRvuBWMpVP8Fg+rMpbzeLQ6dTM4gig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.14.tgz",
+      "integrity": "sha512-qnfDlIHjm6DrTYNvWOUbnZdVKgtoKbO/Qzj+C0Wp5Y7VUrsvBRQtGKxD+hc+mRTS4N0kBJ6iZ3+zxm4N1OSyjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-format-url": "^3.972.8",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.16.tgz",
+      "integrity": "sha512-L7Qzoj/qQU1cL5GnYLQP5LbI+wlLCLoINvcykR3htKcQ4tzrPf2DOs72x933BM7oArYj1SKrkb2lGlsJHIic3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.26",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.12",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1019.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1019.0.tgz",
+      "integrity": "sha512-OF+2RfRmUKyjzrRWlDcyju3RBsuqcrYDQ8TwrJg8efcOotMzuZN4U9mpVTIdATpmEc4lWNZBMSjPzrGm6JPnAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/nested-clients": "^3.996.16",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+      "integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.12.tgz",
+      "integrity": "sha512-8phW0TS8ntENJgDcFewYT/Q8dOmarpvSxEjATu2GUBAutiHr++oEGCiBUwxslCMNvwW2cAPZNT53S/ym8zm/gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2967,6 +3855,921 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+      "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.12",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
+      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.44",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
+      "integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
+      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.43",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
+      "integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
+      "integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+      "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.56.2",
       "license": "MIT",
@@ -4071,6 +5874,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -7017,6 +8826,41 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fault": {
       "version": "1.0.4",
@@ -11087,6 +12931,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "dev": true,
@@ -12760,6 +14619,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-mod": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@aws-sdk/client-bedrock": "^3.1020.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1019.0",
     "@codemirror/state": "^6.5.1",
     "@codemirror/view": "^6.36.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-yolo",
-  "version": "1.5.3.3",
+  "version": "1.5.4.0",
   "description": "AI chat with note context, smart writing assistance, and one-click edits for your vault.",
   "main": "main.js",
   "scripts": {
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1019.0",
     "@codemirror/state": "^6.5.1",
     "@codemirror/view": "^6.36.2",
     "@dnd-kit/core": "^6.3.1",

--- a/src/components/settings/modals/AddChatModelModal.tsx
+++ b/src/components/settings/modals/AddChatModelModal.tsx
@@ -139,7 +139,8 @@ const isThinkingConfigurable = (
 ): provider is LLMProvider =>
   provider?.apiType === 'anthropic' ||
   provider?.apiType === 'gemini' ||
-  provider?.apiType === 'openai-compatible'
+  provider?.apiType === 'openai-compatible' ||
+  provider?.apiType === 'amazon-bedrock'
 
 const supportsGeminiTools = (provider: LLMProvider | undefined): boolean =>
   provider?.apiType === 'gemini' || provider?.apiType === 'openai-compatible'

--- a/src/components/settings/modals/AddChatModelModal.tsx
+++ b/src/components/settings/modals/AddChatModelModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { DEFAULT_CHAT_MODELS } from '../../../constants'
 import { useLanguage } from '../../../contexts/language-context'
+import { listBedrockChatModelIds } from '../../../core/llm/bedrockCatalog'
 import SmartComposerPlugin from '../../../main'
 import { ChatModel, chatModelSchema } from '../../../types/chat-model.types'
 import { CustomParameter } from '../../../types/custom-parameter.types'
@@ -219,7 +220,7 @@ function AddChatModelModalComponent({
       }
 
       // Check cache first
-      const cachedModels = plugin.getCachedModelList(selectedProvider.id)
+      const cachedModels = plugin.getCachedModelList(selectedProvider.id, 'chat')
       if (cachedModels) {
         setAvailableModels(cachedModels)
         setLoadingModels(false)
@@ -245,7 +246,7 @@ function AddChatModelModalComponent({
               new Set(CHATGPT_OAUTH_DEFAULT_MODELS),
             ).sort()
             setAvailableModels(fallback)
-            plugin.setCachedModelList(selectedProvider.id, fallback)
+            plugin.setCachedModelList(selectedProvider.id, fallback, 'chat')
             return
           }
 
@@ -306,7 +307,7 @@ function AddChatModelModalComponent({
               }
 
               setAvailableModels(unique)
-              plugin.setCachedModelList(selectedProvider.id, unique)
+              plugin.setCachedModelList(selectedProvider.id, unique, 'chat')
               return
             } catch (error) {
               lastErr = error
@@ -321,7 +322,14 @@ function AddChatModelModalComponent({
             new Set(CHATGPT_OAUTH_DEFAULT_MODELS),
           ).sort()
           setAvailableModels(fallback)
-          plugin.setCachedModelList(selectedProvider.id, fallback)
+          plugin.setCachedModelList(selectedProvider.id, fallback, 'chat')
+          return
+        }
+
+        if (selectedProvider.apiType === 'amazon-bedrock') {
+          const unique = await listBedrockChatModelIds(selectedProvider)
+          setAvailableModels(unique)
+          plugin.setCachedModelList(selectedProvider.id, unique, 'chat')
           return
         }
 
@@ -381,7 +389,7 @@ function AddChatModelModalComponent({
                 const unique = Array.from(new Set(buckets)).sort()
                 setAvailableModels(unique)
                 // Cache the result
-                plugin.setCachedModelList(selectedProvider.id, unique)
+                plugin.setCachedModelList(selectedProvider.id, unique, 'chat')
                 fetched = true
                 break
               } catch (error) {
@@ -423,7 +431,7 @@ function AddChatModelModalComponent({
           const unique = Array.from(new Set(names)).sort()
           setAvailableModels(unique)
           // Cache the result
-          plugin.setCachedModelList(selectedProvider.id, unique)
+          plugin.setCachedModelList(selectedProvider.id, unique, 'chat')
           return
         }
       } catch (err: unknown) {

--- a/src/components/settings/modals/AddEmbeddingModelModal.tsx
+++ b/src/components/settings/modals/AddEmbeddingModelModal.tsx
@@ -3,6 +3,7 @@ import { App, Notice, requestUrl } from 'obsidian'
 import { useEffect, useState } from 'react'
 
 import { useLanguage } from '../../../contexts/language-context'
+import { listBedrockEmbeddingModelIds } from '../../../core/llm/bedrockCatalog'
 import { extractEmbeddingVector } from '../../../core/llm/embedding-utils'
 import { getProviderClient } from '../../../core/llm/manager'
 import { supportedDimensionsForIndex } from '../../../database/schema'
@@ -115,7 +116,10 @@ function AddEmbeddingModelModalComponent({
       }
 
       // Check cache first
-      const cachedModels = plugin.getCachedModelList(selectedProvider.id)
+      const cachedModels = plugin.getCachedModelList(
+        selectedProvider.id,
+        'embedding',
+      )
       if (cachedModels) {
         const sorted = sortModelsForEmbedding(cachedModels)
         setAvailableModels(sorted)
@@ -132,6 +136,18 @@ function AddEmbeddingModelModalComponent({
         const isOpenAIStyle =
           selectedProvider.apiType === 'openai-compatible' ||
           selectedProvider.apiType === 'openai-responses'
+
+        if (selectedProvider.apiType === 'amazon-bedrock') {
+          const unique = await listBedrockEmbeddingModelIds(selectedProvider)
+          const sorted = sortModelsForEmbedding(unique)
+          setAvailableModels(sorted)
+          plugin.setCachedModelList(
+            selectedProvider.id,
+            unique,
+            'embedding',
+          )
+          return
+        }
 
         if (isOpenAIStyle) {
           const base = resolveProviderBaseUrl(selectedProvider) ?? ''
@@ -190,7 +206,11 @@ function AddEmbeddingModelModalComponent({
                 const sorted = sortModelsForEmbedding(unique)
                 setAvailableModels(sorted)
                 // Cache the result (unsorted for consistency)
-                plugin.setCachedModelList(selectedProvider.id, unique)
+                plugin.setCachedModelList(
+                  selectedProvider.id,
+                  unique,
+                  'embedding',
+                )
                 fetched = true
                 break
               } catch (error) {
@@ -233,7 +253,11 @@ function AddEmbeddingModelModalComponent({
           const sorted = sortModelsForEmbedding(unique)
           setAvailableModels(sorted)
           // Cache the result (unsorted for consistency)
-          plugin.setCachedModelList(selectedProvider.id, unique)
+          plugin.setCachedModelList(
+            selectedProvider.id,
+            unique,
+            'embedding',
+          )
           return
         }
       } catch (err: unknown) {

--- a/src/components/settings/modals/ProviderFormModal.tsx
+++ b/src/components/settings/modals/ProviderFormModal.tsx
@@ -11,7 +11,11 @@ import {
   getSupportedApiTypesForPresetType,
   llmProviderSchema,
 } from '../../../types/provider.types'
-import { getRequestTransportModeValue } from '../../../utils/llm/provider-config'
+import {
+  getRequestTransportModeValue,
+  providerSupportsEmbedding,
+  providerSupportsTransportModeSelection,
+} from '../../../utils/llm/provider-config'
 import { sanitizeProviderHeaders } from '../../../utils/llm/provider-headers'
 import { ObsidianButton } from '../../common/ObsidianButton'
 import { ObsidianDropdown } from '../../common/ObsidianDropdown'
@@ -123,6 +127,7 @@ function ProviderFormComponent({
         const providerIdChanged = provider.id !== validatedProvider.id
         const providerPresetChanged =
           provider.presetType !== validatedProvider.presetType
+        const providerApiChanged = provider.apiType !== validatedProvider.apiType
         const updatedProviders = [...plugin.settings.providers]
         updatedProviders[providerIndex] = validatedProvider
 
@@ -142,10 +147,9 @@ function ProviderFormComponent({
           : plugin.settings.chatModels
 
         const updatedEmbeddingModels: typeof plugin.settings.embeddingModels =
-          providerIdChanged || providerPresetChanged
+          providerIdChanged || providerPresetChanged || providerApiChanged
             ? providerPresetChanged &&
-              !PROVIDER_PRESET_INFO[validatedProvider.presetType]
-                .supportEmbedding
+              !providerSupportsEmbedding(validatedProvider)
               ? plugin.settings.embeddingModels
               : plugin.settings.embeddingModels.map((model) => {
                   if (model.providerId !== provider.id) {
@@ -211,6 +215,12 @@ function ProviderFormComponent({
     ]),
   )
   const shouldHideCredentialFields = formData.presetType === 'chatgpt-oauth'
+  const shouldShowBaseUrlField =
+    !shouldHideCredentialFields &&
+    !(
+      formData.presetType === 'amazon-bedrock' &&
+      formData.apiType === 'amazon-bedrock'
+    )
   const requestTransportOptions = {
     auto: t('settings.providers.requestTransportModeAuto'),
     browser: t('settings.providers.requestTransportModeBrowser'),
@@ -221,6 +231,29 @@ function ProviderFormComponent({
         }
       : {}),
   }
+  const visibleAdditionalSettings = providerTypeInfo.additionalSettings.filter(
+    (setting: (typeof providerTypeInfo.additionalSettings)[number]) =>
+      setting.key !== 'requestTransportMode' ||
+      providerSupportsTransportModeSelection(formData),
+  )
+  const apiKeyDesc =
+    formData.presetType === 'amazon-bedrock'
+      ? 'Enter your Amazon Bedrock API key / bearer token.'
+      : t('settings.providers.apiKeyDesc')
+  const apiKeyPlaceholder =
+    formData.presetType === 'amazon-bedrock'
+      ? 'Enter your Amazon Bedrock API key'
+      : t('settings.providers.apiKeyPlaceholder')
+  const baseUrlDesc =
+    formData.presetType === 'amazon-bedrock' &&
+    formData.apiType === 'openai-compatible'
+      ? 'Optional override. Leave empty to use the region-derived Bedrock Mantle endpoint.'
+      : t('settings.providers.baseUrlDesc')
+  const baseUrlPlaceholder =
+    formData.presetType === 'amazon-bedrock' &&
+    formData.apiType === 'openai-compatible'
+      ? 'https://bedrock-mantle.us-east-1.api.aws'
+      : t('settings.providers.baseUrlPlaceholder')
 
   return (
     <div className="smtcmp-provider-form">
@@ -286,35 +319,37 @@ function ProviderFormComponent({
         <>
           <ObsidianSetting
             name={t('settings.providers.apiKey')}
-            desc={t('settings.providers.apiKeyDesc')}
+            desc={apiKeyDesc}
             required={providerTypeInfo.requireApiKey}
           >
             <ObsidianTextInput
               value={formData.apiKey ?? ''}
-              placeholder={t('settings.providers.apiKeyPlaceholder')}
+              placeholder={apiKeyPlaceholder}
               onChange={(value: string) =>
                 setFormData((prev) => ({ ...prev, apiKey: value }))
               }
             />
           </ObsidianSetting>
 
-          <ObsidianSetting
-            name={t('settings.providers.baseUrl')}
-            desc={t('settings.providers.baseUrlDesc')}
-            required={providerTypeInfo.requireBaseUrl}
-          >
-            <ObsidianTextInput
-              value={formData.baseUrl ?? ''}
-              placeholder={t('settings.providers.baseUrlPlaceholder')}
-              onChange={(value: string) =>
-                setFormData((prev) => ({ ...prev, baseUrl: value }))
-              }
-            />
-          </ObsidianSetting>
+          {shouldShowBaseUrlField && (
+            <ObsidianSetting
+              name={t('settings.providers.baseUrl')}
+              desc={baseUrlDesc}
+              required={providerTypeInfo.requireBaseUrl}
+            >
+              <ObsidianTextInput
+                value={formData.baseUrl ?? ''}
+                placeholder={baseUrlPlaceholder}
+                onChange={(value: string) =>
+                  setFormData((prev) => ({ ...prev, baseUrl: value }))
+                }
+              />
+            </ObsidianSetting>
+          )}
         </>
       )}
 
-      {providerTypeInfo.additionalSettings.map((setting) => {
+      {visibleAdditionalSettings.map((setting) => {
         const label =
           setting.key === 'noStainless'
             ? t('settings.providers.noStainlessHeaders')

--- a/src/components/settings/sections/ProvidersAndModelsSection.tsx
+++ b/src/components/settings/sections/ProvidersAndModelsSection.tsx
@@ -36,6 +36,8 @@ import SmartComposerPlugin from '../../../main'
 import { ChatModel } from '../../../types/chat-model.types'
 import { EmbeddingModel } from '../../../types/embedding-model.types'
 import { LLMProvider } from '../../../types/provider.types'
+import { providerSupportsEmbedding } from '../../../utils/llm/provider-config'
+import { resolveProviderDisplayBaseUrl } from '../../../utils/llm/provider-base-url'
 import { ObsidianButton } from '../../common/ObsidianButton'
 import { ObsidianToggle } from '../../common/ObsidianToggle'
 import { AddChatModelModal } from '../modals/AddChatModelModal'
@@ -73,26 +75,8 @@ type ProviderSectionItemProps = {
   handleEmbeddingModelDragEnd: (event: DragEndEvent) => void
 }
 
-const PROVIDER_DISPLAY_BASE_URLS: Partial<
-  Record<LLMProvider['presetType'], string>
-> = {
-  openai: 'https://api.openai.com',
-  'chatgpt-oauth': 'https://chatgpt.com/backend-api/codex',
-  anthropic: 'https://api.anthropic.com',
-  gemini: 'https://generativelanguage.googleapis.com',
-  deepseek: 'https://api.deepseek.com',
-  perplexity: 'https://api.perplexity.ai',
-  groq: 'https://api.groq.com/openai',
-  mistral: 'https://api.mistral.ai',
-  openrouter: 'https://openrouter.ai/api',
-  ollama: 'http://127.0.0.1:11434',
-  'lm-studio': 'http://127.0.0.1:1234',
-  morph: 'https://api.morphllm.com',
-}
-
 function getProviderDisplayBaseUrl(provider: LLMProvider): string {
-  const rawBaseUrl =
-    provider.baseUrl?.trim() || PROVIDER_DISPLAY_BASE_URLS[provider.presetType]
+  const rawBaseUrl = resolveProviderDisplayBaseUrl(provider)
 
   if (!rawBaseUrl) {
     return ''
@@ -561,12 +545,13 @@ function EmbeddingModelsTable({
   onDelete,
 }: EmbeddingModelsTableProps) {
   const items = models.map((model) => model.id)
+  const embeddingSupported = providerSupportsEmbedding(provider)
 
   return (
     <div className="smtcmp-models-subsection">
       <div className="smtcmp-models-subsection-header">
         <span>{t('settings.models.embeddingModels')}</span>
-        {PROVIDER_TYPES_INFO[provider.presetType].supportEmbedding && (
+        {embeddingSupported && (
           <button
             type="button"
             className="smtcmp-add-model-btn"
@@ -622,7 +607,7 @@ function EmbeddingModelsTable({
         </DndContext>
       ) : (
         <div className="smtcmp-no-models">
-          {!PROVIDER_TYPES_INFO[provider.presetType].supportEmbedding
+          {!embeddingSupported
             ? `${provider.id} provider does not support embeddings.`
             : t('settings.models.noEmbeddingModelsConfigured')}
         </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -167,6 +167,23 @@ export const PROVIDER_PRESET_INFO = {
       REQUEST_TRANSPORT_MODE_SETTING,
     ],
   },
+  'amazon-bedrock': {
+    label: 'Amazon Bedrock',
+    defaultProviderId: null, // no default provider for this type
+    requireApiKey: true,
+    requireBaseUrl: false,
+    supportEmbedding: false,
+    additionalSettings: [
+      {
+        label: 'AWS Region',
+        key: 'awsRegion',
+        placeholder: 'us-east-1',
+        type: 'text',
+        required: true,
+      },
+      REQUEST_TRANSPORT_MODE_SETTING,
+    ],
+  },
   'openai-compatible': {
     label: 'OpenAI Compatible',
     defaultProviderId: null, // no default provider for this type
@@ -222,6 +239,9 @@ export const PROVIDER_API_INFO: Record<
   },
   gemini: {
     label: 'Gemini API',
+  },
+  'amazon-bedrock': {
+    label: 'Amazon Bedrock Converse',
   },
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -172,7 +172,7 @@ export const PROVIDER_PRESET_INFO = {
     defaultProviderId: null, // no default provider for this type
     requireApiKey: true,
     requireBaseUrl: false,
-    supportEmbedding: false,
+    supportEmbedding: true,
     additionalSettings: [
       {
         label: 'AWS Region',

--- a/src/core/llm/bedrockCatalog.ts
+++ b/src/core/llm/bedrockCatalog.ts
@@ -1,0 +1,79 @@
+import {
+  BedrockClient,
+  FoundationModelSummary,
+  ListFoundationModelsCommand,
+} from '@aws-sdk/client-bedrock'
+
+import { LLMProvider } from '../../types/provider.types'
+import {
+  createBedrockBearerClientConfig,
+  isSupportedBedrockEmbeddingModel,
+} from '../../utils/llm/bedrock'
+
+const getModelId = (model: FoundationModelSummary): string | null => {
+  const modelId = model.modelId?.trim()
+  return modelId ? modelId : null
+}
+
+const isActiveModel = (model: FoundationModelSummary): boolean => {
+  return model.modelLifecycle?.status !== 'LEGACY'
+}
+
+const hasTextInput = (model: FoundationModelSummary): boolean => {
+  return model.inputModalities?.includes('TEXT') === true
+}
+
+const hasTextOutput = (model: FoundationModelSummary): boolean => {
+  return model.outputModalities?.includes('TEXT') === true
+}
+
+const hasEmbeddingOutput = (model: FoundationModelSummary): boolean => {
+  return model.outputModalities?.includes('EMBEDDING') === true
+}
+
+const isLikelyEmbeddingModel = (model: FoundationModelSummary): boolean => {
+  const modelId = getModelId(model)?.toLowerCase() ?? ''
+  return modelId.includes('embed')
+}
+
+async function listFoundationModels(
+  provider: Pick<LLMProvider, 'apiKey' | 'additionalSettings'>,
+  byOutputModality: 'TEXT' | 'EMBEDDING',
+): Promise<FoundationModelSummary[]> {
+  const client = new BedrockClient(createBedrockBearerClientConfig(provider))
+  const response = await client.send(
+    new ListFoundationModelsCommand({
+      byOutputModality,
+      byInferenceType: 'ON_DEMAND',
+    }),
+  )
+
+  return response.modelSummaries ?? []
+}
+
+export async function listBedrockChatModelIds(
+  provider: Pick<LLMProvider, 'apiKey' | 'additionalSettings'>,
+): Promise<string[]> {
+  const models = await listFoundationModels(provider, 'TEXT')
+
+  return models
+    .filter((model) => isActiveModel(model) && hasTextInput(model))
+    .filter((model) => !hasEmbeddingOutput(model) || hasTextOutput(model))
+    .filter((model) => !isLikelyEmbeddingModel(model))
+    .map((model) => getModelId(model))
+    .filter((modelId): modelId is string => Boolean(modelId))
+    .sort()
+}
+
+export async function listBedrockEmbeddingModelIds(
+  provider: Pick<LLMProvider, 'apiKey' | 'additionalSettings'>,
+): Promise<string[]> {
+  const models = await listFoundationModels(provider, 'EMBEDDING')
+
+  return models
+    .filter((model) => isActiveModel(model) && hasTextInput(model))
+    .map((model) => getModelId(model))
+    .filter((modelId): modelId is string => Boolean(modelId))
+    .filter((modelId) => isSupportedBedrockEmbeddingModel(modelId))
+    .sort()
+}

--- a/src/core/llm/bedrockProvider.test.ts
+++ b/src/core/llm/bedrockProvider.test.ts
@@ -1,0 +1,101 @@
+import { BedrockProvider } from './bedrockProvider'
+
+const createProvider = () =>
+  new BedrockProvider({
+    id: 'bedrock',
+    presetType: 'amazon-bedrock',
+    apiType: 'amazon-bedrock',
+    apiKey: 'token',
+    additionalSettings: { awsRegion: 'us-east-1' },
+  })
+
+const createAsyncIterable = <T>(values: T[]): AsyncIterable<T> => ({
+  [Symbol.asyncIterator]: async function* () {
+    for (const value of values) {
+      yield value
+    }
+  },
+})
+
+describe('BedrockProvider', () => {
+  it('returns native embeddings through InvokeModel', async () => {
+    const provider = createProvider()
+    ;(provider as unknown as { client: { send: jest.Mock } }).client = {
+      send: jest.fn().mockResolvedValue({
+        body: JSON.stringify({
+          embedding: [0.1, 0.2, 0.3],
+        }),
+      }),
+    }
+
+    await expect(
+      provider.getEmbedding('amazon.titan-embed-text-v2:0', 'hello'),
+    ).resolves.toEqual([0.1, 0.2, 0.3])
+  })
+
+  it('emits a final finish_reason chunk for Converse streams', async () => {
+    const provider = createProvider()
+    ;(provider as unknown as { client: { send: jest.Mock } }).client = {
+      send: jest.fn().mockResolvedValue({
+        stream: createAsyncIterable([
+          {
+            contentBlockDelta: {
+              contentBlockIndex: 0,
+              delta: { text: 'hello' },
+            },
+          },
+          {
+            messageStop: {
+              stopReason: 'tool_use',
+            },
+          },
+          {
+            metadata: {
+              usage: {
+                inputTokens: 3,
+                outputTokens: 5,
+                totalTokens: 8,
+              },
+            },
+          },
+        ]),
+      }),
+    }
+
+    const stream = await provider.streamResponse(
+      {
+        providerId: 'bedrock',
+        id: 'model-1',
+        model: 'anthropic.claude-3-7-sonnet',
+      },
+      {
+        model: 'anthropic.claude-3-7-sonnet',
+        messages: [{ role: 'user', content: 'hello' }],
+        stream: true,
+      },
+    )
+
+    const chunks = []
+    for await (const chunk of stream) {
+      chunks.push(chunk)
+    }
+
+    expect(chunks[0]?.choices?.[0]?.delta?.content).toBe('hello')
+    expect(chunks[chunks.length - 1]?.choices?.[0]?.finish_reason).toBe(
+      'tool_calls',
+    )
+    expect(chunks[chunks.length - 1]?.usage).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 5,
+      total_tokens: 8,
+    })
+  })
+
+  it('rejects unsupported Bedrock embedding model families clearly', async () => {
+    const provider = createProvider()
+
+    await expect(
+      provider.getEmbedding('unknown.embedding-model', 'hello'),
+    ).rejects.toThrow('Embedding is not yet supported')
+  })
+})

--- a/src/core/llm/bedrockProvider.ts
+++ b/src/core/llm/bedrockProvider.ts
@@ -5,6 +5,7 @@ import {
   ConverseStreamCommand,
   ConverseStreamOutput,
   ImageFormat,
+  InvokeModelCommand,
   Message,
   SystemContentBlock,
   Tool,
@@ -33,13 +34,25 @@ import {
 import { LLMProvider } from '../../types/provider.types'
 import { getToolCallArgumentsObject } from '../../types/tool-call.types'
 import { parseImageDataUrl } from '../../utils/llm/image'
+import {
+  buildBedrockEmbeddingRequestBody,
+  createBedrockBearerClientConfig,
+  getBedrockRegion,
+} from '../../utils/llm/bedrock'
 
 import { BaseLLMProvider } from './base'
-import { LLMAPIKeyNotSetException } from './exception'
+import {
+  LLMAPIKeyInvalidException,
+  LLMAPIKeyNotSetException,
+  LLMModelNotFoundException,
+  LLMProviderNotConfiguredException,
+  LLMRateLimitExceededException,
+} from './exception'
 
-type BedrockAdditionalSettings = {
-  awsRegion?: string
-}
+type BedrockJsonBody =
+  | string
+  | Uint8Array
+  | { transformToString?: () => Promise<string> }
 
 export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
   private client: BedrockRuntimeClient
@@ -48,17 +61,7 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
 
   constructor(provider: LLMProvider) {
     super(provider)
-
-    const additionalSettings =
-      (provider.additionalSettings as BedrockAdditionalSettings) ?? {}
-
-    const region = additionalSettings.awsRegion || 'us-east-1'
-
-    this.client = new BedrockRuntimeClient({
-      region,
-      token: { token: provider.apiKey ?? '' },
-      authSchemePreference: ['httpBearerAuth'],
-    })
+    this.client = new BedrockRuntimeClient(createBedrockBearerClientConfig(provider))
   }
 
   async generateResponse(
@@ -66,7 +69,7 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
     request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming> {
-    this.validateCredentials()
+    this.validateConfiguration()
 
     const systemBlocks = BedrockProvider.extractSystemBlocks(request.messages)
     const messages = BedrockProvider.convertMessages(request.messages)
@@ -85,73 +88,80 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
     const additionalModelRequestFields =
       BedrockProvider.buildAdditionalModelRequestFields(model)
 
-    const command = new ConverseCommand({
-      modelId: request.model,
-      messages,
-      ...(systemBlocks.length > 0 ? { system: systemBlocks } : {}),
-      inferenceConfig: {
-        maxTokens,
-        ...(request.temperature != null
-          ? { temperature: request.temperature }
-          : {}),
-        ...(request.top_p != null ? { topP: request.top_p } : {}),
-      },
-      ...(toolConfig ? { toolConfig } : {}),
-      ...(additionalModelRequestFields ? { additionalModelRequestFields } : {}),
-    })
-
-    const response = await this.client.send(command, {
-      abortSignal: options?.signal,
-    })
-
-    const outputMessage = response.output?.message
-    const contentBlocks = outputMessage?.content ?? []
-
-    const textContent = contentBlocks
-      .filter((b): b is ContentBlock.TextMember => 'text' in b)
-      .map((b) => b.text)
-      .join('')
-
-    const reasoningContent =
-      contentBlocks
-        .filter(
-          (b): b is ContentBlock.ReasoningContentMember =>
-            'reasoningContent' in b,
-        )
-        .map((b) => b.reasoningContent.reasoningText?.text ?? '')
-        .join('') || undefined
-
-    const toolCalls: ToolCall[] = contentBlocks
-      .filter((b): b is ContentBlock.ToolUseMember => 'toolUse' in b)
-      .map(
-        (b): ToolCall => ({
-          id: b.toolUse.toolUseId,
-          type: 'function',
-          function: {
-            name: b.toolUse.name ?? '',
-            arguments: JSON.stringify(b.toolUse.input),
+    try {
+      const response = await this.client.send(
+        new ConverseCommand({
+          modelId: request.model,
+          messages,
+          ...(systemBlocks.length > 0 ? { system: systemBlocks } : {}),
+          inferenceConfig: {
+            maxTokens,
+            ...(request.temperature != null
+              ? { temperature: request.temperature }
+              : {}),
+            ...(request.top_p != null ? { topP: request.top_p } : {}),
           },
+          ...(toolConfig ? { toolConfig } : {}),
+          ...(additionalModelRequestFields
+            ? { additionalModelRequestFields }
+            : {}),
         }),
+        {
+          abortSignal: options?.signal,
+        },
       )
 
-    const usage = BedrockProvider.convertUsage(response.usage)
+      const outputMessage = response.output?.message
+      const contentBlocks = outputMessage?.content ?? []
 
-    return {
-      id: `bedrock-${Date.now()}`,
-      choices: [
-        {
-          finish_reason: BedrockProvider.mapStopReason(response.stopReason),
-          message: {
-            content: textContent,
-            reasoning: reasoningContent,
-            role: 'assistant',
-            tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+      const textContent = contentBlocks
+        .filter((b): b is ContentBlock.TextMember => 'text' in b)
+        .map((b) => b.text)
+        .join('')
+
+      const reasoningContent =
+        contentBlocks
+          .filter(
+            (b): b is ContentBlock.ReasoningContentMember =>
+              'reasoningContent' in b,
+          )
+          .map((b) => b.reasoningContent.reasoningText?.text ?? '')
+          .join('') || undefined
+
+      const toolCalls: ToolCall[] = contentBlocks
+        .filter((b): b is ContentBlock.ToolUseMember => 'toolUse' in b)
+        .map(
+          (b): ToolCall => ({
+            id: b.toolUse.toolUseId,
+            type: 'function',
+            function: {
+              name: b.toolUse.name ?? '',
+              arguments: JSON.stringify(b.toolUse.input),
+            },
+          }),
+        )
+
+      const usage = BedrockProvider.convertUsage(response.usage)
+
+      return {
+        id: `bedrock-${Date.now()}`,
+        choices: [
+          {
+            finish_reason: BedrockProvider.mapStopReason(response.stopReason),
+            message: {
+              content: textContent,
+              reasoning: reasoningContent,
+              role: 'assistant',
+              tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+            },
           },
-        },
-      ],
-      model: request.model,
-      object: 'chat.completion',
-      usage,
+        ],
+        model: request.model,
+        object: 'chat.completion',
+        usage,
+      }
+    } catch (error) {
+      throw BedrockProvider.toBedrockError(this.provider, error)
     }
   }
 
@@ -160,7 +170,7 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
     request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>> {
-    this.validateCredentials()
+    this.validateConfiguration()
 
     const systemBlocks = BedrockProvider.extractSystemBlocks(request.messages)
     const messages = BedrockProvider.convertMessages(request.messages)
@@ -179,30 +189,37 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
     const additionalModelRequestFields =
       BedrockProvider.buildAdditionalModelRequestFields(model)
 
-    const command = new ConverseStreamCommand({
-      modelId: request.model,
-      messages,
-      ...(systemBlocks.length > 0 ? { system: systemBlocks } : {}),
-      inferenceConfig: {
-        maxTokens,
-        ...(request.temperature != null
-          ? { temperature: request.temperature }
-          : {}),
-        ...(request.top_p != null ? { topP: request.top_p } : {}),
-      },
-      ...(toolConfig ? { toolConfig } : {}),
-      ...(additionalModelRequestFields ? { additionalModelRequestFields } : {}),
-    })
+    try {
+      const response = await this.client.send(
+        new ConverseStreamCommand({
+          modelId: request.model,
+          messages,
+          ...(systemBlocks.length > 0 ? { system: systemBlocks } : {}),
+          inferenceConfig: {
+            maxTokens,
+            ...(request.temperature != null
+              ? { temperature: request.temperature }
+              : {}),
+            ...(request.top_p != null ? { topP: request.top_p } : {}),
+          },
+          ...(toolConfig ? { toolConfig } : {}),
+          ...(additionalModelRequestFields
+            ? { additionalModelRequestFields }
+            : {}),
+        }),
+        {
+          abortSignal: options?.signal,
+        },
+      )
 
-    const response = await this.client.send(command, {
-      abortSignal: options?.signal,
-    })
+      if (!response.stream) {
+        throw new Error('Bedrock ConverseStream returned no stream')
+      }
 
-    if (!response.stream) {
-      throw new Error('Bedrock ConverseStream returned no stream')
+      return this.streamResponseGenerator(response.stream, request.model)
+    } catch (error) {
+      throw BedrockProvider.toBedrockError(this.provider, error)
     }
-
-    return this.streamResponseGenerator(response.stream, request.model)
   }
 
   private async *streamResponseGenerator(
@@ -215,6 +232,7 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
       completion_tokens: 0,
       total_tokens: 0,
     }
+    let finishReason: string | null = null
 
     for await (const event of stream) {
       if (event.contentBlockDelta) {
@@ -309,65 +327,86 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
             model,
           }
         }
-      } else if (event.metadata) {
-        if (event.metadata.usage) {
-          usage = BedrockProvider.convertUsage(event.metadata.usage)
-        }
+      } else if (event.messageStop) {
+        finishReason = BedrockProvider.mapStopReason(event.messageStop.stopReason)
+      } else if (event.metadata?.usage) {
+        usage = BedrockProvider.convertUsage(event.metadata.usage)
       }
     }
 
-    // Yield final usage chunk
     yield {
       id: messageId,
-      choices: [],
+      choices: [
+        {
+          finish_reason: finishReason,
+          delta: {},
+        },
+      ],
       object: 'chat.completion.chunk',
       model,
       usage,
     }
   }
 
-  getEmbedding(_model: string, _text: string): Promise<number[]> {
-    return Promise.reject(
-      new Error(
-        `Provider ${this.provider.id} does not support embeddings via the Converse API. Please use a different provider.`,
-      ),
-    )
+  async getEmbedding(model: string, text: string): Promise<number[]> {
+    this.validateConfiguration()
+
+    try {
+      const response = await this.client.send(
+        new InvokeModelCommand({
+          modelId: model,
+          contentType: 'application/json',
+          accept: 'application/json',
+          body: JSON.stringify(buildBedrockEmbeddingRequestBody(model, text)),
+        }),
+      )
+
+      const rawBody = await BedrockProvider.bodyToString(response.body)
+      const parsed = JSON.parse(rawBody) as Record<string, unknown>
+      const vector = BedrockProvider.extractBedrockEmbeddingVector(parsed)
+
+      if (!Array.isArray(vector) || vector.length === 0) {
+        throw new Error('Bedrock embedding response did not include values.')
+      }
+
+      return vector
+    } catch (error) {
+      throw BedrockProvider.toBedrockError(this.provider, error, {
+        modelId: model,
+        action: 'embedding',
+      })
+    }
   }
 
-  // ---------------------------------------------------------------------------
-  // Private helpers
-  // ---------------------------------------------------------------------------
-
-  private validateCredentials(): void {
-    if (!this.provider.apiKey) {
+  private validateConfiguration(): void {
+    const token = this.provider.apiKey?.trim()
+    if (!token) {
       throw new LLMAPIKeyNotSetException(
         `Provider ${this.provider.id} API key is not set. Please set the API key in the provider settings.`,
       )
     }
+
+    const region = getBedrockRegion(this.provider)
+    if (!region) {
+      throw new LLMProviderNotConfiguredException(
+        `Provider ${this.provider.id} AWS region is not set. Please set the AWS region in the provider settings.`,
+      )
+    }
   }
 
-  /**
-   * Extract system messages into Bedrock SystemContentBlock[].
-   */
   static extractSystemBlocks(messages: RequestMessage[]): SystemContentBlock[] {
     return messages
       .filter((m) => m.role === 'system')
       .map((m): SystemContentBlock => ({ text: m.content as string }))
   }
 
-  /**
-   * Convert the unified RequestMessage[] into Bedrock Message[].
-   * System messages are excluded (handled separately).
-   */
   static convertMessages(messages: RequestMessage[]): Message[] {
     const result: Message[] = []
 
     for (const msg of messages) {
       switch (msg.role) {
         case 'system':
-          // Handled separately
           break
-
         case 'user': {
           const contentBlocks = BedrockProvider.convertUserContent(msg.content)
           if (contentBlocks.length > 0) {
@@ -375,7 +414,6 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
           }
           break
         }
-
         case 'assistant': {
           const contentBlocks: ContentBlock[] = []
 
@@ -401,11 +439,9 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
           }
           break
         }
-
         case 'tool': {
           const toolResultContent: ToolResultContentBlock[] = []
 
-          // Try to parse as JSON first, fall back to text
           try {
             const parsed = JSON.parse(msg.content)
             toolResultContent.push({ json: parsed })
@@ -433,9 +469,6 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
     return result
   }
 
-  /**
-   * Convert user message content (string or ContentPart[]) to Bedrock ContentBlock[].
-   */
   private static convertUserContent(
     content: string | ContentPart[],
   ): ContentBlock[] {
@@ -480,9 +513,6 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
     return format
   }
 
-  /**
-   * Build Bedrock ToolConfiguration from request tools/choice.
-   */
   private static buildToolConfig(
     tools?: RequestTool[],
     toolChoice?: RequestToolChoice,
@@ -508,7 +538,6 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
       } else if (toolChoice === 'required') {
         bedrockToolChoice = { any: {} }
       } else if (toolChoice === 'none') {
-        // Bedrock doesn't have a "none" tool choice -- omit toolConfig entirely
         return undefined
       } else if (
         typeof toolChoice === 'object' &&
@@ -524,16 +553,11 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
     }
   }
 
-  /**
-   * Build additionalModelRequestFields for model-specific features
-   * like Claude extended thinking.
-   */
   private static buildAdditionalModelRequestFields(
     model: ChatModel,
   ): DocumentType | undefined {
     const fields: { [prop: string]: DocumentType } = {}
 
-    // Claude extended thinking support via Bedrock
     if (
       model.thinking?.enabled &&
       typeof model.thinking.budget_tokens === 'number'
@@ -562,11 +586,131 @@ export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
       case 'tool_use':
         return 'tool_calls'
       case 'max_tokens':
+      case 'model_context_window_exceeded':
         return 'length'
       case 'stop_sequence':
         return 'stop'
+      case 'guardrail_intervened':
+      case 'content_filtered':
+        return 'content_filter'
       default:
         return reason ?? 'stop'
     }
+  }
+
+  private static extractBedrockEmbeddingVector(
+    payload: Record<string, unknown>,
+  ): number[] {
+    if (Array.isArray(payload.embedding)) {
+      return payload.embedding as number[]
+    }
+
+    if (Array.isArray(payload.embeddings) && payload.embeddings.length > 0) {
+      const first = payload.embeddings[0]
+      if (Array.isArray(first)) {
+        return first as number[]
+      }
+      if (
+        first &&
+        typeof first === 'object' &&
+        Array.isArray((first as { embedding?: number[] }).embedding)
+      ) {
+        return (first as { embedding: number[] }).embedding
+      }
+    }
+
+    throw new Error('Embedding model returned an invalid result')
+  }
+
+  private static async bodyToString(body: BedrockJsonBody): Promise<string> {
+    if (typeof body === 'string') {
+      return body
+    }
+
+    if (body instanceof Uint8Array) {
+      return new TextDecoder().decode(body)
+    }
+
+    if (body && typeof body.transformToString === 'function') {
+      return body.transformToString()
+    }
+
+    throw new Error('Bedrock returned a response body in an unknown format.')
+  }
+
+  private static toBedrockError(
+    provider: Pick<LLMProvider, 'id'>,
+    error: unknown,
+    context?: { modelId?: string; action?: 'chat' | 'embedding' },
+  ): Error {
+    if (!(error instanceof Error)) {
+      return new Error(
+        `Amazon Bedrock request failed for provider ${provider.id}.`,
+      )
+    }
+
+    const metadata = error as Error & {
+      $metadata?: { httpStatusCode?: number }
+      name?: string
+    }
+    const statusCode = metadata.$metadata?.httpStatusCode
+    const action = context?.action ?? 'chat'
+    const modelId = context?.modelId
+    const messageSuffix = modelId ? ` (model: ${modelId})` : ''
+
+    if (statusCode === 403) {
+      return new LLMAPIKeyInvalidException(
+        `Amazon Bedrock authentication failed for provider ${provider.id}${messageSuffix}. Please verify the API key / bearer token and its permissions.`,
+        error,
+      )
+    }
+
+    if (statusCode === 404) {
+      return new LLMModelNotFoundException(
+        `Amazon Bedrock could not find the requested ${action} model for provider ${provider.id}${messageSuffix}.`,
+        error,
+      )
+    }
+
+    if (statusCode === 429) {
+      return new LLMRateLimitExceededException(
+        `Amazon Bedrock rate limit exceeded for provider ${provider.id}${messageSuffix}. Please try again later.`,
+        error,
+      )
+    }
+
+    if (
+      statusCode === 503 ||
+      metadata.name === 'ServiceUnavailableException'
+    ) {
+      return new Error(
+        `Amazon Bedrock is temporarily unavailable for provider ${provider.id}${messageSuffix}. Please retry shortly.`,
+      )
+    }
+
+    if (
+      metadata.name === 'ValidationException' &&
+      action === 'embedding' &&
+      modelId
+    ) {
+      return new Error(
+        `Amazon Bedrock rejected the embedding request for model ${modelId}. Make sure the model supports text embeddings and is compatible with Bedrock InvokeModel.`,
+      )
+    }
+
+    if (
+      /model not found|could not resolve the foundation model|unknown model/i.test(
+        error.message,
+      )
+    ) {
+      return new LLMModelNotFoundException(
+        `Amazon Bedrock could not find the requested model for provider ${provider.id}${messageSuffix}.`,
+        error,
+      )
+    }
+
+    return new Error(
+      `Amazon Bedrock ${action} request failed for provider ${provider.id}${messageSuffix}: ${error.message}`,
+    )
   }
 }

--- a/src/core/llm/bedrockProvider.ts
+++ b/src/core/llm/bedrockProvider.ts
@@ -1,0 +1,572 @@
+import {
+  BedrockRuntimeClient,
+  ContentBlock,
+  ConverseCommand,
+  ConverseStreamCommand,
+  ConverseStreamOutput,
+  ImageFormat,
+  Message,
+  SystemContentBlock,
+  Tool,
+  ToolChoice,
+  ToolResultContentBlock,
+  TokenUsage,
+} from '@aws-sdk/client-bedrock-runtime'
+import { DocumentType } from '@smithy/types'
+
+import { ChatModel } from '../../types/chat-model.types'
+import {
+  ContentPart,
+  LLMOptions,
+  LLMRequestNonStreaming,
+  LLMRequestStreaming,
+  RequestMessage,
+  RequestTool,
+  RequestToolChoice,
+} from '../../types/llm/request'
+import {
+  LLMResponseNonStreaming,
+  LLMResponseStreaming,
+  ResponseUsage,
+  ToolCall,
+} from '../../types/llm/response'
+import { LLMProvider } from '../../types/provider.types'
+import { getToolCallArgumentsObject } from '../../types/tool-call.types'
+import { parseImageDataUrl } from '../../utils/llm/image'
+
+import { BaseLLMProvider } from './base'
+import { LLMAPIKeyNotSetException } from './exception'
+
+type BedrockAdditionalSettings = {
+  awsRegion?: string
+}
+
+export class BedrockProvider extends BaseLLMProvider<LLMProvider> {
+  private client: BedrockRuntimeClient
+
+  private static readonly DEFAULT_MAX_TOKENS = 8192
+
+  constructor(provider: LLMProvider) {
+    super(provider)
+
+    const additionalSettings =
+      (provider.additionalSettings as BedrockAdditionalSettings) ?? {}
+
+    const region = additionalSettings.awsRegion || 'us-east-1'
+
+    this.client = new BedrockRuntimeClient({
+      region,
+      token: { token: provider.apiKey ?? '' },
+      authSchemePreference: ['httpBearerAuth'],
+    })
+  }
+
+  async generateResponse(
+    model: ChatModel,
+    request: LLMRequestNonStreaming,
+    options?: LLMOptions,
+  ): Promise<LLMResponseNonStreaming> {
+    this.validateCredentials()
+
+    const systemBlocks = BedrockProvider.extractSystemBlocks(request.messages)
+    const messages = BedrockProvider.convertMessages(request.messages)
+    const maxTokens =
+      request.max_tokens ??
+      (model.thinking?.enabled &&
+      typeof model.thinking.budget_tokens === 'number'
+        ? model.thinking.budget_tokens + BedrockProvider.DEFAULT_MAX_TOKENS
+        : BedrockProvider.DEFAULT_MAX_TOKENS)
+
+    const toolConfig = BedrockProvider.buildToolConfig(
+      request.tools,
+      request.tool_choice,
+    )
+
+    const additionalModelRequestFields =
+      BedrockProvider.buildAdditionalModelRequestFields(model)
+
+    const command = new ConverseCommand({
+      modelId: request.model,
+      messages,
+      ...(systemBlocks.length > 0 ? { system: systemBlocks } : {}),
+      inferenceConfig: {
+        maxTokens,
+        ...(request.temperature != null
+          ? { temperature: request.temperature }
+          : {}),
+        ...(request.top_p != null ? { topP: request.top_p } : {}),
+      },
+      ...(toolConfig ? { toolConfig } : {}),
+      ...(additionalModelRequestFields ? { additionalModelRequestFields } : {}),
+    })
+
+    const response = await this.client.send(command, {
+      abortSignal: options?.signal,
+    })
+
+    const outputMessage = response.output?.message
+    const contentBlocks = outputMessage?.content ?? []
+
+    const textContent = contentBlocks
+      .filter((b): b is ContentBlock.TextMember => 'text' in b)
+      .map((b) => b.text)
+      .join('')
+
+    const reasoningContent =
+      contentBlocks
+        .filter(
+          (b): b is ContentBlock.ReasoningContentMember =>
+            'reasoningContent' in b,
+        )
+        .map((b) => b.reasoningContent.reasoningText?.text ?? '')
+        .join('') || undefined
+
+    const toolCalls: ToolCall[] = contentBlocks
+      .filter((b): b is ContentBlock.ToolUseMember => 'toolUse' in b)
+      .map(
+        (b): ToolCall => ({
+          id: b.toolUse.toolUseId,
+          type: 'function',
+          function: {
+            name: b.toolUse.name ?? '',
+            arguments: JSON.stringify(b.toolUse.input),
+          },
+        }),
+      )
+
+    const usage = BedrockProvider.convertUsage(response.usage)
+
+    return {
+      id: `bedrock-${Date.now()}`,
+      choices: [
+        {
+          finish_reason: BedrockProvider.mapStopReason(response.stopReason),
+          message: {
+            content: textContent,
+            reasoning: reasoningContent,
+            role: 'assistant',
+            tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+          },
+        },
+      ],
+      model: request.model,
+      object: 'chat.completion',
+      usage,
+    }
+  }
+
+  async streamResponse(
+    model: ChatModel,
+    request: LLMRequestStreaming,
+    options?: LLMOptions,
+  ): Promise<AsyncIterable<LLMResponseStreaming>> {
+    this.validateCredentials()
+
+    const systemBlocks = BedrockProvider.extractSystemBlocks(request.messages)
+    const messages = BedrockProvider.convertMessages(request.messages)
+    const maxTokens =
+      request.max_tokens ??
+      (model.thinking?.enabled &&
+      typeof model.thinking.budget_tokens === 'number'
+        ? model.thinking.budget_tokens + BedrockProvider.DEFAULT_MAX_TOKENS
+        : BedrockProvider.DEFAULT_MAX_TOKENS)
+
+    const toolConfig = BedrockProvider.buildToolConfig(
+      request.tools,
+      request.tool_choice,
+    )
+
+    const additionalModelRequestFields =
+      BedrockProvider.buildAdditionalModelRequestFields(model)
+
+    const command = new ConverseStreamCommand({
+      modelId: request.model,
+      messages,
+      ...(systemBlocks.length > 0 ? { system: systemBlocks } : {}),
+      inferenceConfig: {
+        maxTokens,
+        ...(request.temperature != null
+          ? { temperature: request.temperature }
+          : {}),
+        ...(request.top_p != null ? { topP: request.top_p } : {}),
+      },
+      ...(toolConfig ? { toolConfig } : {}),
+      ...(additionalModelRequestFields ? { additionalModelRequestFields } : {}),
+    })
+
+    const response = await this.client.send(command, {
+      abortSignal: options?.signal,
+    })
+
+    if (!response.stream) {
+      throw new Error('Bedrock ConverseStream returned no stream')
+    }
+
+    return this.streamResponseGenerator(response.stream, request.model)
+  }
+
+  private async *streamResponseGenerator(
+    stream: AsyncIterable<ConverseStreamOutput>,
+    model: string,
+  ): AsyncIterable<LLMResponseStreaming> {
+    const messageId = `bedrock-${Date.now()}`
+    let usage: ResponseUsage = {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    }
+
+    for await (const event of stream) {
+      if (event.contentBlockDelta) {
+        const delta = event.contentBlockDelta.delta
+        const blockIndex = event.contentBlockDelta.contentBlockIndex ?? 0
+
+        if (delta && 'text' in delta && delta.text) {
+          yield {
+            id: messageId,
+            choices: [
+              {
+                finish_reason: null,
+                delta: {
+                  content: delta.text,
+                },
+              },
+            ],
+            object: 'chat.completion.chunk',
+            model,
+          }
+        } else if (
+          delta &&
+          'reasoningContent' in delta &&
+          delta.reasoningContent
+        ) {
+          const reasoningText =
+            'text' in delta.reasoningContent
+              ? delta.reasoningContent.text
+              : undefined
+          if (reasoningText) {
+            yield {
+              id: messageId,
+              choices: [
+                {
+                  finish_reason: null,
+                  delta: {
+                    reasoning: reasoningText,
+                  },
+                },
+              ],
+              object: 'chat.completion.chunk',
+              model,
+            }
+          }
+        } else if (delta && 'toolUse' in delta && delta.toolUse) {
+          yield {
+            id: messageId,
+            choices: [
+              {
+                finish_reason: null,
+                delta: {
+                  tool_calls: [
+                    {
+                      index: blockIndex,
+                      function: {
+                        arguments: delta.toolUse.input ?? '',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            object: 'chat.completion.chunk',
+            model,
+          }
+        }
+      } else if (event.contentBlockStart) {
+        const start = event.contentBlockStart.start
+        const blockIndex = event.contentBlockStart.contentBlockIndex ?? 0
+
+        if (start && 'toolUse' in start && start.toolUse) {
+          yield {
+            id: messageId,
+            choices: [
+              {
+                finish_reason: null,
+                delta: {
+                  tool_calls: [
+                    {
+                      index: blockIndex,
+                      id: start.toolUse.toolUseId,
+                      type: 'function',
+                      function: {
+                        name: start.toolUse.name,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            object: 'chat.completion.chunk',
+            model,
+          }
+        }
+      } else if (event.metadata) {
+        if (event.metadata.usage) {
+          usage = BedrockProvider.convertUsage(event.metadata.usage)
+        }
+      }
+    }
+
+    // Yield final usage chunk
+    yield {
+      id: messageId,
+      choices: [],
+      object: 'chat.completion.chunk',
+      model,
+      usage,
+    }
+  }
+
+  getEmbedding(_model: string, _text: string): Promise<number[]> {
+    return Promise.reject(
+      new Error(
+        `Provider ${this.provider.id} does not support embeddings via the Converse API. Please use a different provider.`,
+      ),
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private validateCredentials(): void {
+    if (!this.provider.apiKey) {
+      throw new LLMAPIKeyNotSetException(
+        `Provider ${this.provider.id} API key is not set. Please set the API key in the provider settings.`,
+      )
+    }
+  }
+
+  /**
+   * Extract system messages into Bedrock SystemContentBlock[].
+   */
+  static extractSystemBlocks(messages: RequestMessage[]): SystemContentBlock[] {
+    return messages
+      .filter((m) => m.role === 'system')
+      .map((m): SystemContentBlock => ({ text: m.content as string }))
+  }
+
+  /**
+   * Convert the unified RequestMessage[] into Bedrock Message[].
+   * System messages are excluded (handled separately).
+   */
+  static convertMessages(messages: RequestMessage[]): Message[] {
+    const result: Message[] = []
+
+    for (const msg of messages) {
+      switch (msg.role) {
+        case 'system':
+          // Handled separately
+          break
+
+        case 'user': {
+          const contentBlocks = BedrockProvider.convertUserContent(msg.content)
+          if (contentBlocks.length > 0) {
+            result.push({ role: 'user', content: contentBlocks })
+          }
+          break
+        }
+
+        case 'assistant': {
+          const contentBlocks: ContentBlock[] = []
+
+          if (msg.content && msg.content.trim() !== '') {
+            contentBlocks.push({ text: msg.content })
+          }
+
+          if (msg.tool_calls) {
+            for (const tc of msg.tool_calls) {
+              contentBlocks.push({
+                toolUse: {
+                  toolUseId: tc.id,
+                  name: tc.name,
+                  input: (getToolCallArgumentsObject(tc.arguments) ??
+                    {}) as DocumentType,
+                },
+              })
+            }
+          }
+
+          if (contentBlocks.length > 0) {
+            result.push({ role: 'assistant', content: contentBlocks })
+          }
+          break
+        }
+
+        case 'tool': {
+          const toolResultContent: ToolResultContentBlock[] = []
+
+          // Try to parse as JSON first, fall back to text
+          try {
+            const parsed = JSON.parse(msg.content)
+            toolResultContent.push({ json: parsed })
+          } catch {
+            toolResultContent.push({ text: msg.content })
+          }
+
+          result.push({
+            role: 'user',
+            content: [
+              {
+                toolResult: {
+                  toolUseId: msg.tool_call.id,
+                  content: toolResultContent,
+                  status: 'success',
+                },
+              },
+            ],
+          })
+          break
+        }
+      }
+    }
+
+    return result
+  }
+
+  /**
+   * Convert user message content (string or ContentPart[]) to Bedrock ContentBlock[].
+   */
+  private static convertUserContent(
+    content: string | ContentPart[],
+  ): ContentBlock[] {
+    if (typeof content === 'string') {
+      return [{ text: content }]
+    }
+
+    return content.map((part): ContentBlock => {
+      switch (part.type) {
+        case 'text':
+          return { text: part.text }
+        case 'image_url': {
+          const { mimeType, base64Data } = parseImageDataUrl(part.image_url.url)
+          const format = BedrockProvider.toBedrockImageFormat(mimeType)
+          const bytes = Uint8Array.from(atob(base64Data), (c) =>
+            c.charCodeAt(0),
+          )
+          return {
+            image: {
+              format,
+              source: { bytes },
+            },
+          }
+        }
+      }
+    })
+  }
+
+  private static toBedrockImageFormat(mimeType: string): ImageFormat {
+    const map: Record<string, ImageFormat> = {
+      'image/jpeg': 'jpeg',
+      'image/png': 'png',
+      'image/gif': 'gif',
+      'image/webp': 'webp',
+    }
+    const format = map[mimeType]
+    if (!format) {
+      throw new Error(
+        `Unsupported image type ${mimeType}. Bedrock supports: jpeg, png, gif, webp`,
+      )
+    }
+    return format
+  }
+
+  /**
+   * Build Bedrock ToolConfiguration from request tools/choice.
+   */
+  private static buildToolConfig(
+    tools?: RequestTool[],
+    toolChoice?: RequestToolChoice,
+  ): { tools: Tool[]; toolChoice?: ToolChoice } | undefined {
+    if (!tools || tools.length === 0) return undefined
+
+    const bedrockTools: Tool[] = tools.map(
+      (t): Tool => ({
+        toolSpec: {
+          name: t.function.name,
+          description: t.function.description,
+          inputSchema: {
+            json: t.function.parameters as DocumentType,
+          },
+        },
+      }),
+    )
+
+    let bedrockToolChoice: ToolChoice | undefined
+    if (toolChoice) {
+      if (toolChoice === 'auto') {
+        bedrockToolChoice = { auto: {} }
+      } else if (toolChoice === 'required') {
+        bedrockToolChoice = { any: {} }
+      } else if (toolChoice === 'none') {
+        // Bedrock doesn't have a "none" tool choice -- omit toolConfig entirely
+        return undefined
+      } else if (
+        typeof toolChoice === 'object' &&
+        toolChoice.type === 'function'
+      ) {
+        bedrockToolChoice = { tool: { name: toolChoice.function.name } }
+      }
+    }
+
+    return {
+      tools: bedrockTools,
+      ...(bedrockToolChoice ? { toolChoice: bedrockToolChoice } : {}),
+    }
+  }
+
+  /**
+   * Build additionalModelRequestFields for model-specific features
+   * like Claude extended thinking.
+   */
+  private static buildAdditionalModelRequestFields(
+    model: ChatModel,
+  ): DocumentType | undefined {
+    const fields: { [prop: string]: DocumentType } = {}
+
+    // Claude extended thinking support via Bedrock
+    if (
+      model.thinking?.enabled &&
+      typeof model.thinking.budget_tokens === 'number'
+    ) {
+      fields.thinking = {
+        type: 'enabled',
+        budget_tokens: model.thinking.budget_tokens,
+      }
+    }
+
+    return Object.keys(fields).length > 0 ? fields : undefined
+  }
+
+  private static convertUsage(usage?: TokenUsage): ResponseUsage {
+    return {
+      prompt_tokens: usage?.inputTokens ?? 0,
+      completion_tokens: usage?.outputTokens ?? 0,
+      total_tokens: usage?.totalTokens ?? 0,
+    }
+  }
+
+  private static mapStopReason(reason?: string): string {
+    switch (reason) {
+      case 'end_turn':
+        return 'stop'
+      case 'tool_use':
+        return 'tool_calls'
+      case 'max_tokens':
+        return 'length'
+      case 'stop_sequence':
+        return 'stop'
+      default:
+        return reason ?? 'stop'
+    }
+  }
+}

--- a/src/core/llm/manager.test.ts
+++ b/src/core/llm/manager.test.ts
@@ -1,0 +1,45 @@
+import { SmartComposerSettings } from '../../settings/schema/setting.types'
+
+import { BedrockProvider } from './bedrockProvider'
+import { getProviderClient } from './manager'
+import { OpenAICompatibleProvider } from './openaiCompatibleProvider'
+
+const createSettings = (): SmartComposerSettings =>
+  ({
+    providers: [
+      {
+        id: 'bedrock-native',
+        presetType: 'amazon-bedrock',
+        apiType: 'amazon-bedrock',
+        apiKey: 'token',
+        additionalSettings: { awsRegion: 'us-east-1' },
+      },
+      {
+        id: 'bedrock-mantle',
+        presetType: 'amazon-bedrock',
+        apiType: 'openai-compatible',
+        apiKey: 'token',
+        additionalSettings: { awsRegion: 'us-east-1' },
+      },
+    ],
+  } as unknown as SmartComposerSettings)
+
+describe('getProviderClient', () => {
+  it('routes native Bedrock providers to BedrockProvider', () => {
+    const client = getProviderClient({
+      settings: createSettings(),
+      providerId: 'bedrock-native',
+    })
+
+    expect(client).toBeInstanceOf(BedrockProvider)
+  })
+
+  it('routes Bedrock Mantle providers to OpenAICompatibleProvider', () => {
+    const client = getProviderClient({
+      settings: createSettings(),
+      providerId: 'bedrock-mantle',
+    })
+
+    expect(client).toBeInstanceOf(OpenAICompatibleProvider)
+  })
+})

--- a/src/core/llm/manager.ts
+++ b/src/core/llm/manager.ts
@@ -115,19 +115,6 @@ export function getProviderClient({
             onAutoPromoteTransportMode: (mode) =>
               onAutoPromoteTransportMode?.(provider.id, mode),
           })
-        case 'amazon-bedrock': {
-          const awsRegion =
-            (provider.additionalSettings as { awsRegion?: string })
-              ?.awsRegion || 'us-east-1'
-          const bedrockProvider = {
-            ...provider,
-            baseUrl: `https://bedrock-mantle.${awsRegion}.api.aws`,
-          }
-          return new OpenAICompatibleProvider(bedrockProvider as never, {
-            onAutoPromoteTransportMode: (mode) =>
-              onAutoPromoteTransportMode?.(provider.id, mode),
-          })
-        }
         default:
           return new OpenAICompatibleProvider(provider as never, {
             onAutoPromoteTransportMode: (mode) =>

--- a/src/core/llm/manager.ts
+++ b/src/core/llm/manager.ts
@@ -5,6 +5,7 @@ import { LLMProvider } from '../../types/provider.types'
 import { AnthropicProvider } from './anthropic'
 import { AzureOpenAIProvider } from './azureOpenaiProvider'
 import { BaseLLMProvider } from './base'
+import { BedrockProvider } from './bedrockProvider'
 import { ChatGPTOAuthProvider } from './chatgptOAuthProvider'
 import { DeepSeekStudioProvider } from './deepseekStudioProvider'
 import { LLMModelNotFoundException } from './exception'
@@ -62,6 +63,11 @@ export function getProviderClient({
     case 'gemini': {
       return new GeminiProvider(provider as never)
     }
+    case 'amazon-bedrock': {
+      // Base URL is constructed internally by the AWS SDK as
+      // https://bedrock-runtime.{region}.amazonaws.com from the region config.
+      return new BedrockProvider(provider)
+    }
     case 'openai-compatible': {
       switch (provider.presetType) {
         case 'openrouter':
@@ -109,6 +115,19 @@ export function getProviderClient({
             onAutoPromoteTransportMode: (mode) =>
               onAutoPromoteTransportMode?.(provider.id, mode),
           })
+        case 'amazon-bedrock': {
+          const awsRegion =
+            (provider.additionalSettings as { awsRegion?: string })
+              ?.awsRegion || 'us-east-1'
+          const bedrockProvider = {
+            ...provider,
+            baseUrl: `https://bedrock-mantle.${awsRegion}.api.aws`,
+          }
+          return new OpenAICompatibleProvider(bedrockProvider as never, {
+            onAutoPromoteTransportMode: (mode) =>
+              onAutoPromoteTransportMode?.(provider.id, mode),
+          })
+        }
         default:
           return new OpenAICompatibleProvider(provider as never, {
             onAutoPromoteTransportMode: (mode) =>

--- a/src/core/llm/openaiCompatibleProvider.ts
+++ b/src/core/llm/openaiCompatibleProvider.ts
@@ -61,6 +61,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
   private browserClient: OpenAI
   private obsidianClient: OpenAI
   private nodeClient: OpenAI
+  private resolvedBaseUrl?: string
   private requestTransportMode: RequestTransportMode
   private requestTransportMemoryKey: string
   private onAutoPromoteTransportMode?: (mode: AutoPromotedTransportMode) => void
@@ -87,11 +88,12 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
     super(provider)
     this.onAutoPromoteTransportMode = options?.onAutoPromoteTransportMode
     this.adapter = new OpenAIMessageAdapter()
+    this.resolvedBaseUrl = resolveProviderBaseUrl(provider)
     const defaultHeaders = toProviderHeadersRecord(provider.customHeaders)
     this.requestTransportMemoryKey = createRequestTransportMemoryKey({
       providerType: provider.presetType,
       providerId: provider.id,
-      baseUrl: provider.baseUrl,
+      baseUrl: this.resolvedBaseUrl,
     })
     this.requestTransportMode = resolveRequestTransportMode({
       additionalSettings: provider.additionalSettings,
@@ -104,7 +106,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
     // Prefer standard OpenAI SDK; allow opting into NoStainless to bypass headers/validation when needed
     const clientOptions = {
       apiKey: provider.apiKey ?? '',
-      baseURL: resolveProviderBaseUrl(provider) ?? '',
+      baseURL: this.resolvedBaseUrl ?? '',
       dangerouslyAllowBrowser: true,
       maxRetries: this.requestTransportMode === 'auto' ? 0 : undefined,
       defaultHeaders,
@@ -125,7 +127,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
     request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming> {
-    if (!this.provider.baseUrl) {
+    if (!this.resolvedBaseUrl) {
       throw new LLMBaseUrlNotSetException(
         `Provider ${this.provider.id} base URL is missing. Please set it in settings menu.`,
       )
@@ -198,7 +200,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
     applyOpenAICompatibleCapabilities({
       request: formattedRequest,
       model,
-      baseUrl: this.provider.baseUrl,
+      baseUrl: this.resolvedBaseUrl,
     })
 
     // Keep explicit ReasoningEffort typing fallback for strongly OpenAI-like gateways.
@@ -241,7 +243,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
     request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>> {
-    if (!this.provider.baseUrl) {
+    if (!this.resolvedBaseUrl) {
       throw new LLMBaseUrlNotSetException(
         `Provider ${this.provider.id} base URL is missing. Please set it in settings menu.`,
       )
@@ -314,7 +316,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
     applyOpenAICompatibleCapabilities({
       request: formattedRequest,
       model,
-      baseUrl: this.provider.baseUrl,
+      baseUrl: this.resolvedBaseUrl,
     })
 
     if (model.reasoning?.enabled && !formattedRequest.reasoning_effort) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,9 +135,21 @@ export default class SmartComposerPlugin extends Plugin {
     return this.chatLeafSessionManager
   }
 
+  private getModelListCacheKey(
+    providerId: string,
+    scope: 'chat' | 'embedding',
+  ): string {
+    return `${providerId}::${scope}`
+  }
+
   // Get cached model list for a provider
-  getCachedModelList(providerId: string): string[] | null {
-    const cached = this.modelListCache.get(providerId)
+  getCachedModelList(
+    providerId: string,
+    scope: 'chat' | 'embedding' = 'chat',
+  ): string[] | null {
+    const cached = this.modelListCache.get(
+      this.getModelListCacheKey(providerId, scope),
+    )
     if (cached) {
       return cached.models
     }
@@ -145,8 +157,12 @@ export default class SmartComposerPlugin extends Plugin {
   }
 
   // Set model list cache for a provider
-  setCachedModelList(providerId: string, models: string[]): void {
-    this.modelListCache.set(providerId, {
+  setCachedModelList(
+    providerId: string,
+    models: string[],
+    scope: 'chat' | 'embedding' = 'chat',
+  ): void {
+    this.modelListCache.set(this.getModelListCacheKey(providerId, scope), {
       models,
       timestamp: Date.now(),
     })

--- a/src/settings/schema/migrations/39_to_40.ts
+++ b/src/settings/schema/migrations/39_to_40.ts
@@ -1,0 +1,7 @@
+import type { SettingMigration } from '../setting.types'
+
+export const migrateFrom39To40: SettingMigration['migrate'] = (data) => {
+  // No-op migration: bumps version to 40 for Amazon Bedrock provider support.
+  // Bedrock providers are user-created (no default providers or models added).
+  return { ...data, version: 40 }
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -32,6 +32,7 @@ import { migrateFrom35To36 } from './35_to_36'
 import { migrateFrom36To37 } from './36_to_37'
 import { migrateFrom37To38 } from './37_to_38'
 import { migrateFrom38To39 } from './38_to_39'
+import { migrateFrom39To40 } from './39_to_40'
 import { migrateFrom3To4 } from './3_to_4'
 import { migrateFrom4To5 } from './4_to_5'
 import { migrateFrom5To6 } from './5_to_6'
@@ -40,7 +41,7 @@ import { migrateFrom7To8 } from './7_to_8'
 import { migrateFrom8To9 } from './8_to_9'
 import { migrateFrom9To10 } from './9_to_10'
 
-export const SETTINGS_SCHEMA_VERSION = 39
+export const SETTINGS_SCHEMA_VERSION = 40
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -237,5 +238,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 38,
     toVersion: 39,
     migrate: migrateFrom38To39,
+  },
+  {
+    fromVersion: 39,
+    toVersion: 40,
+    migrate: migrateFrom39To40,
   },
 ]

--- a/src/types/provider.types.ts
+++ b/src/types/provider.types.ts
@@ -30,6 +30,7 @@ export const providerPresetTypeSchema = z.enum([
   'lm-studio',
   'morph',
   'azure-openai',
+  'amazon-bedrock',
   'openai-compatible',
 ])
 
@@ -38,6 +39,7 @@ export const providerApiTypeSchema = z.enum([
   'openai-responses',
   'anthropic',
   'gemini',
+  'amazon-bedrock',
 ])
 
 export type LLMProviderPresetType = z.infer<typeof providerPresetTypeSchema>
@@ -60,6 +62,7 @@ const DEFAULT_PROVIDER_API_TYPE_BY_PRESET: Record<
   'lm-studio': 'openai-compatible',
   morph: 'openai-compatible',
   'azure-openai': 'openai-compatible',
+  'amazon-bedrock': 'amazon-bedrock',
   'openai-compatible': 'openai-compatible',
 }
 
@@ -81,6 +84,9 @@ export function getSupportedApiTypesForPresetType(
       defaults.add('openai-compatible')
       break
     case 'gemini':
+      defaults.add('openai-compatible')
+      break
+    case 'amazon-bedrock':
       defaults.add('openai-compatible')
       break
     default:

--- a/src/utils/llm/bedrock.test.ts
+++ b/src/utils/llm/bedrock.test.ts
@@ -1,0 +1,45 @@
+import {
+  buildBedrockEmbeddingRequestBody,
+  isSupportedBedrockEmbeddingModel,
+} from './bedrock'
+
+describe('bedrock utils', () => {
+  it('recognizes supported Bedrock embedding model families', () => {
+    expect(
+      isSupportedBedrockEmbeddingModel('amazon.titan-embed-text-v2:0'),
+    ).toBe(true)
+    expect(isSupportedBedrockEmbeddingModel('cohere.embed-english-v3')).toBe(
+      true,
+    )
+    expect(
+      isSupportedBedrockEmbeddingModel('some-future.embedding-family-v1'),
+    ).toBe(false)
+  })
+
+  it('builds a Titan embedding request body', () => {
+    expect(
+      buildBedrockEmbeddingRequestBody(
+        'amazon.titan-embed-text-v2:0',
+        'hello',
+      ),
+    ).toEqual({
+      inputText: 'hello',
+    })
+  })
+
+  it('builds a Cohere embedding request body', () => {
+    expect(
+      buildBedrockEmbeddingRequestBody('cohere.embed-english-v3', 'hello'),
+    ).toEqual({
+      texts: ['hello'],
+      input_type: 'search_document',
+      embedding_types: ['float'],
+    })
+  })
+
+  it('rejects unsupported Bedrock embedding families clearly', () => {
+    expect(() =>
+      buildBedrockEmbeddingRequestBody('unsupported.embedding-model', 'hello'),
+    ).toThrow('Embedding is not yet supported')
+  })
+})

--- a/src/utils/llm/bedrock.ts
+++ b/src/utils/llm/bedrock.ts
@@ -1,0 +1,114 @@
+import { LLMProvider } from '../../types/provider.types'
+
+type BedrockAdditionalSettings = {
+  awsRegion?: string
+}
+
+type BedrockProviderLike = Pick<
+  LLMProvider,
+  'presetType' | 'apiType' | 'apiKey' | 'additionalSettings'
+>
+
+export function getBedrockRegion(
+  provider: Pick<LLMProvider, 'additionalSettings'>,
+): string | undefined {
+  const additionalSettings =
+    (provider.additionalSettings as BedrockAdditionalSettings) ?? {}
+  const awsRegion = additionalSettings.awsRegion?.trim()
+  return awsRegion ? awsRegion : undefined
+}
+
+export function resolveBedrockMantleBaseUrl(
+  provider: Pick<LLMProvider, 'additionalSettings'>,
+): string | undefined {
+  const region = getBedrockRegion(provider)
+  if (!region) {
+    return undefined
+  }
+
+  return `https://bedrock-mantle.${region}.api.aws`
+}
+
+export function resolveBedrockRuntimeBaseUrl(
+  provider: Pick<LLMProvider, 'additionalSettings'>,
+): string | undefined {
+  const region = getBedrockRegion(provider)
+  if (!region) {
+    return undefined
+  }
+
+  return `https://bedrock-runtime.${region}.amazonaws.com`
+}
+
+export function isNativeBedrockProvider(provider: BedrockProviderLike): boolean {
+  return (
+    provider.presetType === 'amazon-bedrock' &&
+    provider.apiType === 'amazon-bedrock'
+  )
+}
+
+export function isBedrockMantleProvider(
+  provider: BedrockProviderLike,
+): boolean {
+  return (
+    provider.presetType === 'amazon-bedrock' &&
+    provider.apiType === 'openai-compatible'
+  )
+}
+
+export function createBedrockBearerClientConfig(
+  provider: Pick<LLMProvider, 'apiKey' | 'additionalSettings'>,
+): {
+  region: string
+  token: { token: string }
+  authSchemePreference: ['httpBearerAuth']
+} {
+  const region = getBedrockRegion(provider)
+  if (!region) {
+    throw new Error('AWS region is required for Amazon Bedrock providers.')
+  }
+  const token = provider.apiKey?.trim()
+  if (!token) {
+    throw new Error('Amazon Bedrock API key (bearer token) is required.')
+  }
+
+  return {
+    region,
+    token: { token },
+    authSchemePreference: ['httpBearerAuth'],
+  }
+}
+
+export function isSupportedBedrockEmbeddingModel(modelId: string): boolean {
+  const normalizedModelId = modelId.toLowerCase()
+
+  return (
+    normalizedModelId.startsWith('amazon.titan-embed') ||
+    normalizedModelId.startsWith('cohere.embed')
+  )
+}
+
+export function buildBedrockEmbeddingRequestBody(
+  modelId: string,
+  text: string,
+): Record<string, unknown> {
+  const normalizedModelId = modelId.toLowerCase()
+
+  if (normalizedModelId.startsWith('amazon.titan-embed')) {
+    return {
+      inputText: text,
+    }
+  }
+
+  if (normalizedModelId.startsWith('cohere.embed')) {
+    return {
+      texts: [text],
+      input_type: 'search_document',
+      embedding_types: ['float'],
+    }
+  }
+
+  throw new Error(
+    `Embedding is not yet supported for the Bedrock model family "${modelId}". Please use a text embedding model such as amazon.titan-embed-* or cohere.embed-*.`,
+  )
+}

--- a/src/utils/llm/provider-base-url.test.ts
+++ b/src/utils/llm/provider-base-url.test.ts
@@ -1,0 +1,66 @@
+import { getDefaultApiTypeForPresetType, LLMProvider } from '../../types/provider.types'
+
+import {
+  resolveProviderBaseUrl,
+  resolveProviderDisplayBaseUrl,
+} from './provider-base-url'
+import { providerSupportsEmbedding } from './provider-config'
+
+const createBedrockProvider = (
+  overrides: Partial<LLMProvider> = {},
+): LLMProvider => ({
+  id: 'bedrock',
+  presetType: 'amazon-bedrock',
+  apiType: 'amazon-bedrock',
+  apiKey: 'token',
+  additionalSettings: {
+    awsRegion: 'us-east-1',
+  },
+  ...overrides,
+})
+
+describe('provider-base-url', () => {
+  it('defaults amazon-bedrock preset to the native api type', () => {
+    expect(getDefaultApiTypeForPresetType('amazon-bedrock')).toBe(
+      'amazon-bedrock',
+    )
+  })
+
+  it('derives the Bedrock Mantle URL for openai-compatible mode', () => {
+    expect(
+      resolveProviderBaseUrl(
+        createBedrockProvider({
+          apiType: 'openai-compatible',
+        }),
+      ),
+    ).toBe('https://bedrock-mantle.us-east-1.api.aws')
+  })
+
+  it('keeps a custom base URL override for Bedrock Mantle', () => {
+    expect(
+      resolveProviderBaseUrl(
+        createBedrockProvider({
+          apiType: 'openai-compatible',
+          baseUrl: 'https://custom-mantle.example/v1/',
+        }),
+      ),
+    ).toBe('https://custom-mantle.example/v1')
+  })
+
+  it('shows the Bedrock runtime URL for native providers', () => {
+    expect(resolveProviderDisplayBaseUrl(createBedrockProvider())).toBe(
+      'https://bedrock-runtime.us-east-1.amazonaws.com',
+    )
+  })
+
+  it('only enables embeddings for native Bedrock providers', () => {
+    expect(providerSupportsEmbedding(createBedrockProvider())).toBe(true)
+    expect(
+      providerSupportsEmbedding(
+        createBedrockProvider({
+          apiType: 'openai-compatible',
+        }),
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/utils/llm/provider-base-url.ts
+++ b/src/utils/llm/provider-base-url.ts
@@ -1,5 +1,12 @@
 import { LLMProvider } from '../../types/provider.types'
 
+import {
+  isBedrockMantleProvider,
+  isNativeBedrockProvider,
+  resolveBedrockMantleBaseUrl,
+  resolveBedrockRuntimeBaseUrl,
+} from './bedrock'
+
 const DEFAULT_BASE_URL_BY_PRESET: Partial<
   Record<LLMProvider['presetType'], string>
 > = {
@@ -8,12 +15,32 @@ const DEFAULT_BASE_URL_BY_PRESET: Partial<
 }
 
 export function resolveProviderBaseUrl(
-  provider: Pick<LLMProvider, 'presetType' | 'baseUrl'>,
+  provider: Pick<
+    LLMProvider,
+    'presetType' | 'apiType' | 'baseUrl' | 'additionalSettings'
+  >,
 ): string | undefined {
   const customBaseUrl = provider.baseUrl?.trim()
   if (customBaseUrl) {
     return customBaseUrl.replace(/\/+$/, '')
   }
 
+  if (isBedrockMantleProvider(provider)) {
+    return resolveBedrockMantleBaseUrl(provider)
+  }
+
   return DEFAULT_BASE_URL_BY_PRESET[provider.presetType]
+}
+
+export function resolveProviderDisplayBaseUrl(
+  provider: Pick<
+    LLMProvider,
+    'presetType' | 'apiType' | 'baseUrl' | 'additionalSettings'
+  >,
+): string | undefined {
+  if (isNativeBedrockProvider(provider)) {
+    return resolveBedrockRuntimeBaseUrl(provider)
+  }
+
+  return resolveProviderBaseUrl(provider)
 }

--- a/src/utils/llm/provider-config.ts
+++ b/src/utils/llm/provider-config.ts
@@ -51,6 +51,7 @@ export function getRequestTransportModeValue(
 export function providerSupportsEmbedding(provider: LLMProvider): boolean {
   switch (provider.apiType) {
     case 'anthropic':
+    case 'amazon-bedrock':
       return false
     case 'gemini':
       return true

--- a/src/utils/llm/provider-config.ts
+++ b/src/utils/llm/provider-config.ts
@@ -3,6 +3,11 @@ import { ChatModel } from '../../types/chat-model.types'
 import { EmbeddingModel } from '../../types/embedding-model.types'
 import { LLMProvider, RequestTransportMode } from '../../types/provider.types'
 
+import {
+  isBedrockMantleProvider,
+  isNativeBedrockProvider,
+} from './bedrock'
+
 export function getProviderById(
   settings: Pick<SmartComposerSettings, 'providers'>,
   providerId: string,
@@ -49,16 +54,31 @@ export function getRequestTransportModeValue(
 }
 
 export function providerSupportsEmbedding(provider: LLMProvider): boolean {
+  if (isNativeBedrockProvider(provider)) {
+    return true
+  }
+
   switch (provider.apiType) {
     case 'anthropic':
+      return false
     case 'amazon-bedrock':
       return false
     case 'gemini':
       return true
     case 'openai-compatible':
+      return (
+        provider.presetType !== 'chatgpt-oauth' &&
+        !isBedrockMantleProvider(provider)
+      )
     case 'openai-responses':
       return provider.presetType !== 'chatgpt-oauth'
   }
+}
+
+export function providerSupportsTransportModeSelection(
+  provider: Pick<LLMProvider, 'presetType' | 'apiType'>,
+): boolean {
+  return !isNativeBedrockProvider(provider as LLMProvider)
 }
 
 export function providerSupportsGeminiTools(provider: LLMProvider): boolean {


### PR DESCRIPTION
## Summary\n- base this work on #213\n- route Amazon Bedrock native providers through the Bedrock runtime path while keeping Mantle on the OpenAI-compatible path\n- align Bedrock embedding model discovery with the embedding families currently supported at runtime\n\n## Testing\n- npm run type:check\n- npm test -- --runInBand src/utils/llm/bedrock.test.ts src/core/llm/bedrockProvider.test.ts src/utils/llm/provider-base-url.test.ts