### PR TITLE
feat: include quoted block content in conversation title generation

### DIFF
--- a/src/components/panels/quick-ask/QuickAskPanel.tsx
+++ b/src/components/panels/quick-ask/QuickAskPanel.tsx
@@ -955,9 +955,6 @@ export function QuickAskPanel({
         }
       })
 
-      // Create user message with all required fields
-      // Note: promptContent is set to null so that compileUserMessagePrompt will be called
-      // to properly process mentionables and include file contents
       const userMessage: ChatUserMessage = {
         role: 'user',
         content: editorState,
@@ -974,11 +971,49 @@ export function QuickAskPanel({
         userMessage,
       ]
       setChatMessages(newMessages)
+
+      // Set up the abort controller before any awaits so that abortStream()
+      // works while we're still compiling mentionables.
+      const abortController = new AbortController()
+      abortControllerRef.current = abortController
+      let unsubscribeRunner: (() => void) | null = null
+
+      // Compile mentionables into promptContent up front so the title model
+      // and the chat model see the same expanded context. Mirrors Chat.tsx.
+      let compiledMessages: ChatMessage[] = newMessages
+      try {
+        const { promptContent } =
+          await requestContextBuilder.compileUserMessagePrompt({
+            message: userMessage,
+          })
+        const compiledUserMessage: ChatUserMessage = {
+          ...userMessage,
+          promptContent,
+        }
+        compiledMessages = [
+          ...(options?.baseMessages ?? chatMessages),
+          compiledUserMessage,
+        ]
+      } catch (error) {
+        console.error('Failed to compile quick ask user message prompt', error)
+      }
+
+      if (abortController.signal.aborted) {
+        // Only clear shared state if we still own it — a follow-up submit may
+        // have already replaced the controller while we were compiling.
+        if (abortControllerRef.current === abortController) {
+          setIsStreaming(false)
+          setRunStatus(null)
+          abortControllerRef.current = null
+        }
+        return
+      }
+
       void (async () => {
         try {
           await createOrUpdateConversationImmediately(
             conversationId,
-            newMessages,
+            compiledMessages,
           )
         } catch (error) {
           console.error('Failed to save quick ask conversation', error)
@@ -986,7 +1021,7 @@ export function QuickAskPanel({
         }
 
         try {
-          await generateConversationTitle(conversationId, newMessages)
+          await generateConversationTitle(conversationId, compiledMessages)
         } catch (error) {
           console.error(
             'Failed to generate quick ask conversation title',
@@ -994,11 +1029,6 @@ export function QuickAskPanel({
           )
         }
       })()
-
-      // Create abort controller
-      const abortController = new AbortController()
-      abortControllerRef.current = abortController
-      let unsubscribeRunner: (() => void) | null = null
 
       try {
         const mcpManager = await getMcpManager()
@@ -1040,7 +1070,7 @@ export function QuickAskPanel({
           input: {
             providerClient,
             model: effectiveModel,
-            messages: newMessages,
+            messages: compiledMessages,
             conversationId,
             requestContextBuilder,
             mcpManager,

--- a/src/hooks/useChatHistory.ts
+++ b/src/hooks/useChatHistory.ts
@@ -21,15 +21,12 @@ import {
   ChatConversationCompactionState,
   ChatMessage,
   ChatSelectedSkill,
+  ChatUserMessage,
   SerializedChatMessage,
   normalizeChatConversationCompactionState,
 } from '../types/chat'
 import { ConversationOverrideSettings } from '../types/conversation-settings.types'
-import {
-  Mentionable,
-  MentionableAssistantQuote,
-  MentionableBlock,
-} from '../types/mentionable'
+import { Mentionable } from '../types/mentionable'
 import { ToolCallResponseStatus } from '../types/tool-call.types'
 import {
   deserializeMentionable,
@@ -45,21 +42,12 @@ const LEGACY_UNTITLED_CONVERSATION_TITLES = new Set([
 const AUTO_TITLE_TIMEOUT_MS = 10000
 const AUTO_TITLE_MAX_RETRIES = 2
 const AUTO_TITLE_FAILURE_COOLDOWN_MS = 5 * 60 * 1000
-const AUTO_TITLE_INPUT_MAX_LENGTH = 1200
 const AUTO_TITLE_WAIT_CONVERSATION_RETRIES = 15
 const AUTO_TITLE_WAIT_CONVERSATION_INTERVAL_MS = 200
 const CHAT_HISTORY_UPDATED_EVENT = 'smtcmp:chat-history-updated'
 
 const isUntitledConversationTitle = (title: string): boolean =>
   LEGACY_UNTITLED_CONVERSATION_TITLES.has(title)
-
-const truncateForTitleInput = (text: string): string => {
-  const normalized = text.trim()
-  if (normalized.length <= AUTO_TITLE_INPUT_MAX_LENGTH) {
-    return normalized
-  }
-  return `${normalized.slice(0, AUTO_TITLE_INPUT_MAX_LENGTH)}...`
-}
 
 const formatSelectedSkillsForTitleInput = (
   selectedSkills: ChatSelectedSkill[],
@@ -72,23 +60,19 @@ const formatSelectedSkillsForTitleInput = (
     return '[User selected only skills without text.]'
   }
 
-  return truncateForTitleInput(
-    `[User selected skills: ${skillNames.join(', ')}]`,
-  )
+  return `[User selected skills: ${skillNames.join(', ')}]`
 }
 
-const formatMentionableContentForTitleInput = (
-  mentionables: Mentionable[],
+const extractTextFromPromptContent = (
+  promptContent: ChatUserMessage['promptContent'],
 ): string => {
-  const contentParts = mentionables
-    .filter(
-      (m): m is MentionableBlock | MentionableAssistantQuote =>
-        m.type === 'block' || m.type === 'assistant-quote',
-    )
-    .map((m) => m.content.trim())
-    .filter((c) => c.length > 0)
-
-  return contentParts.join('\n')
+  if (!promptContent) return ''
+  if (typeof promptContent === 'string') return promptContent.trim()
+  return promptContent
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text.trim())
+    .filter((text) => text.length > 0)
+    .join('\n\n')
 }
 
 type UseChatHistory = {
@@ -561,23 +545,21 @@ export function useChatHistory(): UseChatHistory {
           return
         }
 
-        const referenceContent =
-          formatMentionableContentForTitleInput(userMentionables)
-
-        const contextParts: string[] = []
-        if (referenceContent.length > 0) {
-          contextParts.push(`[Referenced content:\n${referenceContent}]`)
-        }
-        if (normalizedUserText.length > 0) {
-          contextParts.push(normalizedUserText)
-        } else if (userSelectedSkills.length > 0) {
-          contextParts.push(formatSelectedSkillsForTitleInput(userSelectedSkills))
-        }
+        // Reuse the same expanded prompt that gets sent to the chat model so
+        // the title model sees referenced files / URLs / blocks / quotes
+        // without re-running compilation or doing extra I/O here.
+        const compiledText = extractTextFromPromptContent(
+          firstUserMessage.promptContent,
+        )
 
         const userContext =
-          contextParts.length > 0
-            ? truncateForTitleInput(contextParts.join('\n\n'))
-            : '[User shared only attachments/mentions without text.]'
+          compiledText.length > 0
+            ? compiledText
+            : normalizedUserText.length > 0
+              ? normalizedUserText
+              : userSelectedSkills.length > 0
+                ? formatSelectedSkillsForTitleInput(userSelectedSkills)
+                : '[User shared only attachments/mentions without text.]'
 
         const titleInput = `User first message:\n${userContext}`
 

--- a/src/hooks/useChatHistory.ts
+++ b/src/hooks/useChatHistory.ts
@@ -25,7 +25,11 @@ import {
   normalizeChatConversationCompactionState,
 } from '../types/chat'
 import { ConversationOverrideSettings } from '../types/conversation-settings.types'
-import { Mentionable } from '../types/mentionable'
+import {
+  Mentionable,
+  MentionableAssistantQuote,
+  MentionableBlock,
+} from '../types/mentionable'
 import { ToolCallResponseStatus } from '../types/tool-call.types'
 import {
   deserializeMentionable,
@@ -71,6 +75,20 @@ const formatSelectedSkillsForTitleInput = (
   return truncateForTitleInput(
     `[User selected skills: ${skillNames.join(', ')}]`,
   )
+}
+
+const formatMentionableContentForTitleInput = (
+  mentionables: Mentionable[],
+): string => {
+  const contentParts = mentionables
+    .filter(
+      (m): m is MentionableBlock | MentionableAssistantQuote =>
+        m.type === 'block' || m.type === 'assistant-quote',
+    )
+    .map((m) => m.content.trim())
+    .filter((c) => c.length > 0)
+
+  return contentParts.join('\n')
 }
 
 type UseChatHistory = {
@@ -543,12 +561,23 @@ export function useChatHistory(): UseChatHistory {
           return
         }
 
+        const referenceContent =
+          formatMentionableContentForTitleInput(userMentionables)
+
+        const contextParts: string[] = []
+        if (referenceContent.length > 0) {
+          contextParts.push(`[Referenced content:\n${referenceContent}]`)
+        }
+        if (normalizedUserText.length > 0) {
+          contextParts.push(normalizedUserText)
+        } else if (userSelectedSkills.length > 0) {
+          contextParts.push(formatSelectedSkillsForTitleInput(userSelectedSkills))
+        }
+
         const userContext =
-          normalizedUserText.length > 0
-            ? truncateForTitleInput(normalizedUserText)
-            : userSelectedSkills.length > 0
-              ? formatSelectedSkillsForTitleInput(userSelectedSkills)
-              : '[User shared only attachments/mentions without text.]'
+          contextParts.length > 0
+            ? truncateForTitleInput(contextParts.join('\n\n'))
+            : '[User shared only attachments/mentions without text.]'
 
         const titleInput = `User first message:\n${userContext}`
 


### PR DESCRIPTION
Fixes #273

## Summary

- Extract content from `MentionableBlock` and `MentionableAssistantQuote` mentionables in the first user message
- Include this referenced content in the title generation LLM prompt
- Fixes inaccurate titles when main content is in a quote and user input is a short action (e.g. "translate this")
- Fixes generic fallback title when user quotes content without typing any text

Generated with [Claude Code](https://claude.ai/code)