### PR TITLE
将 Chat 输入区图片按钮替换为统一的添加文件按钮，同时支持图片与 PDF

### DIFF
--- a/src/components/chat-view/chat-input/ChatUserInput.tsx
+++ b/src/components/chat-view/chat-input/ChatUserInput.tsx
@@ -36,6 +36,7 @@ import { ChatModel } from '../../../types/chat-model.types'
 import {
   Mentionable,
   MentionableImage,
+  MentionablePDF,
   SerializedMentionable,
 } from '../../../types/mentionable'
 import { getDisplayOnlyCurrentFileMentionables } from '../../../utils/chat/currentFileMentionable'
@@ -46,9 +47,10 @@ import {
   serializeMentionable,
 } from '../../../utils/chat/mentionable'
 import { fileToMentionableImage } from '../../../utils/llm/image'
+import { fileToMentionablePDF } from '../../../utils/llm/pdf'
 
 import ChatSkillBadge from './ChatSkillBadge'
-import { ImageUploadButton } from './ImageUploadButton'
+import { FileUploadButton } from './FileUploadButton'
 import LexicalContentEditable from './LexicalContentEditable'
 import MentionableBadge from './MentionableBadge'
 import { ModelSelect } from './ModelSelect'
@@ -858,6 +860,127 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
       [mentionableUnitLabel, mentionables, setMentionables],
     )
 
