### PR TITLE
新增实验性选项：把插件的 data.json 镜像到 YOLO 文件夹，方便通过 Obsidian Sync 在多设备间同步设置

### DIFF
--- a/src/components/settings/sections/EtcSection.tsx
+++ b/src/components/settings/sections/EtcSection.tsx
@@ -342,6 +342,31 @@ export function EtcSection({ app, className }: EtcSectionProps) {
           </ObsidianSetting>
 
           <ObsidianSetting
+            name={t(
+              'settings.etc.storeDataInVault',
+              '通过 vault 同步设置（实验性）',
+            )}
+            desc={t(
+              'settings.etc.storeDataInVaultDesc',
+              '开启后会把设置文件额外写入 {path}，使其可被 Obsidian Sync 同步。关闭时会从 vault 删除该文件。',
+            ).replace('{path}', `${yoloBaseDir}/.yolo_data.json`)}
+            className="smtcmp-settings-card"
+          >
+            <ObsidianToggle
+              value={settings.experimental?.storeDataInVault ?? false}
+              onChange={(value) => {
+                void setSettings({
+                  ...settings,
+                  experimental: {
+                    ...(settings.experimental ?? { storeDataInVault: false }),
+                    storeDataInVault: value,
+                  },
+                })
+              }}
+            />
+          </ObsidianSetting>
+
+          <ObsidianSetting
             name={t('settings.etc.logModelRequestContext')}
             desc={t('settings.etc.logModelRequestContextDesc')}
             className="smtcmp-settings-card"

--- a/src/core/paths/yoloManagedData.ts
+++ b/src/core/paths/yoloManagedData.ts
@@ -6,6 +6,7 @@ import {
   getYoloBaseDir,
   getYoloDataJsonPath,
   getYoloJsonDbRootDir,
+  getYoloSyncPointerPath,
   getYoloVectorDbPath,
 } from './yoloPaths'
 
@@ -297,6 +298,9 @@ const relocateVectorDbFile = async ({
   }
 }
 
+// Move the optional vault-stored `data.json` mirror alongside `baseDir`
+// changes. Failure is non-fatal — the mirror is best-effort and the next
+// successful `writeVaultDataJson` will overwrite the target anyway.
 const relocateDataJsonFile = async ({
   app,
   sourcePath,
@@ -305,31 +309,29 @@ const relocateDataJsonFile = async ({
   app: App
   sourcePath: string
   targetPath: string
-}): Promise<boolean> => {
+}): Promise<void> => {
   if (sourcePath === targetPath) {
-    return true
+    return
   }
   if (!(await app.vault.adapter.exists(sourcePath))) {
-    return true
+    return
   }
-
   try {
     await ensureParentDir(app, targetPath)
-    if (await app.vault.adapter.exists(targetPath)) {
-      // Target already has data — keep target, drop source to avoid overwriting.
-      await removePathIfExists(app, sourcePath)
-      return true
+    // If target already exists, we still drop source to avoid orphan. The
+    // caller (`saveSettings`) invokes `writeVaultDataJson` right after, which
+    // overwrites target with the latest in-memory settings — so whatever was
+    // at target gets refreshed regardless.
+    if (!(await app.vault.adapter.exists(targetPath))) {
+      const content = await app.vault.adapter.read(sourcePath)
+      await app.vault.adapter.write(targetPath, content)
     }
-    const content = await app.vault.adapter.read(sourcePath)
-    await app.vault.adapter.write(targetPath, content)
     await removePathIfExists(app, sourcePath)
-    return true
   } catch (error) {
     console.warn(
-      `[YOLO] Failed to relocate data.json from "${sourcePath}" to "${targetPath}".`,
+      `[YOLO] Failed to relocate data.json mirror from "${sourcePath}" to "${targetPath}".`,
       error,
     )
-    return false
   }
 }
 
@@ -382,42 +384,40 @@ export const relocateYoloManagedData = async ({
     return false
   }
 
-  // When the YOLO base dir changes, also move the optional vault-stored
-  // `data.json` mirror (used by the experimental `storeDataInVault` option).
-  // A failure here is non-fatal — the mirror is best-effort.
-  const sourceDataJsonPath = getYoloDataJsonPath(fromSettings)
-  const targetDataJsonPath = getYoloDataJsonPath(toSettings)
+  // Move the optional vault-stored mirror alongside baseDir changes. The
+  // pointer file is updated by the subsequent `writeVaultDataJson` call in
+  // `saveSettings` (if the feature is on); if the feature is off, a stale
+  // pointer may remain — that's fine, `readVaultDataJson` gracefully returns
+  // null when the pointer target is missing.
   await relocateDataJsonFile({
     app,
-    sourcePath: sourceDataJsonPath,
-    targetPath: targetDataJsonPath,
+    sourcePath: getYoloDataJsonPath(fromSettings),
+    targetPath: getYoloDataJsonPath(toSettings),
   })
 
   return true
 }
 
-/**
- * Reads the vault-stored `data.json` mirror, if it exists. Returns null when
- * the file is missing or cannot be parsed as JSON.
- */
-export const readVaultDataJson = async (
-  app: App,
-  settings?: YoloSettingsLike | null,
-): Promise<Record<string, unknown> | null> => {
-  const path = getYoloDataJsonPath(settings)
-  if (!(await app.vault.adapter.exists(path))) {
+const readPointerDataPath = async (app: App): Promise<string | null> => {
+  const pointerPath = getYoloSyncPointerPath()
+  if (!(await app.vault.adapter.exists(pointerPath))) {
     return null
   }
   try {
-    const raw = await app.vault.adapter.read(path)
+    const raw = await app.vault.adapter.read(pointerPath)
     const parsed = JSON.parse(raw) as unknown
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      typeof (parsed as { dataPath?: unknown }).dataPath === 'string'
+    ) {
+      return normalizePath((parsed as { dataPath: string }).dataPath)
     }
     return null
   } catch (error) {
     console.warn(
-      `[YOLO] Failed to read vault data.json at "${path}"; falling back to plugin data.`,
+      `[YOLO] Failed to read sync pointer at "${pointerPath}".`,
       error,
     )
     return null
@@ -425,42 +425,90 @@ export const readVaultDataJson = async (
 }
 
 /**
- * Writes settings to the vault-stored `data.json` mirror. Returns true on
- * success; failures are non-fatal and logged.
+ * Reads the vault-stored `data.json` mirror by first resolving the pointer
+ * file at vault root, then reading the file it points to. Returns null when
+ * the pointer or data file is missing or unparseable.
+ */
+export const readVaultDataJson = async (
+  app: App,
+): Promise<Record<string, unknown> | null> => {
+  const dataPath = await readPointerDataPath(app)
+  if (!dataPath) {
+    return null
+  }
+  if (!(await app.vault.adapter.exists(dataPath))) {
+    return null
+  }
+  try {
+    const raw = await app.vault.adapter.read(dataPath)
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+    return null
+  } catch (error) {
+    console.warn(
+      `[YOLO] Failed to read vault data mirror at "${dataPath}"; falling back to plugin data.`,
+      error,
+    )
+    return null
+  }
+}
+
+/**
+ * Writes settings to the vault-stored `data.json` mirror under `baseDir`,
+ * and refreshes the vault-root pointer so other devices can locate it.
+ * Returns true on success; failures are non-fatal and logged.
  */
 export const writeVaultDataJson = async (
   app: App,
   settings: YoloSettingsLike | null,
   data: unknown,
 ): Promise<boolean> => {
-  const path = getYoloDataJsonPath(settings)
+  const dataPath = getYoloDataJsonPath(settings)
+  const pointerPath = getYoloSyncPointerPath()
   try {
     await ensureDir(app, getYoloBaseDir(settings))
-    await app.vault.adapter.write(path, JSON.stringify(data, null, 2))
+    await app.vault.adapter.write(dataPath, JSON.stringify(data, null, 2))
+    await app.vault.adapter.write(
+      pointerPath,
+      JSON.stringify({ dataPath }, null, 2),
+    )
     return true
   } catch (error) {
-    console.warn(`[YOLO] Failed to write vault data.json at "${path}".`, error)
+    console.warn(
+      `[YOLO] Failed to write vault data mirror at "${dataPath}".`,
+      error,
+    )
     return false
   }
 }
 
 /**
- * Removes the vault-stored `data.json` mirror if present. Returns true when
- * the file is absent after the call.
+ * Removes both the pointer file and the data mirror it points to. Falls back
+ * to the settings-derived data path when the pointer is missing or invalid,
+ * so a stale/partial state still gets cleaned up.
  */
 export const removeVaultDataJson = async (
   app: App,
   settings?: YoloSettingsLike | null,
 ): Promise<boolean> => {
-  const path = getYoloDataJsonPath(settings)
-  if (!(await app.vault.adapter.exists(path))) {
-    return true
-  }
+  const pointerPath = getYoloSyncPointerPath()
+  const dataPathFromPointer = await readPointerDataPath(app)
+  const dataPath = dataPathFromPointer ?? getYoloDataJsonPath(settings)
   try {
-    await app.vault.adapter.remove(path)
+    if (await app.vault.adapter.exists(dataPath)) {
+      await app.vault.adapter.remove(dataPath)
+    }
+    if (await app.vault.adapter.exists(pointerPath)) {
+      await app.vault.adapter.remove(pointerPath)
+    }
     return true
   } catch (error) {
-    console.warn(`[YOLO] Failed to remove vault data.json at "${path}".`, error)
+    console.warn(
+      `[YOLO] Failed to remove vault data mirror (pointer="${pointerPath}", data="${dataPath}").`,
+      error,
+    )
     return false
   }
 }

--- a/src/core/paths/yoloManagedData.ts
+++ b/src/core/paths/yoloManagedData.ts
@@ -4,6 +4,7 @@ import {
   getLegacyJsonDbRootDir,
   getLegacyVectorDbPath,
   getYoloBaseDir,
+  getYoloDataJsonPath,
   getYoloJsonDbRootDir,
   getYoloVectorDbPath,
 } from './yoloPaths'
@@ -296,6 +297,42 @@ const relocateVectorDbFile = async ({
   }
 }
 
+const relocateDataJsonFile = async ({
+  app,
+  sourcePath,
+  targetPath,
+}: {
+  app: App
+  sourcePath: string
+  targetPath: string
+}): Promise<boolean> => {
+  if (sourcePath === targetPath) {
+    return true
+  }
+  if (!(await app.vault.adapter.exists(sourcePath))) {
+    return true
+  }
+
+  try {
+    await ensureParentDir(app, targetPath)
+    if (await app.vault.adapter.exists(targetPath)) {
+      // Target already has data — keep target, drop source to avoid overwriting.
+      await removePathIfExists(app, sourcePath)
+      return true
+    }
+    const content = await app.vault.adapter.read(sourcePath)
+    await app.vault.adapter.write(targetPath, content)
+    await removePathIfExists(app, sourcePath)
+    return true
+  } catch (error) {
+    console.warn(
+      `[YOLO] Failed to relocate data.json from "${sourcePath}" to "${targetPath}".`,
+      error,
+    )
+    return false
+  }
+}
+
 export const relocateYoloManagedData = async ({
   app,
   fromSettings,
@@ -331,19 +368,99 @@ export const relocateYoloManagedData = async ({
     sourceCandidates: sourceVectorCandidates,
     targetPath: targetVectorPath,
   })
-  if (vectorSucceeded) {
-    return true
+  if (!vectorSucceeded) {
+    const rolledBackJson = await relocateJsonDbRootDir({
+      app,
+      sourceCandidates: [targetJsonDir],
+      targetDir: getYoloJsonDbRootDir(fromSettings),
+    })
+    if (!rolledBackJson) {
+      console.warn(
+        `[YOLO] Failed to roll back chat storage after vector relocation failed. Source root: "${targetJsonDir}".`,
+      )
+    }
+    return false
   }
 
-  const rolledBackJson = await relocateJsonDbRootDir({
+  // When the YOLO base dir changes, also move the optional vault-stored
+  // `data.json` mirror (used by the experimental `storeDataInVault` option).
+  // A failure here is non-fatal — the mirror is best-effort.
+  const sourceDataJsonPath = getYoloDataJsonPath(fromSettings)
+  const targetDataJsonPath = getYoloDataJsonPath(toSettings)
+  await relocateDataJsonFile({
     app,
-    sourceCandidates: [targetJsonDir],
-    targetDir: getYoloJsonDbRootDir(fromSettings),
+    sourcePath: sourceDataJsonPath,
+    targetPath: targetDataJsonPath,
   })
-  if (!rolledBackJson) {
-    console.warn(
-      `[YOLO] Failed to roll back chat storage after vector relocation failed. Source root: "${targetJsonDir}".`,
-    )
+
+  return true
+}
+
+/**
+ * Reads the vault-stored `data.json` mirror, if it exists. Returns null when
+ * the file is missing or cannot be parsed as JSON.
+ */
+export const readVaultDataJson = async (
+  app: App,
+  settings?: YoloSettingsLike | null,
+): Promise<Record<string, unknown> | null> => {
+  const path = getYoloDataJsonPath(settings)
+  if (!(await app.vault.adapter.exists(path))) {
+    return null
   }
-  return false
+  try {
+    const raw = await app.vault.adapter.read(path)
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+    return null
+  } catch (error) {
+    console.warn(
+      `[YOLO] Failed to read vault data.json at "${path}"; falling back to plugin data.`,
+      error,
+    )
+    return null
+  }
+}
+
+/**
+ * Writes settings to the vault-stored `data.json` mirror. Returns true on
+ * success; failures are non-fatal and logged.
+ */
+export const writeVaultDataJson = async (
+  app: App,
+  settings: YoloSettingsLike | null,
+  data: unknown,
+): Promise<boolean> => {
+  const path = getYoloDataJsonPath(settings)
+  try {
+    await ensureDir(app, getYoloBaseDir(settings))
+    await app.vault.adapter.write(path, JSON.stringify(data, null, 2))
+    return true
+  } catch (error) {
+    console.warn(`[YOLO] Failed to write vault data.json at "${path}".`, error)
+    return false
+  }
+}
+
+/**
+ * Removes the vault-stored `data.json` mirror if present. Returns true when
+ * the file is absent after the call.
+ */
+export const removeVaultDataJson = async (
+  app: App,
+  settings?: YoloSettingsLike | null,
+): Promise<boolean> => {
+  const path = getYoloDataJsonPath(settings)
+  if (!(await app.vault.adapter.exists(path))) {
+    return true
+  }
+  try {
+    await app.vault.adapter.remove(path)
+    return true
+  } catch (error) {
+    console.warn(`[YOLO] Failed to remove vault data.json at "${path}".`, error)
+    return false
+  }
 }

--- a/src/core/paths/yoloPaths.ts
+++ b/src/core/paths/yoloPaths.ts
@@ -6,6 +6,10 @@ export const YOLO_SKILLS_INDEX_FILE_NAME = 'Skills.md'
 export const YOLO_JSON_DB_DIR_NAME = '.yolo_json_db'
 export const YOLO_VECTOR_DB_FILE_NAME = '.yolo_vector_db.tar.gz'
 export const YOLO_DATA_JSON_FILE_NAME = '.yolo_data.json'
+// Fixed-name pointer file at vault root. Its content is a JSON object
+// { "dataPath": "<vault-relative path to .yolo_data.json>" } used to locate
+// the actual mirror file whose directory depends on `yolo.baseDir`.
+export const YOLO_SYNC_POINTER_FILE_NAME = '.yolo_sync'
 export const LEGACY_JSON_DB_DIR_NAME = '.smtcmp_json_db'
 export const LEGACY_VECTOR_DB_FILE_NAME = '.smtcmp_vector_db.tar.gz'
 
@@ -75,12 +79,21 @@ export const getYoloVectorDbPath = (
   )
 }
 
+// The vault-stored `data.json` mirror sits under `yolo.baseDir` for UX
+// consistency with other plugin files (.yolo_json_db, .yolo_vector_db.tar.gz).
+// A sibling pointer file at vault root (`.yolo_sync`) records where this
+// path is, so other devices can locate the mirror without needing the synced
+// `baseDir` value upfront — breaking the bootstrap circular dependency.
 export const getYoloDataJsonPath = (
   settings?: YoloSettingsLike | null,
 ): string => {
   return normalizePath(
     `${getYoloBaseDir(settings)}/${YOLO_DATA_JSON_FILE_NAME}`,
   )
+}
+
+export const getYoloSyncPointerPath = (): string => {
+  return normalizePath(YOLO_SYNC_POINTER_FILE_NAME)
 }
 
 export const getLegacyJsonDbRootDir = (): string => {

--- a/src/core/paths/yoloPaths.ts
+++ b/src/core/paths/yoloPaths.ts
@@ -5,6 +5,7 @@ export const YOLO_SKILLS_SUBDIR = 'skills'
 export const YOLO_SKILLS_INDEX_FILE_NAME = 'Skills.md'
 export const YOLO_JSON_DB_DIR_NAME = '.yolo_json_db'
 export const YOLO_VECTOR_DB_FILE_NAME = '.yolo_vector_db.tar.gz'
+export const YOLO_DATA_JSON_FILE_NAME = '.yolo_data.json'
 export const LEGACY_JSON_DB_DIR_NAME = '.smtcmp_json_db'
 export const LEGACY_VECTOR_DB_FILE_NAME = '.smtcmp_vector_db.tar.gz'
 
@@ -71,6 +72,14 @@ export const getYoloVectorDbPath = (
 ): string => {
   return normalizePath(
     `${getYoloBaseDir(settings)}/${YOLO_VECTOR_DB_FILE_NAME}`,
+  )
+}
+
+export const getYoloDataJsonPath = (
+  settings?: YoloSettingsLike | null,
+): string => {
+  return normalizePath(
+    `${getYoloBaseDir(settings)}/${YOLO_DATA_JSON_FILE_NAME}`,
   )
 }
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1008,6 +1008,9 @@ export const en: TranslationKeys = {
       yoloBaseDirDesc:
         'Enter a vault-relative path (without a leading /). Example: use YOLO at vault root, or setting/YOLO under the setting folder. Current skills directory: {path}.',
       yoloBaseDirPlaceholder: 'YOLO',
+      storeDataInVault: 'Sync settings via vault (Experimental)',
+      storeDataInVaultDesc:
+        'When enabled, settings are also written to {path} so they can be synced by Obsidian Sync. Turning this off removes the vault copy.',
       mentionDisplayMode: 'Mention display position',
       mentionDisplayModeDesc:
         'Choose whether @ file mentions and / skill selections are shown inline in the editor or as badges above the input box.',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1010,7 +1010,7 @@ export const en: TranslationKeys = {
       yoloBaseDirPlaceholder: 'YOLO',
       storeDataInVault: 'Sync settings via vault (Experimental)',
       storeDataInVaultDesc:
-        'When enabled, settings are also written to {path} so they can be synced by Obsidian Sync. Turning this off removes the vault copy.',
+        'When enabled, settings are also written to {path} so they can be synced by Obsidian Sync; turning this off removes the vault copy. ⚠️ This file contains API keys and other sensitive data. Make sure your vault is NOT synced through any public channel (e.g. public Git repos, public cloud drives), and that you fully trust every plugin that can read the vault.',
       mentionDisplayMode: 'Mention display position',
       mentionDisplayModeDesc:
         'Choose whether @ file mentions and / skill selections are shown inline in the editor or as badges above the input box.',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -998,7 +998,7 @@ export const it: TranslationKeys = {
       storeDataInVault:
         'Sincronizza le impostazioni tramite vault (sperimentale)',
       storeDataInVaultDesc:
-        'Se attivo, le impostazioni vengono scritte anche in {path} così da poter essere sincronizzate da Obsidian Sync. Disattivandolo il file nel vault viene rimosso.',
+        'Se attivo, le impostazioni vengono scritte anche in {path} così da poter essere sincronizzate da Obsidian Sync; disattivandolo il file nel vault viene rimosso. ⚠️ Il file contiene chiavi API e altri dati sensibili. Assicurati che il tuo vault NON sia sincronizzato tramite canali pubblici (ad esempio repository Git pubblici o cloud drive pubblici) e di fidarti pienamente di tutti i plugin che possono leggere il vault.',
       mentionDisplayMode: 'Posizione visualizzazione mention',
       mentionDisplayModeDesc:
         "Scegli se mostrare i file selezionati con @ e le skill selezionate con / nel testo dell'input o come badge sopra la casella.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -995,6 +995,10 @@ export const it: TranslationKeys = {
       yoloBaseDirDesc:
         'Inserisci un percorso relativo al vault (senza / iniziale). Esempio: YOLO nella radice del vault, oppure setting/YOLO nella cartella setting. Directory skill attuale: {path}.',
       yoloBaseDirPlaceholder: 'YOLO',
+      storeDataInVault:
+        'Sincronizza le impostazioni tramite vault (sperimentale)',
+      storeDataInVaultDesc:
+        'Se attivo, le impostazioni vengono scritte anche in {path} così da poter essere sincronizzate da Obsidian Sync. Disattivandolo il file nel vault viene rimosso.',
       mentionDisplayMode: 'Posizione visualizzazione mention',
       mentionDisplayModeDesc:
         "Scegli se mostrare i file selezionati con @ e le skill selezionate con / nel testo dell'input o come badge sopra la casella.",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -925,6 +925,9 @@ export const zh: TranslationKeys = {
       yoloBaseDirDesc:
         '填写库内相对路径（不要以 / 开头）。例如：放在库根目录填 YOLO；放在 setting 文件夹下填 setting/YOLO。当前技能目录：{path}。',
       yoloBaseDirPlaceholder: 'YOLO',
+      storeDataInVault: '通过 vault 同步设置（实验性）',
+      storeDataInVaultDesc:
+        '开启后会把设置文件额外写入 {path}，使其可被 Obsidian Sync 同步。关闭时会从 vault 删除该文件。',
       mentionDisplayMode: '引用内容显示位置',
       mentionDisplayModeDesc:
         '选择 @ 文件引用和 / 技能选择是在输入框内显示，还是在输入框顶部以徽章显示。',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -927,7 +927,7 @@ export const zh: TranslationKeys = {
       yoloBaseDirPlaceholder: 'YOLO',
       storeDataInVault: '通过 vault 同步设置（实验性）',
       storeDataInVaultDesc:
-        '开启后会把设置文件额外写入 {path}，使其可被 Obsidian Sync 同步。关闭时会从 vault 删除该文件。',
+        '开启后会把设置文件额外写入 {path}，使其可被 Obsidian Sync 同步；关闭时会从 vault 删除该文件。⚠️ 该文件包含 API 密钥等敏感信息，请务必确认你的 vault 未通过公开渠道同步（如公共 Git 仓库、公共网盘），并充分信任所有可读取 vault 的插件。',
       mentionDisplayMode: '引用内容显示位置',
       mentionDisplayModeDesc:
         '选择 @ 文件引用和 / 技能选择是在输入框内显示，还是在输入框顶部以徽章显示。',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -773,6 +773,8 @@ export type TranslationKeys = {
       yoloBaseDir?: string
       yoloBaseDirDesc?: string
       yoloBaseDirPlaceholder?: string
+      storeDataInVault?: string
+      storeDataInVaultDesc?: string
       mentionDisplayMode?: string
       mentionDisplayModeDesc?: string
       mentionDisplayModeInline?: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -1917,19 +1917,15 @@ export default class SmartComposerPlugin extends Plugin {
   }
 
   async loadSettings() {
-    const pluginData = await this.loadData()
-    // First pass: parse the plugin-directory data to learn the YOLO base dir
-    // so we can look for a vault-stored mirror at `{baseDir}/.yolo_data.json`.
-    const pluginParsedSettings = parseSmartComposerSettings(pluginData)
-
-    // If the vault mirror exists, it is the authoritative source. This lets
-    // Obsidian Sync propagate settings across devices even when the local
-    // plugin-dir copy is stale.
-    const vaultData = await readVaultDataJson(this.app, pluginParsedSettings)
+    // The vault-stored mirror lives at a fixed vault-root path and does not
+    // depend on `yolo.baseDir`. If it exists, it is the authoritative source
+    // so Obsidian Sync can propagate settings across devices even when the
+    // local plugin-dir copy is stale.
+    const vaultData = await readVaultDataJson(this.app)
     const usedVaultSource = vaultData !== null
-    const parsedSettings = usedVaultSource
-      ? parseSmartComposerSettings(vaultData)
-      : pluginParsedSettings
+    const parsedSettings = parseSmartComposerSettings(
+      usedVaultSource ? vaultData : await this.loadData(),
+    )
 
     const settingsWithDefaultAssistant =
       ensureDefaultAssistantInSettings(parsedSettings)
@@ -1956,15 +1952,22 @@ export default class SmartComposerPlugin extends Plugin {
       )
     }
 
-    if (JSON.stringify(parsedSettings) !== JSON.stringify(normalizedSettings)) {
-      await this.saveData(normalizedSettings)
-    } else if (usedVaultSource) {
-      // Keep the plugin-directory copy in sync with what we actually loaded
-      // so subsequent boots find the same baseDir/flag without reading vault.
+    const normalizationChanged =
+      JSON.stringify(parsedSettings) !== JSON.stringify(normalizedSettings)
+
+    // Persist to plugin-dir when: normalization changed anything, OR vault
+    // was authoritative (so the local copy gets refreshed and subsequent
+    // boots are consistent even without reading the mirror).
+    if (normalizationChanged || usedVaultSource) {
       await this.saveData(normalizedSettings)
     }
 
-    if (normalizedSettings.experimental?.storeDataInVault) {
+    // Persist to vault mirror only when there is something new to write:
+    // normalization changed content, or the mirror didn't exist yet.
+    if (
+      normalizedSettings.experimental?.storeDataInVault &&
+      (normalizationChanged || !usedVaultSource)
+    ) {
       await writeVaultDataJson(this.app, normalizedSettings, normalizedSettings)
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,12 @@ import { McpCoordinator } from './core/mcp/mcpCoordinator'
 import type { McpManager } from './core/mcp/mcpManager'
 import { AgentNotificationCoordinator } from './core/notifications/agentNotificationCoordinator'
 import { NotificationService } from './core/notifications/notificationService'
-import { relocateYoloManagedData } from './core/paths/yoloManagedData'
+import {
+  readVaultDataJson,
+  relocateYoloManagedData,
+  removeVaultDataJson,
+  writeVaultDataJson,
+} from './core/paths/yoloManagedData'
 import { RagAutoUpdateService } from './core/rag/ragAutoUpdateService'
 import { RagCoordinator } from './core/rag/ragCoordinator'
 import type { RAGEngine } from './core/rag/ragEngine'
@@ -1912,7 +1917,20 @@ export default class SmartComposerPlugin extends Plugin {
   }
 
   async loadSettings() {
-    const parsedSettings = parseSmartComposerSettings(await this.loadData())
+    const pluginData = await this.loadData()
+    // First pass: parse the plugin-directory data to learn the YOLO base dir
+    // so we can look for a vault-stored mirror at `{baseDir}/.yolo_data.json`.
+    const pluginParsedSettings = parseSmartComposerSettings(pluginData)
+
+    // If the vault mirror exists, it is the authoritative source. This lets
+    // Obsidian Sync propagate settings across devices even when the local
+    // plugin-dir copy is stale.
+    const vaultData = await readVaultDataJson(this.app, pluginParsedSettings)
+    const usedVaultSource = vaultData !== null
+    const parsedSettings = usedVaultSource
+      ? parseSmartComposerSettings(vaultData)
+      : pluginParsedSettings
+
     const settingsWithDefaultAssistant =
       ensureDefaultAssistantInSettings(parsedSettings)
     const { chatModels, changed } = applyKnownMaxContextTokensToChatModels(
@@ -1940,6 +1958,14 @@ export default class SmartComposerPlugin extends Plugin {
 
     if (JSON.stringify(parsedSettings) !== JSON.stringify(normalizedSettings)) {
       await this.saveData(normalizedSettings)
+    } else if (usedVaultSource) {
+      // Keep the plugin-directory copy in sync with what we actually loaded
+      // so subsequent boots find the same baseDir/flag without reading vault.
+      await this.saveData(normalizedSettings)
+    }
+
+    if (normalizedSettings.experimental?.storeDataInVault) {
+      await writeVaultDataJson(this.app, normalizedSettings, normalizedSettings)
     }
   }
 
@@ -1959,6 +1985,10 @@ ${validationResult.error.issues.map((v) => v.message).join('\n')}`)
     const previousSettings = this.settings
     const yoloBaseDirChanged =
       previousSettings?.yolo?.baseDir !== normalizedSettings.yolo.baseDir
+    const previousStoreDataInVault =
+      previousSettings?.experimental?.storeDataInVault ?? false
+    const nextStoreDataInVault =
+      normalizedSettings.experimental?.storeDataInVault ?? false
 
     if (yoloBaseDirChanged) {
       if (this.dbManager) {
@@ -1984,6 +2014,14 @@ ${validationResult.error.issues.map((v) => v.message).join('\n')}`)
 
     this.settings = normalizedSettings
     await this.saveData(normalizedSettings)
+
+    if (nextStoreDataInVault) {
+      await writeVaultDataJson(this.app, normalizedSettings, normalizedSettings)
+    } else if (previousStoreDataInVault) {
+      // Flag turned off: clean up the vault mirror so future loads use the
+      // plugin-directory copy exclusively.
+      await removeVaultDataJson(this.app, normalizedSettings)
+    }
     this.syncOAuthRuntimesFromSettings(normalizedSettings)
     this.ragCoordinator?.updateSettings(normalizedSettings)
 

--- a/src/settings/schema/migrations/45_to_46.ts
+++ b/src/settings/schema/migrations/45_to_46.ts
@@ -1,0 +1,19 @@
+import type { SettingMigration } from '../setting.types'
+
+export const migrateFrom45To46: SettingMigration['migrate'] = (data) => {
+  const existingExperimental =
+    data.experimental && typeof data.experimental === 'object'
+      ? (data.experimental as Record<string, unknown>)
+      : {}
+  return {
+    ...data,
+    experimental: {
+      ...existingExperimental,
+      storeDataInVault:
+        typeof existingExperimental.storeDataInVault === 'boolean'
+          ? existingExperimental.storeDataInVault
+          : false,
+    },
+    version: 46,
+  }
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -39,6 +39,7 @@ import { migrateFrom41To42 } from './41_to_42'
 import { migrateFrom42To43 } from './42_to_43'
 import { migrateFrom43To44 } from './43_to_44'
 import { migrateFrom44To45 } from './44_to_45'
+import { migrateFrom45To46 } from './45_to_46'
 import { migrateFrom4To5 } from './4_to_5'
 import { migrateFrom5To6 } from './5_to_6'
 import { migrateFrom6To7 } from './6_to_7'
@@ -46,7 +47,7 @@ import { migrateFrom7To8 } from './7_to_8'
 import { migrateFrom8To9 } from './8_to_9'
 import { migrateFrom9To10 } from './9_to_10'
 
-export const SETTINGS_SCHEMA_VERSION = 45
+export const SETTINGS_SCHEMA_VERSION = 46
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -273,5 +274,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 44,
     toVersion: 45,
     migrate: migrateFrom44To45,
+  },
+  {
+    fromVersion: 45,
+    toVersion: 46,
+    migrate: migrateFrom45To46,
   },
 ]

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -304,6 +304,17 @@ export const smartComposerSettingsSchema = z.object({
       baseDir: 'YOLO',
     }),
 
+  // Experimental options
+  experimental: z
+    .object({
+      // When true, mirror the plugin's data.json into the vault under
+      // `{yolo.baseDir}/.yolo_data.json` so it can be synced by Obsidian Sync.
+      storeDataInVault: z.boolean().catch(false),
+    })
+    .catch({
+      storeDataInVault: false,
+    }),
+
   debug: z
     .object({
       logModelRequestContext: z.boolean().optional(),


### PR DESCRIPTION
当开启 settings.experimental.storeDataInVault 时，会把 data.json 的完整内容额外写入 {yolo.baseDir}/.yolo_data.json。启动时如果检测到该文件会优先使用 vault 版本，从而让其他设备在同步之后自动生效。关闭开关或改变 baseDir 时会自动搬家或清理。

https://claude.ai/code/session_01WJeaXb2D4Fq3rzWvwubixw