### PR TITLE
修复远程 HTTP MCP Streamable HTTP 初始化后超时（#252）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-yolo",
-  "version": "1.5.5.2",
+  "version": "1.5.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-yolo",
-      "version": "1.5.5.2",
+      "version": "1.5.6.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
@@ -58,6 +58,7 @@
         "react-virtuoso": "^4.18.4",
         "remark-gfm": "^4.0.0",
         "shell-env": "^4.0.1",
+        "undici": "6.25.0",
         "uuid": "^10.0.0",
         "vscode-diff": "^2.1.1",
         "zod": "^3.23.8"
@@ -15503,6 +15504,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "react-virtuoso": "^4.18.4",
     "remark-gfm": "^4.0.0",
     "shell-env": "^4.0.1",
+    "undici": "6.25.0",
     "uuid": "^10.0.0",
     "vscode-diff": "^2.1.1",
     "zod": "^3.23.8"

--- a/src/core/mcp/desktopMcpFetch.test.ts
+++ b/src/core/mcp/desktopMcpFetch.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for the proxy resolution + SOCKS fail-fast contract of
+ * `createDesktopMcpFetch`. Verifies parity with the legacy
+ * `createProxyAgent` semantics in `remoteTransport.ts`.
+ */
+import { Platform } from 'obsidian'
+
+jest.mock('obsidian', () => ({
+  Platform: { isDesktop: true },
+}))
+
+type FetchArgs = [input: unknown, init?: { dispatcher?: unknown }]
+const undiciFetchMock = jest.fn(
+  async (..._args: FetchArgs) => new Response('ok'),
+)
+const proxyAgentCtor = jest.fn()
+
+jest.mock(
+  'undici',
+  () => ({
+    fetch: (...args: FetchArgs) => undiciFetchMock(...args),
+    ProxyAgent: function (this: { uri: string }, uri: string) {
+      this.uri = uri
+      proxyAgentCtor(uri)
+    },
+  }),
+  { virtual: true },
+)
+
+const getProxyForUrlMock = jest.fn<string, [string]>()
+
+jest.mock('proxy-from-env', () => ({
+  getProxyForUrl: (url: string) => getProxyForUrlMock(url),
+}))
+
+const resolveSystemProxyMock = jest.fn<Promise<string>, [string]>()
+
+jest.mock('../../utils/net/systemProxyResolver', () => ({
+  resolveSystemProxy: (url: string) => resolveSystemProxyMock(url),
+}))
+
+import { createDesktopMcpFetch } from './desktopMcpFetch'
+
+const PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'ALL_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'all_proxy',
+  'no_proxy',
+] as const
+
+const stripProxyEnv = () => {
+  const saved: Record<string, string | undefined> = {}
+  for (const key of PROXY_ENV_KEYS) {
+    saved[key] = process.env[key]
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- iterating a fixed allowlist of proxy env keys to isolate test state
+    delete process.env[key]
+  }
+  return () => {
+    for (const key of PROXY_ENV_KEYS) {
+      const v = saved[key]
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- restoring the same fixed allowlist of proxy env keys
+      if (v === undefined) delete process.env[key]
+      else process.env[key] = v
+    }
+  }
+}
+
+describe('desktopMcpFetch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    undiciFetchMock.mockResolvedValue(new Response('ok'))
+    resolveSystemProxyMock.mockResolvedValue('')
+    getProxyForUrlMock.mockReturnValue('')
+  })
+
+  it('throws on non-desktop platforms without touching undici / proxy mocks', async () => {
+    ;(Platform as { isDesktop: boolean }).isDesktop = false
+    try {
+      const fetchFn = createDesktopMcpFetch({ env: {} })
+      await expect(fetchFn('https://example.com')).rejects.toThrow(
+        /only available on desktop/,
+      )
+      // Mobile-safety contract: the platform check must precede any lazy
+      // import / proxy resolution work. None of the network-side mocks
+      // should fire on this code path.
+      expect(undiciFetchMock).not.toHaveBeenCalled()
+      expect(proxyAgentCtor).not.toHaveBeenCalled()
+      expect(resolveSystemProxyMock).not.toHaveBeenCalled()
+      expect(getProxyForUrlMock).not.toHaveBeenCalled()
+    } finally {
+      ;(Platform as { isDesktop: boolean }).isDesktop = true
+    }
+  })
+
+  it('fails fast when env resolves to socks5:// (env path, not just system proxy)', async () => {
+    const restore = stripProxyEnv()
+    getProxyForUrlMock.mockReturnValue('socks5://127.0.0.1:1080')
+
+    try {
+      const fetchFn = createDesktopMcpFetch({
+        env: { ALL_PROXY: 'socks5://127.0.0.1:1080' },
+      })
+      await expect(fetchFn('https://example.com/mcp')).rejects.toThrow(
+        /SOCKS proxy is not supported/i,
+      )
+      // Env path resolved the proxy; the request must short-circuit before
+      // touching undici.
+      expect(undiciFetchMock).not.toHaveBeenCalled()
+      expect(proxyAgentCtor).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  it('bypasses proxy for loopback / private destinations', async () => {
+    const restore = stripProxyEnv()
+    try {
+      const fetchFn = createDesktopMcpFetch({ env: {} })
+      await fetchFn('http://127.0.0.1:3005/mcp')
+
+      expect(proxyAgentCtor).not.toHaveBeenCalled()
+      expect(resolveSystemProxyMock).not.toHaveBeenCalled()
+      expect(undiciFetchMock).toHaveBeenCalledTimes(1)
+      const init = undiciFetchMock.mock.calls[0][1]
+      expect(init?.dispatcher).toBeUndefined()
+    } finally {
+      restore()
+    }
+  })
+
+  it('honors shell env proxy via temporary process.env swap (env parity)', async () => {
+    const restore = stripProxyEnv()
+    process.env.HTTPS_PROXY = 'http://process-only.local:3128'
+
+    // Implementation must swap process.env so getProxyForUrl observes the
+    // shell-supplied value, not the long-lived process value.
+    getProxyForUrlMock.mockImplementation(
+      () => process.env.HTTPS_PROXY ?? process.env.https_proxy ?? '',
+    )
+
+    try {
+      const fetchFn = createDesktopMcpFetch({
+        env: { HTTPS_PROXY: 'http://shell-proxy.local:8080' },
+      })
+      await fetchFn('https://example.com/mcp')
+
+      expect(proxyAgentCtor).toHaveBeenCalledWith(
+        'http://shell-proxy.local:8080',
+      )
+      // process.env restored after the swap.
+      expect(process.env.HTTPS_PROXY).toBe('http://process-only.local:3128')
+    } finally {
+      restore()
+    }
+  })
+
+  it('respects lowercase env keys and NO_PROXY (env parity)', async () => {
+    const restore = stripProxyEnv()
+    getProxyForUrlMock.mockImplementation((url) => {
+      // emulate proxy-from-env: NO_PROXY hits → ''
+      if (process.env.no_proxy && url.includes('skip.example.com')) return ''
+      return process.env.http_proxy ?? ''
+    })
+
+    try {
+      const fetchFn = createDesktopMcpFetch({
+        env: {
+          http_proxy: 'http://lower-case.local:3128',
+          no_proxy: 'skip.example.com',
+        },
+      })
+
+      await fetchFn('http://other.example.com/mcp')
+      expect(proxyAgentCtor).toHaveBeenCalledWith(
+        'http://lower-case.local:3128',
+      )
+
+      proxyAgentCtor.mockClear()
+      await fetchFn('http://skip.example.com/mcp')
+      expect(proxyAgentCtor).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  it('falls back to resolveSystemProxy when no env proxy is set', async () => {
+    const restore = stripProxyEnv()
+    resolveSystemProxyMock.mockResolvedValue('http://system-proxy.corp:8080')
+
+    try {
+      const fetchFn = createDesktopMcpFetch({ env: {} })
+      await fetchFn('https://corp.example.com/mcp')
+
+      expect(resolveSystemProxyMock).toHaveBeenCalledWith(
+        'https://corp.example.com/mcp',
+      )
+      expect(proxyAgentCtor).toHaveBeenCalledWith(
+        'http://system-proxy.corp:8080',
+      )
+    } finally {
+      restore()
+    }
+  })
+
+  it('caches ProxyAgent per proxy URI across requests', async () => {
+    const restore = stripProxyEnv()
+    resolveSystemProxyMock.mockResolvedValue('http://cached.corp:8080')
+
+    try {
+      const fetchFn = createDesktopMcpFetch({ env: {} })
+      await fetchFn('https://a.example.com')
+      await fetchFn('https://b.example.com')
+
+      expect(proxyAgentCtor).toHaveBeenCalledTimes(1)
+      expect(proxyAgentCtor).toHaveBeenCalledWith('http://cached.corp:8080')
+    } finally {
+      restore()
+    }
+  })
+
+  it('preserves resolveSystemProxy silent degrade (empty string → direct)', async () => {
+    const restore = stripProxyEnv()
+    resolveSystemProxyMock.mockResolvedValue('')
+
+    try {
+      const fetchFn = createDesktopMcpFetch({ env: {} })
+      await fetchFn('https://anywhere.example.com')
+
+      expect(proxyAgentCtor).not.toHaveBeenCalled()
+      const init = undiciFetchMock.mock.calls[0][1]
+      expect(init?.dispatcher).toBeUndefined()
+    } finally {
+      restore()
+    }
+  })
+
+  it('fails fast on socks5:// resolved proxy (no fallback)', async () => {
+    const restore = stripProxyEnv()
+    resolveSystemProxyMock.mockResolvedValue('socks5://127.0.0.1:1080')
+
+    try {
+      const fetchFn = createDesktopMcpFetch({ env: {} })
+      await expect(fetchFn('https://example.com/mcp')).rejects.toThrow(
+        /SOCKS proxy is not supported/i,
+      )
+
+      expect(undiciFetchMock).not.toHaveBeenCalled()
+      expect(proxyAgentCtor).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  it('fails fast on socks4:// resolved proxy', async () => {
+    const restore = stripProxyEnv()
+    resolveSystemProxyMock.mockResolvedValue('socks4://127.0.0.1:1080')
+
+    try {
+      const fetchFn = createDesktopMcpFetch({ env: {} })
+      await expect(fetchFn('https://example.com/mcp')).rejects.toThrow(
+        /SOCKS proxy is not supported/i,
+      )
+    } finally {
+      restore()
+    }
+  })
+})

--- a/src/core/mcp/desktopMcpFetch.ts
+++ b/src/core/mcp/desktopMcpFetch.ts
@@ -1,0 +1,164 @@
+/**
+ * MCP-only desktop fetch built on `undici` so that
+ * `StreamableHTTPClientTransport` receives a WHATWG `ReadableStream` body
+ * (with `pipeThrough`/`getReader`). `node-fetch@2` returns Node `Readable`,
+ * which silently breaks the SDK's SSE consumption — see issue #252.
+ *
+ * Scope is intentionally narrow: this fetch is **only** wired into
+ * `remoteTransport.ts`. The LLM SDK fetch in `core/llm/sdkFetch.ts` is left
+ * untouched.
+ */
+import { Platform } from 'obsidian'
+
+import { shouldBypassProxy } from '../../utils/net/proxyBypass'
+import { envHasProxy, withProcessEnv } from '../../utils/net/proxyEnv'
+import { resolveSystemProxy } from '../../utils/net/systemProxyResolver'
+
+// Lazy-loaded undici module (desktop-only). Mobile must never reach this path.
+type UndiciFetch = typeof globalThis.fetch
+// Opaque branded type — undici's `Dispatcher` shape is irrelevant to us; we
+// only ever pass it through to `fetch`'s `dispatcher` slot.
+type UndiciDispatcher = { readonly __undiciDispatcher: unique symbol }
+type UndiciModule = {
+  fetch: UndiciFetch
+  ProxyAgent: new (uri: string) => UndiciDispatcher
+}
+
+let undiciModulePromise: Promise<UndiciModule> | null = null
+
+const loadUndici = (): Promise<UndiciModule> => {
+  if (!undiciModulePromise) {
+    undiciModulePromise = import('undici').then(
+      (mod) =>
+        ({
+          fetch: mod.fetch as unknown as UndiciFetch,
+          ProxyAgent: mod.ProxyAgent as unknown as new (
+            uri: string,
+          ) => UndiciDispatcher,
+        }) satisfies UndiciModule,
+    )
+  }
+  return undiciModulePromise
+}
+
+type ProxyFromEnvModule = {
+  getProxyForUrl: (url: string) => string
+}
+
+let proxyFromEnvPromise: Promise<ProxyFromEnvModule> | null = null
+
+const loadProxyFromEnv = (): Promise<ProxyFromEnvModule> => {
+  if (!proxyFromEnvPromise) {
+    proxyFromEnvPromise = import('proxy-from-env').then(
+      (mod) => mod as ProxyFromEnvModule,
+    )
+  }
+  return proxyFromEnvPromise
+}
+
+const isSocksProxy = (uri: string): boolean =>
+  /^socks[45]?:\/\//i.test(uri.trim())
+
+class UnsupportedSocksProxyError extends Error {
+  readonly code = 'YOLO_MCP_SOCKS_UNSUPPORTED'
+  constructor(uri: string) {
+    super(
+      `SOCKS proxy is not supported by Streamable HTTP MCP transport (resolved proxy: ${uri}). ` +
+        `Please configure an HTTP/HTTPS proxy or add this MCP server's host to your bypass list.`,
+    )
+    this.name = 'UnsupportedSocksProxyError'
+  }
+}
+
+export type DesktopMcpFetchOptions = {
+  /**
+   * Shell environment merged from `shellEnvSync()` upstream. May legitimately
+   * carry HTTP(S)_PROXY values that are not in `process.env`, so the resolver
+   * temporarily swaps `process.env` for `proxy-from-env` to observe them.
+   */
+  env: Record<string, string>
+}
+
+/**
+ * Resolve a proxy URI for `targetUrl` using the same precedence as the
+ * legacy `createProxyAgent` in `remoteTransport.ts`:
+ *   1. Local/private destinations → DIRECT.
+ *   2. Explicit env proxy (`*_PROXY` / `NO_PROXY`, mixed case) → `proxy-from-env`.
+ *   3. Otherwise → Electron system proxy resolver.
+ *
+ * `resolveSystemProxy` intentionally degrades to `''` (DIRECT) on PAC
+ * `DIRECT` or Electron failures; that behavior is preserved.
+ */
+const resolveProxyUri = async (
+  targetUrl: string,
+  resolvedEnv: NodeJS.ProcessEnv,
+): Promise<string> => {
+  if (shouldBypassProxy(targetUrl)) return ''
+
+  if (envHasProxy(resolvedEnv)) {
+    const { getProxyForUrl } = await loadProxyFromEnv()
+    return withProcessEnv(resolvedEnv, () => getProxyForUrl(targetUrl))
+  }
+
+  return resolveSystemProxy(targetUrl)
+}
+
+/**
+ * Build the MCP-only desktop fetch. The factory is **synchronous** so the
+ * existing `McpRemoteTransportFactory` signature (and `mcpManager.ts`) stay
+ * untouched. The returned `fetch` is async and lazy-loads `undici` on first
+ * call, with a module-level promise cache.
+ */
+export const createDesktopMcpFetch = (
+  options: DesktopMcpFetchOptions,
+): typeof fetch => {
+  const resolvedEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...options.env,
+  }
+
+  // ProxyAgent cache keyed by proxy URI to avoid rebuilding per request.
+  const dispatcherCache = new Map<string, UndiciDispatcher>()
+
+  return async (input, init) => {
+    if (!Platform.isDesktop) {
+      throw new Error(
+        'MCP remote HTTP transport is only available on desktop Obsidian.',
+      )
+    }
+
+    const targetUrl =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+
+    const proxyUri = await resolveProxyUri(targetUrl, resolvedEnv)
+
+    if (proxyUri && isSocksProxy(proxyUri)) {
+      throw new UnsupportedSocksProxyError(proxyUri)
+    }
+
+    const { fetch: undiciFetch, ProxyAgent } = await loadUndici()
+
+    let dispatcher: UndiciDispatcher | undefined
+    if (proxyUri) {
+      const cached = dispatcherCache.get(proxyUri)
+      if (cached) {
+        dispatcher = cached
+      } else {
+        dispatcher = new ProxyAgent(proxyUri)
+        dispatcherCache.set(proxyUri, dispatcher)
+      }
+    }
+
+    // undici's fetch accepts `dispatcher` on RequestInit but the standard
+    // RequestInit type doesn't include it; cast at the boundary only.
+    const undiciInit = dispatcher
+      ? ({ ...(init ?? {}), dispatcher } as RequestInit)
+      : init
+
+    return undiciFetch(input, undiciInit)
+  }
+}

--- a/src/core/mcp/remoteTransport.test.ts
+++ b/src/core/mcp/remoteTransport.test.ts
@@ -1,55 +1,28 @@
-import { createDesktopNodeFetch } from '../llm/sdkFetch'
-
+import { createDesktopMcpFetch } from './desktopMcpFetch'
 import {
+  classifyRemoteTransportError,
   createMcpRemoteTransportError,
   createMcpRemoteTransportFactory,
   getMcpRemoteTransportContext,
   getMcpRemoteTransportDiagnostics,
 } from './remoteTransport'
 
-jest.mock('../llm/sdkFetch', () => ({
-  createDesktopNodeFetch: jest.fn(),
+// jest.mock is hoisted by ts-jest above imports, so order with imports is fine.
+jest.mock('./desktopMcpFetch', () => ({
+  createDesktopMcpFetch: jest.fn(),
 }))
-
-jest.mock('proxy-from-env', () => ({
-  getProxyForUrl: jest.fn(
-    () => process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY ?? '',
-  ),
-}))
-
-jest.mock('proxy-agent', () => ({
-  ProxyAgent: jest.fn().mockImplementation((options) => ({
-    options,
-  })),
-}))
-
-jest.mock('../../utils/net/systemProxyResolver', () => ({
-  resolveSystemProxy: jest.fn().mockResolvedValue(''),
-}))
-
-/** Must match `PROXY_ENV_KEYS` in `remoteTransport.ts` — any set value makes `envHasProxy` true. */
-const PROXY_ENV_KEYS = [
-  'HTTP_PROXY',
-  'HTTPS_PROXY',
-  'ALL_PROXY',
-  'NO_PROXY',
-  'http_proxy',
-  'https_proxy',
-  'all_proxy',
-  'no_proxy',
-] as const
 
 describe('remoteTransport', () => {
-  const mockedCreateDesktopNodeFetch =
-    createDesktopNodeFetch as jest.MockedFunction<typeof createDesktopNodeFetch>
+  const mockedCreateDesktopMcpFetch =
+    createDesktopMcpFetch as jest.MockedFunction<typeof createDesktopMcpFetch>
 
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  it('shares one Node fetch backend for MCP http and sse transports', () => {
+  it('shares one MCP fetch backend for http and sse transports', () => {
     const sharedFetch = jest.fn() as unknown as typeof fetch
-    mockedCreateDesktopNodeFetch.mockReturnValue(sharedFetch)
+    mockedCreateDesktopMcpFetch.mockReturnValue(sharedFetch)
 
     const factory = createMcpRemoteTransportFactory({ env: {} })
     const headers = { Authorization: 'Bearer token' }
@@ -65,7 +38,8 @@ describe('remoteTransport', () => {
       headers,
     })
 
-    expect(mockedCreateDesktopNodeFetch).toHaveBeenCalledTimes(1)
+    expect(mockedCreateDesktopMcpFetch).toHaveBeenCalledTimes(1)
+    expect(mockedCreateDesktopMcpFetch).toHaveBeenCalledWith({ env: {} })
     expect(httpOptions.fetch).toBe(sharedFetch)
     expect(sseOptions.fetch).toBe(sharedFetch)
     expect(httpOptions.requestInit).toEqual({ headers })
@@ -73,85 +47,77 @@ describe('remoteTransport', () => {
     expect(sseOptions.eventSourceInit).toEqual({ headers })
   })
 
-  it('resolves proxy configuration from provided shell env values', async () => {
-    mockedCreateDesktopNodeFetch.mockReturnValue(
+  it('forwards shell env into desktopMcpFetch', () => {
+    mockedCreateDesktopMcpFetch.mockReturnValue(
       jest.fn() as unknown as typeof fetch,
     )
 
-    const previousHttpsProxy = process.env.HTTPS_PROXY
-    process.env.HTTPS_PROXY = 'http://process-proxy.local:3128'
+    createMcpRemoteTransportFactory({
+      env: { HTTPS_PROXY: 'http://shell-proxy.local:8080' },
+    })
 
-    try {
-      createMcpRemoteTransportFactory({
-        env: {
-          HTTPS_PROXY: 'http://shell-proxy.local:8080',
-        },
-      })
-
-      const { ProxyAgent } = jest.requireMock('proxy-agent')
-      const proxyAgentOptions = ProxyAgent.mock.calls[0][0] as {
-        getProxyForUrl: (url: string) => string | Promise<string>
-      }
-
-      await expect(
-        Promise.resolve(
-          proxyAgentOptions.getProxyForUrl('https://example.com'),
-        ),
-      ).resolves.toBe('http://shell-proxy.local:8080')
-      expect(process.env.HTTPS_PROXY).toBe('http://process-proxy.local:3128')
-    } finally {
-      if (previousHttpsProxy === undefined) {
-        delete process.env.HTTPS_PROXY
-      } else {
-        process.env.HTTPS_PROXY = previousHttpsProxy
-      }
-    }
+    expect(mockedCreateDesktopMcpFetch).toHaveBeenCalledWith({
+      env: { HTTPS_PROXY: 'http://shell-proxy.local:8080' },
+    })
   })
 
-  it('falls back to resolveSystemProxy when no env proxy is present', async () => {
-    mockedCreateDesktopNodeFetch.mockReturnValue(
-      jest.fn() as unknown as typeof fetch,
+  it('classifies legacy node error codes', () => {
+    const econnrefused = Object.assign(new Error('connect ECONNREFUSED'), {
+      code: 'ECONNREFUSED',
+    })
+    expect(classifyRemoteTransportError(econnrefused)).toBe(
+      'network connection failed',
     )
 
-    const { resolveSystemProxy } = jest.requireMock(
-      '../../utils/net/systemProxyResolver',
+    const etimedout = Object.assign(new Error('socket hang up'), {
+      code: 'ETIMEDOUT',
+    })
+    expect(classifyRemoteTransportError(etimedout)).toBe('request timed out')
+  })
+
+  it('classifies undici error codes (issue #252)', () => {
+    const wrap = (code: string, msg = 'inner') => {
+      const outer = new TypeError('fetch failed')
+      ;(outer as unknown as { cause: unknown }).cause = Object.assign(
+        new Error(msg),
+        { code },
+      )
+      return outer
+    }
+
+    // Timeouts (all three undici timeout variants must collapse).
+    expect(classifyRemoteTransportError(wrap('UND_ERR_HEADERS_TIMEOUT'))).toBe(
+      'request timed out',
     )
-    resolveSystemProxy.mockResolvedValueOnce('http://system-proxy.corp:8080')
+    expect(classifyRemoteTransportError(wrap('UND_ERR_BODY_TIMEOUT'))).toBe(
+      'request timed out',
+    )
+    expect(classifyRemoteTransportError(wrap('UND_ERR_CONNECT_TIMEOUT'))).toBe(
+      'request timed out',
+    )
 
-    const previousProxyEnv: Partial<
-      Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>
-    > = {}
-    for (const key of PROXY_ENV_KEYS) {
-      previousProxyEnv[key] = process.env[key]
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- iterating a fixed allowlist of proxy env keys to isolate test state
-      delete process.env[key]
-    }
+    // Connection / socket family.
+    expect(classifyRemoteTransportError(wrap('UND_ERR_SOCKET'))).toBe(
+      'network connection failed',
+    )
+    expect(classifyRemoteTransportError(wrap('UND_ERR_CLOSED'))).toBe(
+      'network connection failed',
+    )
+    expect(classifyRemoteTransportError(wrap('UND_ERR_DESTROYED'))).toBe(
+      'network connection failed',
+    )
+  })
 
-    try {
-      createMcpRemoteTransportFactory({ env: {} })
-
-      const { ProxyAgent } = jest.requireMock('proxy-agent')
-      const proxyAgentOptions = ProxyAgent.mock.calls[0][0] as {
-        getProxyForUrl: (url: string) => string | Promise<string>
-      }
-
-      await expect(
-        Promise.resolve(
-          proxyAgentOptions.getProxyForUrl('https://example.com'),
-        ),
-      ).resolves.toBe('http://system-proxy.corp:8080')
-      expect(resolveSystemProxy).toHaveBeenCalledWith('https://example.com')
-    } finally {
-      for (const key of PROXY_ENV_KEYS) {
-        const value = previousProxyEnv[key]
-        if (value === undefined) {
-          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- restoring the same fixed allowlist of proxy env keys
-          delete process.env[key]
-        } else {
-          process.env[key] = value
-        }
-      }
-    }
+  it('classifies SOCKS fail-fast as proxy negotiation failed', () => {
+    const socksErr = Object.assign(
+      new Error(
+        'SOCKS proxy is not supported by Streamable HTTP MCP transport (resolved proxy: socks5://127.0.0.1:1080).',
+      ),
+      { code: 'YOLO_MCP_SOCKS_UNSUPPORTED' },
+    )
+    expect(classifyRemoteTransportError(socksErr)).toBe(
+      'proxy negotiation failed',
+    )
   })
 
   it('creates actionable diagnostics for remote transport failures', () => {
@@ -171,9 +137,7 @@ describe('remoteTransport', () => {
 
     const error = Object.assign(
       new Error('connect ECONNREFUSED 127.0.0.1:8080'),
-      {
-        code: 'ECONNREFUSED',
-      },
+      { code: 'ECONNREFUSED' },
     )
 
     const wrapped = createMcpRemoteTransportError({

--- a/src/core/mcp/remoteTransport.ts
+++ b/src/core/mcp/remoteTransport.ts
@@ -1,12 +1,9 @@
 import type { SSEClientTransportOptions } from '@modelcontextprotocol/sdk/client/sse.js'
 import type { StreamableHTTPClientTransportOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import { ProxyAgent } from 'proxy-agent'
-import { getProxyForUrl } from 'proxy-from-env'
 
 import type { McpServerParameters } from '../../types/mcp.types'
-import { shouldBypassProxy } from '../../utils/net/proxyBypass'
-import { resolveSystemProxy } from '../../utils/net/systemProxyResolver'
-import { createDesktopNodeFetch } from '../llm/sdkFetch'
+
+import { createDesktopMcpFetch } from './desktopMcpFetch'
 
 type McpRemoteTransportParameters = Extract<
   McpServerParameters,
@@ -44,7 +41,14 @@ const TLS_ERROR_CODES = new Set([
   'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
 ])
 
-const TIMEOUT_ERROR_CODES = new Set(['ETIMEDOUT', 'ESOCKETTIMEDOUT'])
+const TIMEOUT_ERROR_CODES = new Set([
+  'ETIMEDOUT',
+  'ESOCKETTIMEDOUT',
+  // undici timeout codes (see scripts spike for issue #252)
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+])
 
 const CONNECTION_ERROR_CODES = new Set([
   'EAI_AGAIN',
@@ -53,54 +57,11 @@ const CONNECTION_ERROR_CODES = new Set([
   'ENETUNREACH',
   'ENOTFOUND',
   'EHOSTUNREACH',
+  // undici socket/network errors
+  'UND_ERR_SOCKET',
+  'UND_ERR_CLOSED',
+  'UND_ERR_DESTROYED',
 ])
-
-const PROXY_ENV_KEYS = [
-  'HTTP_PROXY',
-  'HTTPS_PROXY',
-  'ALL_PROXY',
-  'NO_PROXY',
-  'http_proxy',
-  'https_proxy',
-  'all_proxy',
-  'no_proxy',
-] as const
-
-function envHasProxy(env: NodeJS.ProcessEnv): boolean {
-  return PROXY_ENV_KEYS.some(
-    (key) => typeof env[key] === 'string' && env[key]?.trim(),
-  )
-}
-
-function withProcessEnv<T>(env: NodeJS.ProcessEnv, cb: () => T): T {
-  const previousEnv = process.env
-  process.env = env
-  try {
-    return cb()
-  } finally {
-    process.env = previousEnv
-  }
-}
-
-function createProxyAgent(env: Record<string, string>): ProxyAgent {
-  // `env` is the merged shell env from shellEnvSync() — it may legitimately
-  // carry HTTP(S)_PROXY values that are not in process.env, so keep the
-  // env-swap for proxy-from-env to observe them.
-  const resolvedEnv: NodeJS.ProcessEnv = {
-    ...process.env,
-    ...env,
-  }
-
-  return new ProxyAgent({
-    getProxyForUrl: async (url) => {
-      if (shouldBypassProxy(url)) return ''
-      if (envHasProxy(resolvedEnv)) {
-        return withProcessEnv(resolvedEnv, () => getProxyForUrl(url))
-      }
-      return resolveSystemProxy(url)
-    },
-  })
-}
 
 function createRequestInit(
   headers?: Record<string, string>,
@@ -138,7 +99,7 @@ function getErrorCode(error: unknown): string | undefined {
   return undefined
 }
 
-function classifyRemoteTransportError(error: unknown): string {
+export function classifyRemoteTransportError(error: unknown): string {
   const code = getErrorCode(error)
   const message = getErrorMessage(error).toLowerCase()
 
@@ -235,8 +196,10 @@ export function createMcpRemoteTransportFactory({
 }: {
   env: Record<string, string>
 }): McpRemoteTransportFactory {
-  const proxyAgent = createProxyAgent(env)
-  const fetch = createDesktopNodeFetch({ agent: proxyAgent })
+  // Issue #252: switched from `node-fetch@2` to undici-backed fetch so the
+  // MCP SDK's `StreamableHTTPClientTransport` receives a WHATWG ReadableStream
+  // body (with `pipeThrough`/`getReader`) and can consume the SSE channel.
+  const fetch = createDesktopMcpFetch({ env })
 
   return {
     createHttpOptions: (params) => ({

--- a/src/utils/net/proxyEnv.ts
+++ b/src/utils/net/proxyEnv.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared helpers for honoring shell-supplied proxy env vars
+ * (`HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / `NO_PROXY`, mixed case).
+ *
+ * Two callers historically maintained their own copies:
+ * `core/llm/sdkFetch.ts` (LLM transport) and the legacy
+ * `core/mcp/remoteTransport.ts`. The MCP path now consumes this util via
+ * `core/mcp/desktopMcpFetch.ts`. The LLM copy is intentionally left in place
+ * (per the issue #252 plan: do not touch the LLM fetch link); future
+ * refactors may converge it onto this helper.
+ */
+
+export const PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'ALL_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'all_proxy',
+  'no_proxy',
+] as const
+
+export type ProxyEnvKey = (typeof PROXY_ENV_KEYS)[number]
+
+export const envHasProxy = (env: NodeJS.ProcessEnv): boolean =>
+  PROXY_ENV_KEYS.some((key) => typeof env[key] === 'string' && env[key]?.trim())
+
+/**
+ * Run `cb` with `process.env` temporarily replaced by `env`. Restores
+ * `process.env` afterwards.
+ *
+ * Callers MUST keep the callback synchronous: any `await` inside the swap
+ * window leaks the substituted env to other code paths in the same Node
+ * process.
+ */
+export const withProcessEnv = <T>(env: NodeJS.ProcessEnv, cb: () => T): T => {
+  const previousEnv = process.env
+  process.env = env
+  try {
+    return cb()
+  } finally {
+    process.env = previousEnv
+  }
+}


### PR DESCRIPTION
## Summary

- 新版 MCP SDK 的 `StreamableHTTPClientTransport` 用 `response.body.pipeThrough()` 消费 SSE，要求 WHATWG `ReadableStream`；`node-fetch@2` 的 body 是 Node `Readable`，导致 `POST /mcp` 拿到 `mcp-session-id` 后客户端无法继续 `GET /mcp`，连接静默挂死至 timeout。
- 仅替换 MCP 远程传输的 fetch：新增 `desktopMcpFetch`（基于 `undici 6.25.0`），保留 bypass / env / system-PAC 三段代理解析和 `process.env` swap 行为；SOCKS fail fast；undici 错误码纳入分类。
- LLM 链路 `sdkFetch.ts` 完全不动。

修复 issue #252。

## 关键改动

- `src/core/mcp/desktopMcpFetch.ts` (新): 同步工厂返回 async fetch，懒加载 undici，ProxyAgent 按 URI 缓存。
- `src/utils/net/proxyEnv.ts` (新): `PROXY_ENV_KEYS` / `envHasProxy` / `withProcessEnv` 共享 util，避免 drift。
- `src/core/mcp/remoteTransport.ts`: 接入新 fetch；`TIMEOUT_ERROR_CODES` / `CONNECTION_ERROR_CODES` 增补 `UND_ERR_*`；`classifyRemoteTransportError` 改 `export`。
- `package.json`: 新增 `undici: 6.25.0`（pin 版本，不带 caret）。

## Test plan

- [x] `npm run type:check`
- [x] `npm run lint:check`（本次新增/改动文件全过；main 上既有的 3 个 prettier warn 不在本次范围）
- [x] `npm test` — 123 suites / 714 tests 全绿，含新增 `desktopMcpFetch.test.ts`（10 cases，覆盖 mobile fail-fast / 代理矩阵 / SOCKS env+system 双路径 / ProxyAgent 缓存 / silent degrade-to-direct）和 `remoteTransport.test.ts`（6 个 undici 错误码全部 classify）。
- [x] `npm run build` — main.js 14MB → 15MB（+1MB，可接受）。
- [x] Spike 验证：本地 SSE server 用 `undici.fetch` + `response.body.pipeThrough(new TextDecoderStream())`，3 chunks 正确读出。
- [ ] 桌面 Obsidian 手测：复现 issue #252 场景（远程 HTTP MCP，含本地私网 IP），确认 init → tools/list → 调用工具全程通过。

## 不在本次范围

- 不替换 LLM 链路的 `node-fetch@2`（保持最小改动）。
- 不实现 SOCKS 支持（明确 fail fast，issue 报告人未使用）。
- 不 pin MCP SDK 版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)