### PR TITLE
拖拽 Obsidian 笔记到输入框现在会作为 @ 文件提及插入，而不是粘贴一段 obsidian:// 原始链接

### DIFF
--- a/src/components/chat-view/chat-input/LexicalContentEditable.tsx
+++ b/src/components/chat-view/chat-input/LexicalContentEditable.tsx
@@ -24,6 +24,7 @@ import {
   fuzzySearchFolders,
 } from '../../../utils/fuzzy-search'
 
+import ObsidianFileDropPlugin from './plugins/drop/ObsidianFileDropPlugin'
 import DragDropPaste from './plugins/image/DragDropPastePlugin'
 import ImagePastePlugin from './plugins/image/ImagePastePlugin'
 import AutoLinkMentionPlugin from './plugins/mention/AutoLinkMentionPlugin'
@@ -266,6 +267,7 @@ export default function LexicalContentEditable({
       <NoFormatPlugin />
       <AutoLinkMentionPlugin />
       <ImagePastePlugin onCreateImageMentionables={onCreateImageMentionables} />
+      <ObsidianFileDropPlugin />
       <DragDropPaste onCreateImageMentionables={onCreateImageMentionables} />
       {/* templates feature removed */}
     </LexicalComposer>

--- a/src/components/chat-view/chat-input/plugins/drop/ObsidianFileDropPlugin.tsx
+++ b/src/components/chat-view/chat-input/plugins/drop/ObsidianFileDropPlugin.tsx
@@ -1,0 +1,170 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import {
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_HIGH,
+  DROP_COMMAND,
+} from 'lexical'
+import { TFile } from 'obsidian'
+import { useEffect } from 'react'
+
+import { useApp } from '../../../../../contexts/app-context'
+import { Mentionable } from '../../../../../types/mentionable'
+import {
+  getMentionableName,
+  serializeMentionable,
+} from '../../../../../utils/chat/mentionable'
+import { $createMentionNode } from '../mention/MentionNode'
+
+const OBSIDIAN_OPEN_PREFIX = 'obsidian://open?'
+
+type ParsedObsidianLink = {
+  vault: string | null
+  file: string
+}
+
+function parseObsidianOpenUrl(raw: string): ParsedObsidianLink | null {
+  const trimmed = raw.trim()
+  if (!trimmed.startsWith(OBSIDIAN_OPEN_PREFIX)) {
+    return null
+  }
+  try {
+    const url = new URL(trimmed)
+    const file = url.searchParams.get('file')
+    if (!file) {
+      return null
+    }
+    return {
+      vault: url.searchParams.get('vault'),
+      file,
+    }
+  } catch {
+    return null
+  }
+}
+
+function extractCandidateUrls(dataTransfer: DataTransfer): string[] {
+  const uriList = dataTransfer.getData('text/uri-list')
+  if (uriList) {
+    const lines = uriList
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith('#'))
+    if (lines.length > 0) {
+      return lines
+    }
+  }
+
+  const plain = dataTransfer.getData('text/plain')
+  if (plain) {
+    return plain
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+  }
+
+  return []
+}
+
+export default function ObsidianFileDropPlugin(): null {
+  const [editor] = useLexicalComposerContext()
+  const app = useApp()
+
+  useEffect(() => {
+    return editor.registerCommand<DragEvent>(
+      DROP_COMMAND,
+      (event) => {
+        const dataTransfer = event.dataTransfer
+        if (!dataTransfer) {
+          return false
+        }
+
+        // If actual files are present, defer to the existing image DragDropPaste flow.
+        if (dataTransfer.files && dataTransfer.files.length > 0) {
+          return false
+        }
+
+        const candidates = extractCandidateUrls(dataTransfer)
+        if (candidates.length === 0) {
+          return false
+        }
+
+        const currentVaultName = app.vault.getName()
+        const resolvedFiles: TFile[] = []
+        const seenPaths = new Set<string>()
+
+        for (const candidate of candidates) {
+          const parsed = parseObsidianOpenUrl(candidate)
+          if (!parsed) {
+            continue
+          }
+          if (parsed.vault && parsed.vault !== currentVaultName) {
+            continue
+          }
+
+          const linkpath = parsed.file
+          let file: TFile | null =
+            app.metadataCache.getFirstLinkpathDest(linkpath, '') ?? null
+
+          if (!file) {
+            const direct = app.vault.getAbstractFileByPath(linkpath)
+            if (direct instanceof TFile) {
+              file = direct
+            }
+          }
+          if (!file) {
+            const withMd = app.vault.getAbstractFileByPath(`${linkpath}.md`)
+            if (withMd instanceof TFile) {
+              file = withMd
+            }
+          }
+
+          if (file && !seenPaths.has(file.path)) {
+            seenPaths.add(file.path)
+            resolvedFiles.push(file)
+          }
+        }
+
+        if (resolvedFiles.length === 0) {
+          return false
+        }
+
+        event.preventDefault()
+        event.stopPropagation()
+
+        editor.update(() => {
+          const selection = $getSelection()
+          if (!$isRangeSelection(selection)) {
+            $getRoot().selectEnd()
+          }
+
+          const activeSelection = $getSelection()
+          if (!$isRangeSelection(activeSelection)) {
+            return
+          }
+
+          const nodesToInsert = []
+          for (const file of resolvedFiles) {
+            const mentionable: Mentionable = { type: 'file', file }
+            nodesToInsert.push(
+              $createMentionNode(
+                getMentionableName(mentionable),
+                serializeMentionable(mentionable),
+              ),
+            )
+            nodesToInsert.push($createTextNode(' '))
+          }
+
+          activeSelection.insertNodes(nodesToInsert)
+        })
+
+        return true
+      },
+      COMMAND_PRIORITY_HIGH,
+    )
+  }, [app, editor])
+
+  return null
+}

--- a/src/components/chat-view/chat-input/plugins/drop/ObsidianFileDropPlugin.tsx
+++ b/src/components/chat-view/chat-input/plugins/drop/ObsidianFileDropPlugin.tsx
@@ -1,9 +1,13 @@
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import {
+  $createRangeSelection,
   $createTextNode,
+  $getNearestNodeFromDOMNode,
   $getRoot,
   $getSelection,
   $isRangeSelection,
+  $isTextNode,
+  $setSelection,
   COMMAND_PRIORITY_HIGH,
   DROP_COMMAND,
 } from 'lexical'
@@ -134,10 +138,47 @@ export default function ObsidianFileDropPlugin(): null {
         event.preventDefault()
         event.stopPropagation()
 
+        // Capture drop coordinates before the update so we can position the
+        // cursor at the actual drop point rather than the old caret position.
+        const dropX = event.clientX
+        const dropY = event.clientY
+
         editor.update(() => {
-          const selection = $getSelection()
-          if (!$isRangeSelection(selection)) {
-            $getRoot().selectEnd()
+          let selectionPositioned = false
+
+          const domRange =
+            typeof document.caretRangeFromPoint === 'function'
+              ? document.caretRangeFromPoint(dropX, dropY)
+              : null
+
+          if (domRange !== null) {
+            try {
+              const domNode = domRange.startContainer
+              const domOffset = domRange.startOffset
+              const lexicalNode = $getNearestNodeFromDOMNode(domNode)
+              if (lexicalNode !== null) {
+                const newSel = $createRangeSelection()
+                const key = lexicalNode.getKey()
+                if ($isTextNode(lexicalNode)) {
+                  newSel.anchor.set(key, domOffset, 'text')
+                  newSel.focus.set(key, domOffset, 'text')
+                } else {
+                  newSel.anchor.set(key, 0, 'element')
+                  newSel.focus.set(key, 0, 'element')
+                }
+                $setSelection(newSel)
+                selectionPositioned = true
+              }
+            } catch {
+              // fall through to default positioning
+            }
+          }
+
+          if (!selectionPositioned) {
+            const sel = $getSelection()
+            if (!$isRangeSelection(sel)) {
+              $getRoot().selectEnd()
+            }
           }
 
           const activeSelection = $getSelection()


### PR DESCRIPTION
新增 ObsidianFileDropPlugin 拦截 Lexical 的 DROP_COMMAND：解析 dataTransfer 中的 obsidian://open URL，
定位到当前 vault 内对应的 TFile，并在光标处插入文件 MentionNode。现有的 MentionNode 变更监听会自动把
文件加入当前消息的 mentionables，与从 @ 菜单选中一个文件的效果一致。图片等真正带 File 对象的拖拽仍
走原有 DragDropPaste 流程，vault 外的普通链接不受影响。