### PR TITLE
fix(settings): collapse provider during drag to fix mouse misalignment

### DIFF
--- a/src/components/settings/sections/ProvidersAndModelsSection.tsx
+++ b/src/components/settings/sections/ProvidersAndModelsSection.tsx
@@ -1,7 +1,6 @@
 import {
   DndContext,
   type DragEndEvent,
-  type DragStartEvent,
   PointerSensor,
   closestCenter,
   useSensor,
@@ -71,6 +70,7 @@ type ProviderSectionItemProps = {
   handleToggleEnableChatModel: (modelId: string, value: boolean) => void
   handleChatModelDragEnd: (event: DragEndEvent) => void
   handleEmbeddingModelDragEnd: (event: DragEndEvent) => void
+  onCollapseForDrag: () => void
 }
 
 function getProviderDisplayBaseUrl(provider: LLMProvider): string {
@@ -530,6 +530,7 @@ function ProviderSectionItem({
   handleToggleEnableChatModel,
   handleChatModelDragEnd,
   handleEmbeddingModelDragEnd,
+  onCollapseForDrag,
 }: ProviderSectionItemProps) {
   const isChatGPTOAuth = provider.presetType === 'chatgpt-oauth'
   const isGeminiOAuth = provider.presetType === 'gemini-oauth'
@@ -567,6 +568,10 @@ function ProviderSectionItem({
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
           {...listeners}
+          onPointerDown={(e) => {
+            onCollapseForDrag()
+            ;(listeners as Record<string, (e: React.PointerEvent) => void> | undefined)?.onPointerDown?.(e)
+          }}
         >
           <GripVertical />
         </button>
@@ -1090,9 +1095,6 @@ export function ProvidersAndModelsSection({
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(
     new Set(),
   )
-  const [draggingProviderId, setDraggingProviderId] = useState<string | null>(
-    null,
-  )
   const [deletingEmbeddingModelIds, setDeletingEmbeddingModelIds] = useState<
     Set<string>
   >(new Set())
@@ -1582,50 +1584,7 @@ export function ProvidersAndModelsSection({
           <DndContext
             sensors={providerSensors}
             collisionDetection={closestCenter}
-            onDragStart={(event: DragStartEvent) => {
-              const id = String(event.active.id)
-              if (!expandedProviders.has(id)) {
-                return
-              }
-              setDraggingProviderId(id)
-              setExpandedProviders((prev) => {
-                if (!prev.has(id)) {
-                  return prev
-                }
-                const next = new Set(prev)
-                next.delete(id)
-                return next
-              })
-            }}
-            onDragEnd={(event) => {
-              void handleProviderDragEnd(event)
-              if (draggingProviderId) {
-                const idToRestore = draggingProviderId
-                setExpandedProviders((prev) => {
-                  if (prev.has(idToRestore)) {
-                    return prev
-                  }
-                  const next = new Set(prev)
-                  next.add(idToRestore)
-                  return next
-                })
-                setDraggingProviderId(null)
-              }
-            }}
-            onDragCancel={() => {
-              if (draggingProviderId) {
-                const idToRestore = draggingProviderId
-                setExpandedProviders((prev) => {
-                  if (prev.has(idToRestore)) {
-                    return prev
-                  }
-                  const next = new Set(prev)
-                  next.add(idToRestore)
-                  return next
-                })
-                setDraggingProviderId(null)
-              }
-            }}
+            onDragEnd={(event) => void handleProviderDragEnd(event)}
           >
             <SortableContext
               items={providerIds}
@@ -1665,6 +1624,14 @@ export function ProvidersAndModelsSection({
                     }
                     handleEmbeddingModelDragEnd={(event) =>
                       void handleEmbeddingModelDragEnd(provider.id, event)
+                    }
+                    onCollapseForDrag={() =>
+                      setExpandedProviders((prev) => {
+                        if (!prev.has(provider.id)) return prev
+                        const next = new Set(prev)
+                        next.delete(provider.id)
+                        return next
+                      })
                     }
                   />
                 )

--- a/src/components/settings/sections/ProvidersAndModelsSection.tsx
+++ b/src/components/settings/sections/ProvidersAndModelsSection.tsx
@@ -1,6 +1,7 @@
 import {
   DndContext,
   type DragEndEvent,
+  type DragStartEvent,
   PointerSensor,
   closestCenter,
   useSensor,
@@ -1089,6 +1090,9 @@ export function ProvidersAndModelsSection({
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(
     new Set(),
   )
+  const [draggingProviderId, setDraggingProviderId] = useState<string | null>(
+    null,
+  )
   const [deletingEmbeddingModelIds, setDeletingEmbeddingModelIds] = useState<
     Set<string>
   >(new Set())
@@ -1578,7 +1582,50 @@ export function ProvidersAndModelsSection({
           <DndContext
             sensors={providerSensors}
             collisionDetection={closestCenter}
-            onDragEnd={(event) => void handleProviderDragEnd(event)}
+            onDragStart={(event: DragStartEvent) => {
+              const id = String(event.active.id)
+              if (!expandedProviders.has(id)) {
+                return
+              }
+              setDraggingProviderId(id)
+              setExpandedProviders((prev) => {
+                if (!prev.has(id)) {
+                  return prev
+                }
+                const next = new Set(prev)
+                next.delete(id)
+                return next
+              })
+            }}
+            onDragEnd={(event) => {
+              void handleProviderDragEnd(event)
+              if (draggingProviderId) {
+                const idToRestore = draggingProviderId
+                setExpandedProviders((prev) => {
+                  if (prev.has(idToRestore)) {
+                    return prev
+                  }
+                  const next = new Set(prev)
+                  next.add(idToRestore)
+                  return next
+                })
+                setDraggingProviderId(null)
+              }
+            }}
+            onDragCancel={() => {
+              if (draggingProviderId) {
+                const idToRestore = draggingProviderId
+                setExpandedProviders((prev) => {
+                  if (prev.has(idToRestore)) {
+                    return prev
+                  }
+                  const next = new Set(prev)
+                  next.add(idToRestore)
+                  return next
+                })
+                setDraggingProviderId(null)
+              }
+            }}
           >
             <SortableContext
               items={providerIds}


### PR DESCRIPTION
When a provider is expanded and dragged via the grip handle, the dragged
row's height is much larger than its collapsed neighbours. @dnd-kit's
verticalListSortingStrategy shifts sibling rows by the active item's
height, which made surrounding rows jump far past their expected slots
and the cursor lose alignment with the drag preview.

Auto-collapse the dragged provider on drag start and restore its
expanded state on drag end / cancel so the active item's rect matches
its neighbours during reordering.