+    const handleCreatePdfMentionables = useCallback(
+      (mentionablePdfs: MentionablePDF[]) => {
+        const newMentionablePdfs = mentionablePdfs.filter(
+          (m) =>
+            !mentionables.some(
+              (mentionable) =>
+                getMentionableKey(serializeMentionable(mentionable)) ===
+                getMentionableKey(serializeMentionable(m)),
+            ),
+        )
+        if (newMentionablePdfs.length === 0) return
+        const editor = editorRef.current
+        if (editor) {
+          editor.update(() => {
+            const nodesToInsert: LexicalNode[] = []
+            newMentionablePdfs.forEach((mentionable) => {
+              nodesToInsert.push(
+                $createMentionNode(
+                  getMentionableName(mentionable, {
+                    unitLabel: mentionableUnitLabel,
+                  }),
+                  serializeMentionable(mentionable),
+                ),
+              )
+              nodesToInsert.push($createTextNode(' '))
+            })
+            const selection = $getSelection()
+            if (selection && $isRangeSelection(selection)) {
+              selection.insertNodes(nodesToInsert)
+              return
+            }
+
+            const root = $getRoot()
+            let paragraphNode = root.getFirstChild()
+            if (!paragraphNode || !$isParagraphNode(paragraphNode)) {
+              const created = $createParagraphNode()
+              root.append(created)
+              paragraphNode = created
+            }
+            const paragraph = paragraphNode as ParagraphNode
+            nodesToInsert.forEach((node) => {
+              paragraph.append(node)
+            })
+          })
+        }
+        setMentionables([...mentionables, ...newMentionablePdfs])
+      },
+      [mentionableUnitLabel, mentionables, setMentionables],
+    )
+
+    const handleUploadFiles = useCallback(
+      (files: File[]) => {
+        const imageFiles: File[] = []
+        const pdfFiles: File[] = []
+        const unsupported: File[] = []
+        for (const file of files) {
+          if (file.type.startsWith('image/')) {
+            imageFiles.push(file)
+          } else if (
+            file.type === 'application/pdf' ||
+            file.name.toLowerCase().endsWith('.pdf')
+          ) {
+            pdfFiles.push(file)
+          } else {
+            unsupported.push(file)
+          }
+        }
+        if (unsupported.length > 0) {
+          new Notice(
+            `Unsupported file type: ${unsupported.map((f) => f.name).join(', ')}`,
+          )
+        }
+        if (imageFiles.length > 0) {
+          void Promise.all(
+            imageFiles.map((file) => fileToMentionableImage(file)),
+          )
+            .then((mentionableImages) => {
+              handleCreateImageMentionables(mentionableImages)
+            })
+            .catch((error) => {
+              console.error('Failed to process uploaded images', error)
+              new Notice('Failed to process uploaded images')
+            })
+        }
+        if (pdfFiles.length > 0) {
+          void Promise.allSettled(
+            pdfFiles.map((file) => fileToMentionablePDF(file)),
+          ).then((results) => {
+            const successes: MentionablePDF[] = []
+            results.forEach((result, idx) => {
+              if (result.status === 'fulfilled') {
+                successes.push(result.value)
+              } else {
+                const name = pdfFiles[idx]?.name ?? 'PDF'
+                console.error(`Failed to extract PDF ${name}`, result.reason)
+                new Notice(
+                  `Failed to read PDF "${name}": ${
+                    result.reason instanceof Error
+                      ? result.reason.message
+                      : 'unknown error'
+                  }`,
+                )
+              }
+            })
+            if (successes.length > 0) {
+              handleCreatePdfMentionables(successes)
+              const truncated = successes.filter((p) => p.truncated)
+              if (truncated.length > 0) {
+                new Notice(
+                  `Some PDFs were truncated to the first pages: ${truncated
+                    .map((p) => p.name)
+                    .join(', ')}`,
+                )
+              }
+            }
+          })
+        }
+      },
+      [handleCreateImageMentionables, handleCreatePdfMentionables],
+    )
+
     const handleSelectMentionableForBadge = useCallback(
       (mentionable: Mentionable) => {
         if (mentionDisplayMode !== 'badge') return
@@ -1282,6 +1405,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
           {!compact && (
             <div className="smtcmp-chat-user-input-controls">
               <div className="smtcmp-chat-user-input-controls__left">
+                <FileUploadButton onUpload={handleUploadFiles} />
                 <ModelSelect
                   modelId={modelId}
                   onChange={onModelChange}
@@ -1302,22 +1426,6 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
                 )}
               </div>
               <div className="smtcmp-chat-user-input-controls__right">
-                <ImageUploadButton
-                  onUpload={(files) => {
-                    void Promise.all(
-                      files.map((file) => fileToMentionableImage(file)),
-                    )
-                      .then((mentionableImages) => {
-                        handleCreateImageMentionables(mentionableImages)
-                      })
-                      .catch((error) => {
-                        console.error(
-                          'Failed to process uploaded images',
-                          error,
-                        )
-                      })
-                  }}
-                />
                 <SubmitButton onClick={() => handleSubmit()} />
               </div>
             </div>

--- a/src/components/chat-view/chat-input/FileUploadButton.tsx
+++ b/src/components/chat-view/chat-input/FileUploadButton.tsx
@@ -1,14 +1,15 @@
-import { ImageIcon } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import type { ChangeEvent } from 'react'
 
 import { useLanguage } from '../../../contexts/language-context'
 
-export function ImageUploadButton({
+export function FileUploadButton({
   onUpload,
 }: {
   onUpload: (files: File[]) => void
 }) {
   const { t } = useLanguage()
+  const label = t('chat.uploadFile', '添加文件')
 
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? [])
@@ -19,19 +20,20 @@ export function ImageUploadButton({
   }
 
   return (
-    <label className="smtcmp-chat-user-input-submit-button">
+    <label
+      className="smtcmp-chat-user-input-submit-button smtcmp-chat-user-input-upload-button"
+      title={label}
+      aria-label={label}
+    >
       <input
         type="file"
-        accept="image/*"
+        accept="image/*,application/pdf"
         multiple
         onChange={handleFileChange}
         hidden
       />
       <div className="smtcmp-chat-user-input-submit-button-icons">
-        <ImageIcon size={12} />
-      </div>
-      <div className="smtcmp-chat-user-input-submit-button-label">
-        {t('chat.uploadImage', '上传图片')}
+        <Plus size={14} />
       </div>
     </label>
   )

--- a/src/components/chat-view/chat-input/MentionableBadge.tsx
+++ b/src/components/chat-view/chat-input/MentionableBadge.tsx
@@ -13,6 +13,7 @@ import {
   MentionableFolder,
   MentionableImage,
   MentionableModel,
+  MentionablePDF,
   MentionableUrl,
 } from '../../../types/mentionable'
 import { getBlockMentionableCountInfo } from '../../../utils/chat/mentionable'
@@ -368,6 +369,42 @@ function ImageBadge({
   )
 }
 
+function PdfBadge({
+  mentionable,
+  onDelete,
+  onClick,
+  isFocused,
+  showDeleteButton,
+}: {
+  mentionable: MentionablePDF
+  onDelete: () => void
+  onClick: () => void
+  isFocused: boolean
+  showDeleteButton?: boolean
+}) {
+  const Icon = getMentionableIcon(mentionable)
+  return (
+    <BadgeBase
+      onDelete={onDelete}
+      onClick={onClick}
+      isFocused={isFocused}
+      showExpandButton={false}
+      showDeleteButton={showDeleteButton}
+      title={mentionable.name}
+    >
+      <div className="smtcmp-chat-user-input-file-badge-name">
+        {Icon && (
+          <Icon
+            size={12}
+            className="smtcmp-chat-user-input-file-badge-name-icon"
+          />
+        )}
+        <span>{mentionable.name}</span>
+      </div>
+    </BadgeBase>
+  )
+}
+
 function ModelBadge({
   mentionable,
   onDelete,
@@ -496,6 +533,16 @@ export default function MentionableBadge({
           isFocused={isFocused}
           isExpanded={isExpanded}
           onToggleExpand={onToggleExpand}
+          showDeleteButton={showDeleteButton}
+        />
+      )
+    case 'pdf':
+      return (
+        <PdfBadge
+          mentionable={mentionable}
+          onDelete={onDelete}
+          onClick={onClick}
+          isFocused={isFocused}
           showDeleteButton={showDeleteButton}
         />
       )

--- a/src/components/chat-view/chat-input/utils/get-metionable-icon.ts
+++ b/src/components/chat-view/chat-input/utils/get-metionable-icon.ts
@@ -26,6 +26,8 @@ export const getMentionableIcon = (mentionable: Mentionable) => {
       return LinkIcon
     case 'image':
       return ImageIcon
+    case 'pdf':
+      return FileText
     case 'model':
       return Cpu
     default:

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1073,6 +1073,7 @@ export const en: TranslationKeys = {
     stopGeneration: 'Stop generation',
     selectModel: 'Select model',
     uploadImage: 'Upload image',
+    uploadFile: 'Add file',
     addContext: 'Add context',
     applyChanges: 'Apply changes',
     copyMessage: 'Copy message',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1058,6 +1058,7 @@ export const it: TranslationKeys = {
     stopGeneration: 'Ferma generazione',
     selectModel: 'Seleziona modello',
     uploadImage: 'Carica immagine',
+    uploadFile: 'Aggiungi file',
     addContext: 'Aggiungi contesto',
     applyChanges: 'Applica modifiche',
     copyMessage: 'Copia messaggio',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -1006,6 +1006,7 @@ export const zh: TranslationKeys = {
     stopGeneration: '停止生成',
     selectModel: '选择模型',
     uploadImage: '上传图片',
+    uploadFile: '添加文件',
     addContext: '添加上下文',
     applyChanges: '应用更改',
     copyMessage: '复制消息',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -918,6 +918,7 @@ export type TranslationKeys = {
     stopGeneration?: string
     selectModel: string
     uploadImage: string
+    uploadFile?: string
     addContext: string
     applyChanges: string
     copyMessage: string

--- a/src/styles/chat/input.css
+++ b/src/styles/chat/input.css
@@ -2071,6 +2071,22 @@
   white-space: nowrap;
 }
 
+.smtcmp-chat-user-input-controls__left .smtcmp-chat-user-input-upload-button {
+  width: var(--size-4-5);
+  height: var(--size-4-5);
+  padding: 0;
+  gap: 0;
+  border-radius: var(--radius-s);
+  flex: 0 0 auto;
+  justify-content: center;
+  color: var(--text-muted);
+
+  &:hover {
+    color: var(--text-normal);
+    background: var(--background-modifier-hover);
+  }
+}
+
 .smtcmp-chat-input-model-select__label {
   min-width: 0;
   flex: 1 1 auto;

--- a/src/types/mentionable.ts
+++ b/src/types/mentionable.ts
@@ -44,6 +44,13 @@ export type MentionableImage = {
   mimeType: string
   data: string // base64
 }
+export type MentionablePDF = {
+  type: 'pdf'
+  name: string
+  data: string // extracted plain text (pages joined)
+  pageCount?: number
+  truncated?: boolean
+}
 export type MentionableModel = {
   type: 'model'
   modelId: string
@@ -58,6 +65,7 @@ export type Mentionable =
   | MentionableAssistantQuote
   | MentionableUrl
   | MentionableImage
+  | MentionablePDF
   | MentionableModel
 export type SerializedMentionableFile = {
   type: 'file'
@@ -93,6 +101,7 @@ export type SerializedMentionableAssistantQuote = {
 }
 export type SerializedMentionableUrl = MentionableUrl
 export type SerializedMentionableImage = MentionableImage
+export type SerializedMentionablePDF = MentionablePDF
 export type SerializedMentionableModel = MentionableModel
 export type SerializedMentionable =
   | SerializedMentionableFile
@@ -102,4 +111,5 @@ export type SerializedMentionable =
   | SerializedMentionableAssistantQuote
   | SerializedMentionableUrl
   | SerializedMentionableImage
+  | SerializedMentionablePDF
   | SerializedMentionableModel

--- a/src/utils/chat/exportConversation.ts
+++ b/src/utils/chat/exportConversation.ts
@@ -135,6 +135,9 @@ function mentionablesToMarkdownLines(
       case 'image':
         lines.push(`Image: ${m.name}`)
         break
+      case 'pdf':
+        lines.push(`PDF: ${m.name}`)
+        break
       case 'model':
         lines.push(`Model: ${m.name}`)
         break

--- a/src/utils/chat/mentionable.ts
+++ b/src/utils/chat/mentionable.ts
@@ -66,6 +66,14 @@ export const serializeMentionable = (
         mimeType: mentionable.mimeType,
         data: mentionable.data,
       }
+    case 'pdf':
+      return {
+        type: 'pdf',
+        name: mentionable.name,
+        data: mentionable.data,
+        pageCount: mentionable.pageCount,
+        truncated: mentionable.truncated,
+      }
     case 'model':
       return {
         type: 'model',
@@ -187,6 +195,18 @@ export const deserializeMentionable = (
           data: mentionable.data,
         }
       }
+      case 'pdf': {
+        if (typeof mentionable.data !== 'string') {
+          return null
+        }
+        return {
+          type: 'pdf',
+          name: mentionable.name,
+          data: mentionable.data,
+          pageCount: mentionable.pageCount,
+          truncated: mentionable.truncated,
+        }
+      }
       case 'model': {
         return {
           type: 'model',
@@ -218,6 +238,8 @@ export function getMentionableKey(mentionable: SerializedMentionable): string {
       return `url:${mentionable.url}`
     case 'image':
       return `image:${mentionable.name}:${mentionable.data.length}:${mentionable.data.slice(-32)}`
+    case 'pdf':
+      return `pdf:${mentionable.name}:${mentionable.data.length}:${mentionable.data.slice(-32)}`
     case 'model':
       return `model:${mentionable.modelId}`
   }
@@ -317,6 +339,8 @@ export function getMentionableName(
     case 'url':
       return mentionable.url
     case 'image':
+      return mentionable.name
+    case 'pdf':
       return mentionable.name
     case 'model':
       return mentionable.name

--- a/src/utils/chat/requestContextBuilder.ts
+++ b/src/utils/chat/requestContextBuilder.ts
@@ -35,6 +35,7 @@ import type {
   MentionableFile,
   MentionableFolder,
   MentionableImage,
+  MentionablePDF,
   MentionableUrl,
 } from '../../types/mentionable'
 import type { ToolCallRequest } from '../../types/tool-call.types'
@@ -477,17 +478,21 @@ export class RequestContextBuilder {
     const assistantQuotes = message.mentionables.filter(
       (m): m is MentionableAssistantQuote => m.type === 'assistant-quote',
     )
+    const pdfs = message.mentionables.filter(
+      (m): m is MentionablePDF => m.type === 'pdf',
+    )
     const blockPrompt = blocks
       .map(({ file, content }) => {
         return `\`\`\`${file.path}\n${content}\n\`\`\`\n`
       })
       .join('')
     const assistantQuotePrompt = this.buildAssistantQuotePrompt(assistantQuotes)
+    const pdfPrompt = this.buildPdfPrompt(pdfs)
 
     const selectedSkillsPrompt = await this.buildSelectedSkillsPrompt(
       message.selectedSkills,
     )
-    const textContent = `${blockPrompt}${assistantQuotePrompt}${selectedSkillsPrompt}\n\n${query}\n\n`
+    const textContent = `${blockPrompt}${assistantQuotePrompt}${pdfPrompt}${selectedSkillsPrompt}\n\n${query}\n\n`
     if (imageParts.length === 0) {
       return textContent
     }
@@ -767,6 +772,9 @@ ${message.annotations
       const assistantQuotes = message.mentionables.filter(
         (m): m is MentionableAssistantQuote => m.type === 'assistant-quote',
       )
+      const pdfs = message.mentionables.filter(
+        (m): m is MentionablePDF => m.type === 'pdf',
+      )
       const blockPrompt = blocks
         .map(({ file, content }) => {
           return `\`\`\`${file.path}\n${content}\n\`\`\`\n`
@@ -774,6 +782,7 @@ ${message.annotations
         .join('')
       const assistantQuotePrompt =
         this.buildAssistantQuotePrompt(assistantQuotes)
+      const pdfPrompt = this.buildPdfPrompt(pdfs)
 
       const urls = message.mentionables.filter(
         (m): m is MentionableUrl => m.type === 'url',
@@ -820,7 +829,7 @@ ${await this.getWebsiteContent(url)}
           ),
           {
             type: 'text',
-            text: `${filePrompt}${blockPrompt}${assistantQuotePrompt}${urlPrompt}${selectedSkillsPrompt}\n\n${query}\n\n`,
+            text: `${filePrompt}${blockPrompt}${assistantQuotePrompt}${pdfPrompt}${urlPrompt}${selectedSkillsPrompt}\n\n${query}\n\n`,
           },
         ],
       }
@@ -846,6 +855,24 @@ ${quotes
     ({ conversationId, messageId, content }) =>
       `<assistant_quote conversationId="${conversationId}" messageId="${messageId}">\n${content}\n</assistant_quote>`,
   )
+  .join('\n\n')}\n\n`
+  }
+
+  private buildPdfPrompt(pdfs: MentionablePDF[]): string {
+    if (pdfs.length === 0) {
+      return ''
+    }
+    return `## Attached PDFs
+${pdfs
+  .map(({ name, data, pageCount, truncated }) => {
+    const meta =
+      pageCount !== undefined
+        ? ` (${pageCount} pages${truncated ? ', truncated' : ''})`
+        : truncated
+          ? ' (truncated)'
+          : ''
+    return `### ${name}${meta}\n\n${data}`
+  })
   .join('\n\n')}\n\n`
   }
 

--- a/src/utils/llm/pdf.ts
+++ b/src/utils/llm/pdf.ts
@@ -1,0 +1,127 @@
+import { MentionablePDF } from '../../types/mentionable'
+import { createYieldController } from '../common/yield-to-main'
+
+/** Hard cap for uploaded PDF size at the chat input. */
+export const PDF_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
+
+/** Hard cap for uploaded PDF page count. */
+export const PDF_UPLOAD_MAX_PAGES = 500
+
+type PdfTextItem = {
+  str: string
+  transform: number[]
+  hasEOL?: boolean
+}
+
+function pageItemsToText(items: unknown[]): string {
+  const textItems = items.filter(
+    (item): item is PdfTextItem =>
+      typeof item === 'object' &&
+      item !== null &&
+      'str' in item &&
+      typeof (item as PdfTextItem).str === 'string' &&
+      'transform' in item &&
+      Array.isArray((item as PdfTextItem).transform) &&
+      (item as PdfTextItem).transform.length >= 6,
+  )
+
+  if (textItems.length === 0) {
+    return ''
+  }
+
+  const positioned = textItems.map((item) => ({
+    str: item.str,
+    x: item.transform[4] ?? 0,
+    y: item.transform[5] ?? 0,
+    hasEOL: item.hasEOL === true,
+  }))
+
+  positioned.sort((a, b) => {
+    if (b.y !== a.y) {
+      return b.y - a.y
+    }
+    return a.x - b.x
+  })
+
+  const yThreshold = 4
+  const lines: string[][] = []
+  let currentLine: typeof positioned = []
+  let lastY: number | null = null
+
+  const flushLine = () => {
+    if (currentLine.length === 0) {
+      return
+    }
+    currentLine.sort((a, b) => a.x - b.x)
+    lines.push(currentLine.map((p) => p.str))
+    currentLine = []
+  }
+
+  for (const item of positioned) {
+    if (item.hasEOL) {
+      currentLine.push(item)
+      flushLine()
+      lastY = null
+      continue
+    }
+    if (lastY !== null && Math.abs(item.y - lastY) > yThreshold) {
+      flushLine()
+    }
+    currentLine.push(item)
+    lastY = item.y
+  }
+  flushLine()
+
+  return lines.map((parts) => parts.join(' ').trim()).join('\n')
+}
+
+export async function fileToMentionablePDF(
+  file: File,
+  options: { maxBinaryBytes?: number; maxPages?: number } = {},
+): Promise<MentionablePDF> {
+  const maxBinaryBytes = options.maxBinaryBytes ?? PDF_UPLOAD_MAX_BYTES
+  const maxPages = options.maxPages ?? PDF_UPLOAD_MAX_PAGES
+
+  if (file.size > maxBinaryBytes) {
+    throw new Error(
+      `PDF too large (${file.size} bytes). Limit is ${maxBinaryBytes} bytes.`,
+    )
+  }
+
+  const buf = await file.arrayBuffer()
+  const maybeYield = createYieldController(1)
+
+  await import('pdfjs-dist/build/pdf.worker.mjs')
+  const pdfjs = await import('pdfjs-dist')
+
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(buf),
+    useWorkerFetch: false,
+    isEvalSupported: false,
+  })
+
+  const pdf = await loadingTask.promise
+  const totalPages = pdf.numPages
+  const numPages = Math.min(totalPages, maxPages)
+  const pageTexts: string[] = []
+
+  for (let i = 1; i <= numPages; i++) {
+    await maybeYield()
+    const page = await pdf.getPage(i)
+    const textContent = await page.getTextContent()
+    pageTexts.push(pageItemsToText(textContent.items as unknown[]))
+  }
+
+  const truncated = totalPages > maxPages
+  const data = pageTexts
+    .map((text, idx) => `--- Page ${idx + 1} ---\n${text}`)
+    .join('\n\n')
+
+  return {
+    type: 'pdf',
+    name: file.name,
+    data,
+    pageCount: totalPages,
+    truncated,
+  }
+}

--- a/src/utils/llm/pdf.ts
+++ b/src/utils/llm/pdf.ts
@@ -1,79 +1,12 @@
 import { MentionablePDF } from '../../types/mentionable'
 import { createYieldController } from '../common/yield-to-main'
+import { loadPdfPages } from '../pdf/pdfPages'
 
 /** Hard cap for uploaded PDF size at the chat input. */
 export const PDF_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
 
 /** Hard cap for uploaded PDF page count. */
 export const PDF_UPLOAD_MAX_PAGES = 500
-
-type PdfTextItem = {
-  str: string
-  transform: number[]
-  hasEOL?: boolean
-}
-
-function pageItemsToText(items: unknown[]): string {
-  const textItems = items.filter(
-    (item): item is PdfTextItem =>
-      typeof item === 'object' &&
-      item !== null &&
-      'str' in item &&
-      typeof (item as PdfTextItem).str === 'string' &&
-      'transform' in item &&
-      Array.isArray((item as PdfTextItem).transform) &&
-      (item as PdfTextItem).transform.length >= 6,
-  )
-
-  if (textItems.length === 0) {
-    return ''
-  }
-
-  const positioned = textItems.map((item) => ({
-    str: item.str,
-    x: item.transform[4] ?? 0,
-    y: item.transform[5] ?? 0,
-    hasEOL: item.hasEOL === true,
-  }))
-
-  positioned.sort((a, b) => {
-    if (b.y !== a.y) {
-      return b.y - a.y
-    }
-    return a.x - b.x
-  })
-
-  const yThreshold = 4
-  const lines: string[][] = []
-  let currentLine: typeof positioned = []
-  let lastY: number | null = null
-
-  const flushLine = () => {
-    if (currentLine.length === 0) {
-      return
-    }
-    currentLine.sort((a, b) => a.x - b.x)
-    lines.push(currentLine.map((p) => p.str))
-    currentLine = []
-  }
-
-  for (const item of positioned) {
-    if (item.hasEOL) {
-      currentLine.push(item)
-      flushLine()
-      lastY = null
-      continue
-    }
-    if (lastY !== null && Math.abs(item.y - lastY) > yThreshold) {
-      flushLine()
-    }
-    currentLine.push(item)
-    lastY = item.y
-  }
-  flushLine()
-
-  return lines.map((parts) => parts.join(' ').trim()).join('\n')
-}
 
 export async function fileToMentionablePDF(
   file: File,
@@ -91,30 +24,13 @@ export async function fileToMentionablePDF(
   const buf = await file.arrayBuffer()
   const maybeYield = createYieldController(1)
 
-  await import('pdfjs-dist/build/pdf.worker.mjs')
-  const pdfjs = await import('pdfjs-dist')
-
-  const loadingTask = pdfjs.getDocument({
-    data: new Uint8Array(buf),
-    useWorkerFetch: false,
-    isEvalSupported: false,
+  const { totalPages, pages } = await loadPdfPages(new Uint8Array(buf), {
+    maxPages,
+    maybeYield,
   })
 
-  const pdf = await loadingTask.promise
-  const totalPages = pdf.numPages
-  const numPages = Math.min(totalPages, maxPages)
-  const pageTexts: string[] = []
-
-  for (let i = 1; i <= numPages; i++) {
-    await maybeYield()
-    const page = await pdf.getPage(i)
-    const textContent = await page.getTextContent()
-    pageTexts.push(pageItemsToText(textContent.items as unknown[]))
-  }
-
-  const truncated = totalPages > maxPages
-  const data = pageTexts
-    .map((text, idx) => `--- Page ${idx + 1} ---\n${text}`)
+  const data = pages
+    .map(({ page, text }) => `--- Page ${page} ---\n${text}`)
     .join('\n\n')
 
   return {
@@ -122,6 +38,6 @@ export async function fileToMentionablePDF(
     name: file.name,
     data,
     pageCount: totalPages,
-    truncated,
+    truncated: totalPages > maxPages,
   }
 }

--- a/src/utils/pdf/extractPdfText.ts
+++ b/src/utils/pdf/extractPdfText.ts
@@ -7,6 +7,8 @@ import {
 } from '../../database/json/chat/pdfTextCacheStore'
 import { createYieldController } from '../common/yield-to-main'
 
+import { loadPdfPages } from './pdfPages'
+
 /** Hard cap for vault PDF indexing (binary size). */
 export const PDF_INDEX_MAX_BYTES = 50 * 1024 * 1024
 
@@ -17,74 +19,6 @@ type YoloSettingsLike = {
   yolo?: {
     baseDir?: string
   }
-}
-
-type PdfTextItem = {
-  str: string
-  transform: number[]
-  hasEOL?: boolean
-}
-
-function pageItemsToText(items: unknown[]): string {
-  const textItems = items.filter(
-    (item): item is PdfTextItem =>
-      typeof item === 'object' &&
-      item !== null &&
-      'str' in item &&
-      typeof (item as PdfTextItem).str === 'string' &&
-      'transform' in item &&
-      Array.isArray((item as PdfTextItem).transform) &&
-      (item as PdfTextItem).transform.length >= 6,
-  )
-
-  if (textItems.length === 0) {
-    return ''
-  }
-
-  const positioned = textItems.map((item) => ({
-    str: item.str,
-    x: item.transform[4] ?? 0,
-    y: item.transform[5] ?? 0,
-    hasEOL: item.hasEOL === true,
-  }))
-
-  positioned.sort((a, b) => {
-    if (b.y !== a.y) {
-      return b.y - a.y
-    }
-    return a.x - b.x
-  })
-
-  const yThreshold = 4
-  const lines: string[][] = []
-  let currentLine: typeof positioned = []
-  let lastY: number | null = null
-
-  const flushLine = () => {
-    if (currentLine.length === 0) {
-      return
-    }
-    currentLine.sort((a, b) => a.x - b.x)
-    lines.push(currentLine.map((p) => p.str))
-    currentLine = []
-  }
-
-  for (const item of positioned) {
-    if (item.hasEOL) {
-      currentLine.push(item)
-      flushLine()
-      lastY = null
-      continue
-    }
-    if (lastY !== null && Math.abs(item.y - lastY) > yThreshold) {
-      flushLine()
-    }
-    currentLine.push(item)
-    lastY = item.y
-  }
-  flushLine()
-
-  return lines.map((parts) => parts.join(' ').trim()).join('\n')
 }
 
 export type ExtractPdfTextOptions = {
@@ -100,12 +34,6 @@ export type ExtractPdfTextOptions = {
   settings?: YoloSettingsLike | null
 }
 
-/**
- * Lazy-loads pdfjs-dist. Preloads the official worker entry so it registers
- * `globalThis.pdfjsWorker.WorkerMessageHandler`; PDF.js then uses the in-thread
- * fake worker and does not require `GlobalWorkerOptions.workerSrc` or a separate
- * `pdf.worker.mjs` on disk (fits single-file `main.js` releases).
- */
 export async function extractPdfText(
   app: App,
   file: TFile,
@@ -136,33 +64,15 @@ export async function extractPdfText(
   const buf = await app.vault.readBinary(file)
   const maybeYield = createYieldController(1)
 
-  await import('pdfjs-dist/build/pdf.worker.mjs')
-  const pdfjs = await import('pdfjs-dist')
-
-  const loadingTask = pdfjs.getDocument({
-    data: new Uint8Array(buf),
-    useWorkerFetch: false,
-    isEvalSupported: false,
+  const { totalPages, pages } = await loadPdfPages(new Uint8Array(buf), {
+    maxPages,
+    maybeYield,
+    signal: options.signal,
   })
 
-  const pdf = await loadingTask.promise
-  const numPages = Math.min(pdf.numPages, maxPages)
-  const pages: { page: number; text: string }[] = []
-
-  for (let i = 1; i <= numPages; i++) {
-    if (options.signal?.aborted) {
-      throw new DOMException('PDF extraction aborted', 'AbortError')
-    }
-    await maybeYield()
-    const page = await pdf.getPage(i)
-    const textContent = await page.getTextContent()
-    const text = pageItemsToText(textContent.items as unknown[])
-    pages.push({ page: i, text })
-  }
-
-  if (pdf.numPages > maxPages) {
+  if (totalPages > maxPages) {
     console.warn(
-      `[YOLO] PDF ${file.path} has ${pdf.numPages} pages; only first ${maxPages} were extracted.`,
+      `[YOLO] PDF ${file.path} has ${totalPages} pages; only first ${maxPages} were extracted.`,
     )
   }
 

--- a/src/utils/pdf/pdfPages.ts
+++ b/src/utils/pdf/pdfPages.ts
@@ -1,0 +1,121 @@
+type PdfTextItem = {
+  str: string
+  transform: number[]
+  hasEOL?: boolean
+}
+
+export function pageItemsToText(items: unknown[]): string {
+  const textItems = items.filter(
+    (item): item is PdfTextItem =>
+      typeof item === 'object' &&
+      item !== null &&
+      'str' in item &&
+      typeof (item as PdfTextItem).str === 'string' &&
+      'transform' in item &&
+      Array.isArray((item as PdfTextItem).transform) &&
+      (item as PdfTextItem).transform.length >= 6,
+  )
+
+  if (textItems.length === 0) {
+    return ''
+  }
+
+  const positioned = textItems.map((item) => ({
+    str: item.str,
+    x: item.transform[4] ?? 0,
+    y: item.transform[5] ?? 0,
+    hasEOL: item.hasEOL === true,
+  }))
+
+  positioned.sort((a, b) => {
+    if (b.y !== a.y) {
+      return b.y - a.y
+    }
+    return a.x - b.x
+  })
+
+  const yThreshold = 4
+  const lines: string[][] = []
+  let currentLine: typeof positioned = []
+  let lastY: number | null = null
+
+  const flushLine = () => {
+    if (currentLine.length === 0) {
+      return
+    }
+    currentLine.sort((a, b) => a.x - b.x)
+    lines.push(currentLine.map((p) => p.str))
+    currentLine = []
+  }
+
+  for (const item of positioned) {
+    if (item.hasEOL) {
+      currentLine.push(item)
+      flushLine()
+      lastY = null
+      continue
+    }
+    if (lastY !== null && Math.abs(item.y - lastY) > yThreshold) {
+      flushLine()
+    }
+    currentLine.push(item)
+    lastY = item.y
+  }
+  flushLine()
+
+  return lines.map((parts) => parts.join(' ').trim()).join('\n')
+}
+
+export type LoadPdfPagesOptions = {
+  maxPages: number
+  maybeYield?: () => Promise<void>
+  signal?: AbortSignal
+}
+
+export type LoadedPdfPages = {
+  totalPages: number
+  pages: { page: number; text: string }[]
+}
+
+/**
+ * Lazy-loads pdfjs-dist and extracts plain text page-by-page. Preloads the
+ * official worker entry so PDF.js uses its in-thread fake worker (no separate
+ * `pdf.worker.mjs` on disk required for single-file `main.js` releases).
+ */
+export async function loadPdfPages(
+  data: Uint8Array,
+  options: LoadPdfPagesOptions,
+): Promise<LoadedPdfPages> {
+  const { maxPages, maybeYield, signal } = options
+
+  await import('pdfjs-dist/build/pdf.worker.mjs')
+  const pdfjs = await import('pdfjs-dist')
+
+  const loadingTask = pdfjs.getDocument({
+    data,
+    useWorkerFetch: false,
+    isEvalSupported: false,
+  })
+
+  const pdf = await loadingTask.promise
+  const totalPages = pdf.numPages
+  const limit = Math.min(totalPages, maxPages)
+  const pages: { page: number; text: string }[] = []
+
+  for (let i = 1; i <= limit; i++) {
+    if (signal?.aborted) {
+      throw new DOMException('PDF extraction aborted', 'AbortError')
+    }
+    if (maybeYield) {
+      await maybeYield()
+    }
+    const page = await pdf.getPage(i)
+    const textContent = await page.getTextContent()
+    pages.push({
+      page: i,
+      text: pageItemsToText(textContent.items as unknown[]),
+    })
+  }
+
+  return { totalPages, pages }
+}

--- a/styles.css
+++ b/styles.css
@@ -6924,6 +6924,22 @@
   white-space: nowrap;
 }
 
+.smtcmp-chat-user-input-controls__left .smtcmp-chat-user-input-upload-button {
+  width: var(--size-4-5);
+  height: var(--size-4-5);
+  padding: 0;
+  gap: 0;
+  border-radius: var(--radius-s);
+  flex: 0 0 auto;
+  justify-content: center;
+  color: var(--text-muted);
+
+  &:hover {
+    color: var(--text-normal);
+    background: var(--background-modifier-hover);
+  }
+}
+
 .smtcmp-chat-input-model-select__label {
   min-width: 0;
   flex: 1 1 auto;


### PR DESCRIPTION
- 新增 MentionablePDF 类型：上传时用 pdfjs 提取纯文本内联，对所有模型通用
- FileUploadButton 仅图标，放在输入框下方控件行左端，移除 SubmitButton 左侧的冗余图片按钮
- requestContextBuilder 将 PDF 文本以 ## Attached PDFs 段拼入 user message

https://claude.ai/code/session_011uDfmTbcFMxnYcH7bhecYs