### PR TITLE
修复带 NUL 字节的 PDF 建立 RAG 索引失败

### DIFF
--- a/src/database/modules/vector/VectorManager.ts
+++ b/src/database/modules/vector/VectorManager.ts
@@ -507,7 +507,7 @@ export class VectorManager {
 
     const chunks: DesiredChunk[] = []
     for (const { page: pageNum, text } of pages) {
-      const trimmed = text.trim()
+      const trimmed = text.split('\u0000').join('').trim()
       if (!trimmed) continue
       const lineCount = Math.max(1, trimmed.split('\n').length)
       if (trimmed.length <= PDF_PAGE_CHUNK_CHAR_THRESHOLD) {


### PR DESCRIPTION
## Summary
- PDF 索引路径 chunkifyPdf 之前未对 pdfjs 提取的页面文本做 NUL（U+0000）清理，与 Markdown 路径不一致
- 部分文本层包含 NUL 的 PDF 会触发 VectorManager 的 null-byte 检查并中断整个 RAG 索引
- 修复：每页文本进入 splitter 前执行与 Markdown 一致的 NUL 清理

Closes #263

## Test plan
- [ ] 用 issue 中描述的带 NUL 文本层的 PDF 重建 RAG 索引，不再报 Chunk content contains null bytes
- [ ] 普通 PDF 索引行为不变