### PR TITLE
修复 Kimi K2.5/K2-thinking 多轮工具调用因缺失 reasoning_content 报 400 的问题

### DIFF
--- a/src/core/llm/kimiMessageAdapter.test.ts
+++ b/src/core/llm/kimiMessageAdapter.test.ts
@@ -22,7 +22,7 @@ class TestKimiMessageAdapter extends KimiMessageAdapter {
 describe('KimiMessageAdapter', () => {
   const adapter = new TestKimiMessageAdapter()
 
-  it('fills empty assistant tool-call content with a space', () => {
+  it('fills empty assistant tool-call content with a space and injects empty reasoning_content', () => {
     const params = adapter.buildParams({
       model: 'kimi-k2.5',
       stream: false,
@@ -62,8 +62,68 @@ describe('KimiMessageAdapter', () => {
             },
           },
         ],
+        reasoning_content: '',
       },
     ])
+  })
+
+  it('preserves existing reasoning on assistant tool-call messages', () => {
+    const params = adapter.buildParams({
+      model: 'kimi-k2.5',
+      stream: false,
+      messages: [
+        {
+          role: 'assistant',
+          content: 'calling tool',
+          reasoning: 'decided to read the file',
+          tool_calls: [
+            {
+              id: 'call-1',
+              name: 'read_file',
+              arguments: createCompleteToolCallArguments({ value: {} }),
+            },
+          ],
+        },
+      ],
+    }) as unknown as {
+      messages: Array<{
+        role: string
+        content: string
+        tool_calls?: Array<unknown>
+        reasoning_content?: string
+      }>
+    }
+
+    expect(params.messages[0]).toMatchObject({
+      role: 'assistant',
+      content: 'calling tool',
+      reasoning_content: 'decided to read the file',
+    })
+  })
+
+  it('does not inject reasoning_content on plain assistant messages without tool calls', () => {
+    const params = adapter.buildParams({
+      model: 'kimi-k2.5',
+      stream: false,
+      messages: [
+        {
+          role: 'assistant',
+          content: 'hello',
+        },
+      ],
+    }) as unknown as {
+      messages: Array<{
+        role: string
+        content: string
+        reasoning_content?: string
+      }>
+    }
+
+    expect(params.messages[0]).toEqual({
+      role: 'assistant',
+      content: 'hello',
+    })
+    expect(params.messages[0].reasoning_content).toBeUndefined()
   })
 
   it('maps assistant reasoning to reasoning_content', () => {

--- a/src/core/llm/kimiMessageAdapter.ts
+++ b/src/core/llm/kimiMessageAdapter.ts
@@ -20,9 +20,11 @@ export class KimiMessageAdapter extends OpenAIMessageAdapter {
       return parsed
     }
 
+    const hasToolCalls =
+      Array.isArray(parsed.tool_calls) && parsed.tool_calls.length > 0
+
     if (
-      Array.isArray(parsed.tool_calls) &&
-      parsed.tool_calls.length > 0 &&
+      hasToolCalls &&
       typeof parsed.content === 'string' &&
       parsed.content.length === 0
     ) {
@@ -32,6 +34,11 @@ export class KimiMessageAdapter extends OpenAIMessageAdapter {
 
     if (typeof message.reasoning === 'string' && message.reasoning.length > 0) {
       parsed.reasoning_content = message.reasoning
+    } else if (hasToolCalls) {
+      // Kimi thinking models (k2-thinking / k2.5) require reasoning_content on
+      // every assistant tool-call message for cross-turn reasoning continuity.
+      // Fall back to empty string for legacy history that never captured it.
+      parsed.reasoning_content = ''
     }
 
     return parsed


### PR DESCRIPTION
Moonshot API 在启用思考模式时强校验：带 tool_calls 的 assistant 历史消息
必须携带 reasoning_content 字段（官方文档要求用于跨轮推理连续性）。历史
会话里未捕获 reasoning 的消息会触发 400 invalid_request_error。

对此在适配器层兜底：当 assistant 消息带 tool_calls 但没有 reasoning 时，
注入空字符串 reasoning_content 以满足校验；正常有 reasoning 的消息仍按
原逻辑真实透传，保证推理连续性不受影响。