### PR TITLE
fix: replace MCP desktop fetch fallback

### DIFF
--- a/src/core/mcp/desktopMcpFetch.test.ts
+++ b/src/core/mcp/desktopMcpFetch.test.ts
@@ -1,28 +1,47 @@
 /**
- * Tests for the proxy resolution + SOCKS fail-fast contract of
- * `createDesktopMcpFetch`. Verifies parity with the legacy
- * `createProxyAgent` semantics in `remoteTransport.ts`.
+ * Tests for `createDesktopMcpFetch`.
+ *
+ * Tests cover both the primary `globalThis.fetch` path and the `node-fetch`
+ * fallback path, including per-host transport caching.
  */
 import { Platform } from 'obsidian'
 
-jest.mock('obsidian', () => ({
-  Platform: { isDesktop: true },
-}))
+const originalFetch = globalThis.fetch
+type FetchArgs = [input: RequestInfo | URL, init?: RequestInit]
+const globalFetchMock = jest.fn<Promise<Response>, FetchArgs>()
 
-type FetchArgs = [input: unknown, init?: { dispatcher?: unknown }]
-const undiciFetchMock = jest.fn(
-  async (..._args: FetchArgs) => new Response('ok'),
+beforeAll(() => {
+  ;(globalThis as { fetch: typeof globalThis.fetch }).fetch =
+    globalFetchMock as unknown as typeof globalThis.fetch
+})
+
+afterAll(() => {
+  ;(globalThis as { fetch: typeof globalThis.fetch }).fetch = originalFetch
+})
+
+jest.mock('obsidian', () => ({ Platform: { isDesktop: true } }))
+
+type NodeFetchArgs = [input: unknown, init?: { agent?: unknown }]
+const nodeFetchMock = jest.fn(
+  async (..._args: NodeFetchArgs) => new Response('ok'),
 )
-const proxyAgentCtor = jest.fn()
 
 jest.mock(
-  'undici',
+  'node-fetch/lib/index.js',
+  () => ({ default: (...args: NodeFetchArgs) => nodeFetchMock(...args) }),
+  { virtual: true },
+)
+
+const proxyAgentCtor = jest.fn()
+const proxyAgentInstance = { _proxyAgent: true }
+
+jest.mock(
+  'proxy-agent',
   () => ({
-    fetch: (...args: FetchArgs) => undiciFetchMock(...args),
-    ProxyAgent: function (this: { uri: string }, uri: string) {
-      this.uri = uri
-      proxyAgentCtor(uri)
-    },
+    ProxyAgent: jest.fn().mockImplementation((..._args: unknown[]) => {
+      proxyAgentCtor(..._args)
+      return proxyAgentInstance
+    }),
   }),
   { virtual: true },
 )
@@ -39,7 +58,10 @@ jest.mock('../../utils/net/systemProxyResolver', () => ({
   resolveSystemProxy: (url: string) => resolveSystemProxyMock(url),
 }))
 
-import { createDesktopMcpFetch } from './desktopMcpFetch'
+import {
+  __resetDesktopMcpFetchTransportCacheForTests,
+  createDesktopMcpFetch,
+} from './desktopMcpFetch'
 
 const PROXY_ENV_KEYS = [
   'HTTP_PROXY',
@@ -56,13 +78,11 @@ const stripProxyEnv = () => {
   const saved: Record<string, string | undefined> = {}
   for (const key of PROXY_ENV_KEYS) {
     saved[key] = process.env[key]
-    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- iterating a fixed allowlist of proxy env keys to isolate test state
     delete process.env[key]
   }
   return () => {
     for (const key of PROXY_ENV_KEYS) {
       const v = saved[key]
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- restoring the same fixed allowlist of proxy env keys
       if (v === undefined) delete process.env[key]
       else process.env[key] = v
     }
@@ -70,36 +90,53 @@ const stripProxyEnv = () => {
 }
 
 describe('desktopMcpFetch', () => {
+  let consoleWarnSpy: jest.SpyInstance
+
   beforeEach(() => {
     jest.clearAllMocks()
-    undiciFetchMock.mockResolvedValue(new Response('ok'))
+    __resetDesktopMcpFetchTransportCacheForTests()
+    globalFetchMock.mockRejectedValue(new TypeError('Failed to fetch'))
+    nodeFetchMock.mockResolvedValue(new Response('ok'))
     resolveSystemProxyMock.mockResolvedValue('')
     getProxyForUrlMock.mockReturnValue('')
+    consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
   })
 
-  it('throws on non-desktop platforms without touching undici / proxy mocks', async () => {
+  afterEach(() => {
+    consoleWarnSpy.mockRestore()
+  })
+
+  it('throws on non-desktop platforms', async () => {
     ;(Platform as { isDesktop: boolean }).isDesktop = false
     try {
       const fetchFn = createDesktopMcpFetch({ env: {} })
       await expect(fetchFn('https://example.com')).rejects.toThrow(
         /only available on desktop/,
       )
-      // Mobile-safety contract: the platform check must precede any lazy
-      // import / proxy resolution work. None of the network-side mocks
-      // should fire on this code path.
-      expect(undiciFetchMock).not.toHaveBeenCalled()
-      expect(proxyAgentCtor).not.toHaveBeenCalled()
-      expect(resolveSystemProxyMock).not.toHaveBeenCalled()
-      expect(getProxyForUrlMock).not.toHaveBeenCalled()
+      expect(globalFetchMock).not.toHaveBeenCalled()
+      expect(nodeFetchMock).not.toHaveBeenCalled()
     } finally {
       ;(Platform as { isDesktop: boolean }).isDesktop = true
     }
   })
 
-  it('fails fast when env resolves to socks5:// (env path, not just system proxy)', async () => {
+  it('returns globalThis.fetch response without calling node-fetch when browser fetch succeeds', async () => {
+    globalFetchMock.mockResolvedValueOnce(new Response('global-ok'))
+
+    const fetchFn = createDesktopMcpFetch({ env: {} })
+    const res = await fetchFn('https://example.com/mcp')
+
+    expect(await res.text()).toBe('global-ok')
+    expect(globalFetchMock).toHaveBeenCalledTimes(1)
+    expect(nodeFetchMock).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).not.toHaveBeenCalled()
+  })
+
+  it('fails fast on socks5 proxy', async () => {
     const restore = stripProxyEnv()
     getProxyForUrlMock.mockReturnValue('socks5://127.0.0.1:1080')
-
     try {
       const fetchFn = createDesktopMcpFetch({
         env: { ALL_PROXY: 'socks5://127.0.0.1:1080' },
@@ -107,158 +144,112 @@ describe('desktopMcpFetch', () => {
       await expect(fetchFn('https://example.com/mcp')).rejects.toThrow(
         /SOCKS proxy is not supported/i,
       )
-      // Env path resolved the proxy; the request must short-circuit before
-      // touching undici.
-      expect(undiciFetchMock).not.toHaveBeenCalled()
+      expect(globalFetchMock).toHaveBeenCalledTimes(1)
+      expect(nodeFetchMock).not.toHaveBeenCalled()
       expect(proxyAgentCtor).not.toHaveBeenCalled()
     } finally {
       restore()
     }
   })
 
-  it('bypasses proxy for loopback / private destinations', async () => {
+  it('bypasses system proxy for loopback', async () => {
     const restore = stripProxyEnv()
     try {
       const fetchFn = createDesktopMcpFetch({ env: {} })
       await fetchFn('http://127.0.0.1:3005/mcp')
-
-      expect(proxyAgentCtor).not.toHaveBeenCalled()
       expect(resolveSystemProxyMock).not.toHaveBeenCalled()
-      expect(undiciFetchMock).toHaveBeenCalledTimes(1)
-      const init = undiciFetchMock.mock.calls[0][1]
-      expect(init?.dispatcher).toBeUndefined()
+      expect(globalFetchMock).toHaveBeenCalledTimes(1)
+      expect(nodeFetchMock).toHaveBeenCalledTimes(1)
     } finally {
       restore()
     }
   })
 
-  it('honors shell env proxy via temporary process.env swap (env parity)', async () => {
+  it('returns node-fetch response with working json/text', async () => {
     const restore = stripProxyEnv()
-    process.env.HTTPS_PROXY = 'http://process-only.local:3128'
+    try {
+      const fetchFn = createDesktopMcpFetch({ env: {} })
+      const res = await fetchFn('http://127.0.0.1:3005/mcp')
+      expect(res.status).toBe(200)
+      expect(typeof res.json).toBe('function')
+      expect(typeof res.text).toBe('function')
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      restore()
+    }
+  })
 
-    // Implementation must swap process.env so getProxyForUrl observes the
-    // shell-supplied value, not the long-lived process value.
-    getProxyForUrlMock.mockImplementation(
-      () => process.env.HTTPS_PROXY ?? process.env.https_proxy ?? '',
+  it('falls back for alternate fetch-related TypeError messages', async () => {
+    const restore = stripProxyEnv()
+    globalFetchMock.mockRejectedValueOnce(
+      new TypeError('NetworkError when attempting to fetch resource.'),
     )
-
     try {
-      const fetchFn = createDesktopMcpFetch({
-        env: { HTTPS_PROXY: 'http://shell-proxy.local:8080' },
-      })
-      await fetchFn('https://example.com/mcp')
-
-      expect(proxyAgentCtor).toHaveBeenCalledWith(
-        'http://shell-proxy.local:8080',
-      )
-      // process.env restored after the swap.
-      expect(process.env.HTTPS_PROXY).toBe('http://process-only.local:3128')
+      const fetchFn = createDesktopMcpFetch({ env: {} })
+      const res = await fetchFn('https://example.com/mcp')
+      expect(res.status).toBe(200)
+      expect(nodeFetchMock).toHaveBeenCalledTimes(1)
     } finally {
       restore()
     }
   })
 
-  it('respects lowercase env keys and NO_PROXY (env parity)', async () => {
+  it('uses cached node-fetch transport for a second request to the same host', async () => {
     const restore = stripProxyEnv()
-    getProxyForUrlMock.mockImplementation((url) => {
-      // emulate proxy-from-env: NO_PROXY hits → ''
-      if (process.env.no_proxy && url.includes('skip.example.com')) return ''
-      return process.env.http_proxy ?? ''
-    })
-
     try {
-      const fetchFn = createDesktopMcpFetch({
-        env: {
-          http_proxy: 'http://lower-case.local:3128',
-          no_proxy: 'skip.example.com',
-        },
-      })
+      const fetchFn = createDesktopMcpFetch({ env: {} })
+      await fetchFn('https://cached.example.com/mcp')
+      await fetchFn('https://cached.example.com/other')
 
-      await fetchFn('http://other.example.com/mcp')
-      expect(proxyAgentCtor).toHaveBeenCalledWith(
-        'http://lower-case.local:3128',
-      )
-
-      proxyAgentCtor.mockClear()
-      await fetchFn('http://skip.example.com/mcp')
-      expect(proxyAgentCtor).not.toHaveBeenCalled()
+      expect(globalFetchMock).toHaveBeenCalledTimes(1)
+      expect(nodeFetchMock).toHaveBeenCalledTimes(2)
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
     } finally {
       restore()
     }
   })
 
-  it('falls back to resolveSystemProxy when no env proxy is set', async () => {
+  it('passes proxy-agent to node-fetch', async () => {
     const restore = stripProxyEnv()
-    resolveSystemProxyMock.mockResolvedValue('http://system-proxy.corp:8080')
-
+    resolveSystemProxyMock.mockResolvedValue('http://corp.proxy:8080')
     try {
       const fetchFn = createDesktopMcpFetch({ env: {} })
       await fetchFn('https://corp.example.com/mcp')
-
-      expect(resolveSystemProxyMock).toHaveBeenCalledWith(
-        'https://corp.example.com/mcp',
-      )
-      expect(proxyAgentCtor).toHaveBeenCalledWith(
-        'http://system-proxy.corp:8080',
-      )
+      expect(proxyAgentCtor).toHaveBeenCalledTimes(1)
+      const init = nodeFetchMock.mock.calls[0][1] as { agent?: unknown }
+      expect(init?.agent).toBe(proxyAgentInstance)
     } finally {
       restore()
     }
   })
 
-  it('caches ProxyAgent per proxy URI across requests', async () => {
+  it('caches proxy-agent per factory', async () => {
     const restore = stripProxyEnv()
-    resolveSystemProxyMock.mockResolvedValue('http://cached.corp:8080')
-
     try {
       const fetchFn = createDesktopMcpFetch({ env: {} })
       await fetchFn('https://a.example.com')
       await fetchFn('https://b.example.com')
-
       expect(proxyAgentCtor).toHaveBeenCalledTimes(1)
-      expect(proxyAgentCtor).toHaveBeenCalledWith('http://cached.corp:8080')
     } finally {
       restore()
     }
   })
 
-  it('preserves resolveSystemProxy silent degrade (empty string → direct)', async () => {
+  it('succeeds with empty system proxy', async () => {
     const restore = stripProxyEnv()
     resolveSystemProxyMock.mockResolvedValue('')
-
     try {
       const fetchFn = createDesktopMcpFetch({ env: {} })
-      await fetchFn('https://anywhere.example.com')
-
-      expect(proxyAgentCtor).not.toHaveBeenCalled()
-      const init = undiciFetchMock.mock.calls[0][1]
-      expect(init?.dispatcher).toBeUndefined()
+      const res = await fetchFn('https://anywhere.example.com')
+      expect(res.status).toBe(200)
     } finally {
       restore()
     }
   })
 
-  it('fails fast on socks5:// resolved proxy (no fallback)', async () => {
+  it('fails fast on socks5:// system proxy', async () => {
     const restore = stripProxyEnv()
     resolveSystemProxyMock.mockResolvedValue('socks5://127.0.0.1:1080')
-
-    try {
-      const fetchFn = createDesktopMcpFetch({ env: {} })
-      await expect(fetchFn('https://example.com/mcp')).rejects.toThrow(
-        /SOCKS proxy is not supported/i,
-      )
-
-      expect(undiciFetchMock).not.toHaveBeenCalled()
-      expect(proxyAgentCtor).not.toHaveBeenCalled()
-    } finally {
-      restore()
-    }
-  })
-
-  it('fails fast on socks4:// resolved proxy', async () => {
-    const restore = stripProxyEnv()
-    resolveSystemProxyMock.mockResolvedValue('socks4://127.0.0.1:1080')
-
     try {
       const fetchFn = createDesktopMcpFetch({ env: {} })
       await expect(fetchFn('https://example.com/mcp')).rejects.toThrow(

--- a/src/core/mcp/desktopMcpFetch.ts
+++ b/src/core/mcp/desktopMcpFetch.ts
@@ -1,12 +1,26 @@
 /**
- * MCP-only desktop fetch built on `undici` so that
- * `StreamableHTTPClientTransport` receives a WHATWG `ReadableStream` body
- * (with `pipeThrough`/`getReader`). `node-fetch@2` returns Node `Readable`,
- * which silently breaks the SDK's SSE consumption — see issue #252.
+ * MCP-only desktop fetch with automatic fallback.
  *
- * Scope is intentionally narrow: this fetch is **only** wired into
- * `remoteTransport.ts`. The LLM SDK fetch in `core/llm/sdkFetch.ts` is left
- * untouched.
+ * 1. `globalThis.fetch` (primary):
+ *    - Chromium networking → system proxy, TLS.
+ *    - Native WHATWG `ReadableStream` body (`pipeThrough` / `getReader`).
+ *    - Supports Streamable HTTP SSE streaming.
+ *    - Fails on CORS if the server lacks `Access-Control-Allow-*` headers.
+ *
+ * 2. `node-fetch@2` (fallback):
+ *    - Node.js `http`/`https` → no CORS, works in any Electron renderer.
+ *    - Body is a Node.js `Readable` (no `pipeThrough`), so SSE streaming
+ *      may not work, but standard MCP JSON request/response always succeeds.
+ *
+ * Fallback logic: `globalThis.fetch` is tried first. If it throws a
+ * fetch/network-like `TypeError` (CORS / network error), the request is
+ * retried with `node-fetch@2`. Successful backends are cached per host
+ * briefly to avoid repeated retries while still allowing server-side CORS
+ * fixes to take effect without restarting Obsidian.
+ *
+ * We avoid the `undici` npm package (timer `.unref()` crash in Electron).
+ *
+ * Scope: only wired into `remoteTransport.ts`. LLM transport is untouched.
  */
 import { Platform } from 'obsidian'
 
@@ -14,47 +28,9 @@ import { shouldBypassProxy } from '../../utils/net/proxyBypass'
 import { envHasProxy, withProcessEnv } from '../../utils/net/proxyEnv'
 import { resolveSystemProxy } from '../../utils/net/systemProxyResolver'
 
-// Lazy-loaded undici module (desktop-only). Mobile must never reach this path.
-type UndiciFetch = typeof globalThis.fetch
-// Opaque branded type — undici's `Dispatcher` shape is irrelevant to us; we
-// only ever pass it through to `fetch`'s `dispatcher` slot.
-type UndiciDispatcher = { readonly __undiciDispatcher: unique symbol }
-type UndiciModule = {
-  fetch: UndiciFetch
-  ProxyAgent: new (uri: string) => UndiciDispatcher
-}
+type RequestOptions = import('node:http').RequestOptions
 
-let undiciModulePromise: Promise<UndiciModule> | null = null
-
-const loadUndici = (): Promise<UndiciModule> => {
-  if (!undiciModulePromise) {
-    undiciModulePromise = import('undici').then(
-      (mod) =>
-        ({
-          fetch: mod.fetch as unknown as UndiciFetch,
-          ProxyAgent: mod.ProxyAgent as unknown as new (
-            uri: string,
-          ) => UndiciDispatcher,
-        }) satisfies UndiciModule,
-    )
-  }
-  return undiciModulePromise
-}
-
-type ProxyFromEnvModule = {
-  getProxyForUrl: (url: string) => string
-}
-
-let proxyFromEnvPromise: Promise<ProxyFromEnvModule> | null = null
-
-const loadProxyFromEnv = (): Promise<ProxyFromEnvModule> => {
-  if (!proxyFromEnvPromise) {
-    proxyFromEnvPromise = import('proxy-from-env').then(
-      (mod) => mod as ProxyFromEnvModule,
-    )
-  }
-  return proxyFromEnvPromise
-}
+// ---- proxy utilities (for node-fetch fallback) ----
 
 const isSocksProxy = (uri: string): boolean =>
   /^socks[45]?:\/\//i.test(uri.trim())
@@ -62,70 +38,168 @@ const isSocksProxy = (uri: string): boolean =>
 class UnsupportedSocksProxyError extends Error {
   readonly code = 'YOLO_MCP_SOCKS_UNSUPPORTED'
   constructor(uri: string) {
-    super(
-      `SOCKS proxy is not supported by Streamable HTTP MCP transport (resolved proxy: ${uri}). ` +
-        `Please configure an HTTP/HTTPS proxy or add this MCP server's host to your bypass list.`,
-    )
+    super(`SOCKS proxy is not supported (node-fetch, proxy: ${uri}).`)
     this.name = 'UnsupportedSocksProxyError'
   }
 }
 
-export type DesktopMcpFetchOptions = {
-  /**
-   * Shell environment merged from `shellEnvSync()` upstream. May legitimately
-   * carry HTTP(S)_PROXY values that are not in `process.env`, so the resolver
-   * temporarily swaps `process.env` for `proxy-from-env` to observe them.
-   */
-  env: Record<string, string>
+type ProxyFromEnvModule = { getProxyForUrl: (url: string) => string }
+
+let proxyFromEnvPromise: Promise<ProxyFromEnvModule> | null = null
+
+const loadProxyFromEnv = (): Promise<ProxyFromEnvModule> => {
+  if (!proxyFromEnvPromise)
+    proxyFromEnvPromise = import('proxy-from-env').then(
+      (mod) => mod as ProxyFromEnvModule,
+    )
+  return proxyFromEnvPromise
 }
 
-/**
- * Resolve a proxy URI for `targetUrl` using the same precedence as the
- * legacy `createProxyAgent` in `remoteTransport.ts`:
- *   1. Local/private destinations → DIRECT.
- *   2. Explicit env proxy (`*_PROXY` / `NO_PROXY`, mixed case) → `proxy-from-env`.
- *   3. Otherwise → Electron system proxy resolver.
- *
- * `resolveSystemProxy` intentionally degrades to `''` (DIRECT) on PAC
- * `DIRECT` or Electron failures; that behavior is preserved.
- */
 const resolveProxyUri = async (
   targetUrl: string,
   resolvedEnv: NodeJS.ProcessEnv,
 ): Promise<string> => {
   if (shouldBypassProxy(targetUrl)) return ''
-
   if (envHasProxy(resolvedEnv)) {
     const { getProxyForUrl } = await loadProxyFromEnv()
     return withProcessEnv(resolvedEnv, () => getProxyForUrl(targetUrl))
   }
-
   return resolveSystemProxy(targetUrl)
 }
 
+// ---- node-fetch (fallback) ----
+
+let nodeFetchPromise: Promise<typeof fetch> | null = null
+
+const loadNodeFetch = (): Promise<typeof fetch> => {
+  if (!nodeFetchPromise) {
+    nodeFetchPromise = import('node-fetch/lib/index.js').then(
+      (module) =>
+        ((module as unknown as { default?: typeof fetch }).default ??
+          module) as unknown as typeof fetch,
+    )
+  }
+  return nodeFetchPromise
+}
+
+let proxyAgentPromise: Promise<{
+  ProxyAgent: new (...args: unknown[]) => RequestOptions['agent']
+}> | null = null
+
+const loadProxyAgent = (): Promise<{
+  ProxyAgent: new (...args: unknown[]) => RequestOptions['agent']
+}> => {
+  if (!proxyAgentPromise) proxyAgentPromise = import('proxy-agent')
+  return proxyAgentPromise
+}
+
+const createProxyAgent = async (
+  resolvedEnv: NodeJS.ProcessEnv,
+): Promise<RequestOptions['agent'] | undefined> => {
+  const [{ ProxyAgent }, { getProxyForUrl }] = await Promise.all([
+    loadProxyAgent(),
+    loadProxyFromEnv(),
+  ])
+  return new ProxyAgent({
+    getProxyForUrl: async (url: string): Promise<string> => {
+      if (shouldBypassProxy(url)) return ''
+      if (envHasProxy(resolvedEnv))
+        return withProcessEnv(resolvedEnv, () => getProxyForUrl(url))
+      return resolveSystemProxy(url)
+    },
+  })
+}
+
+// ---- fallback routing ----
+
 /**
- * Build the MCP-only desktop fetch. The factory is **synchronous** so the
- * existing `McpRemoteTransportFactory` signature (and `mcpManager.ts`) stay
- * untouched. The returned `fetch` is async and lazy-loads `undici` on first
- * call, with a module-level promise cache.
+ * Returns true when the error looks like a fetch-level CORS / network
+ * failure that should trigger a fallback to node-fetch. Real server errors
+ * (4xx/5xx) are NOT retried because they resolve as Response objects.
  */
+const isCorsLikeError = (error: unknown): boolean => {
+  if (!(error instanceof TypeError)) return false
+  const message = error.message.toLowerCase()
+  return message === 'failed to fetch' || /fetch|network/.test(message)
+}
+
+const HOST_TRANSPORT_CACHE_TTL_MS = 60_000
+
+type HostTransportCacheEntry = {
+  usesGlobalFetch: boolean
+  expiresAt: number
+}
+
+/**
+ * Per-host cache of which transport succeeded last. `true` = globalThis.fetch
+ * worked, `false` = node-fetch was needed. Entries expire so users can fix
+ * CORS headers or server config without restarting Obsidian.
+ */
+const hostTransportCache = new Map<string, HostTransportCacheEntry>()
+
+const getCachedTransport = (host: string): boolean | undefined => {
+  const cached = hostTransportCache.get(host)
+  if (!cached) return undefined
+  if (cached.expiresAt <= Date.now()) {
+    hostTransportCache.delete(host)
+    return undefined
+  }
+  return cached.usesGlobalFetch
+}
+
+const setCachedTransport = (host: string, usesGlobalFetch: boolean): void => {
+  hostTransportCache.set(host, {
+    usesGlobalFetch,
+    expiresAt: Date.now() + HOST_TRANSPORT_CACHE_TTL_MS,
+  })
+}
+
+export const __resetDesktopMcpFetchTransportCacheForTests = (): void => {
+  hostTransportCache.clear()
+}
+
+// ---- factory ----
+
+export type DesktopMcpFetchOptions = { env: Record<string, string> }
+
 export const createDesktopMcpFetch = (
   options: DesktopMcpFetchOptions,
 ): typeof fetch => {
-  const resolvedEnv: NodeJS.ProcessEnv = {
-    ...process.env,
-    ...options.env,
+  const resolvedEnv: NodeJS.ProcessEnv = { ...process.env, ...options.env }
+  let nodeFetchFn: typeof fetch | null = null
+  let agent: RequestOptions['agent'] | null = null
+
+  const makeNodeFetchRequest = async (
+    input: RequestInfo | URL,
+    init: RequestInit | undefined,
+  ): Promise<Response> => {
+    // SOCKS fail-fast — must happen before creating proxy-agent.
+    const targetUrl =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+    const proxyUri = await resolveProxyUri(targetUrl, resolvedEnv)
+    if (proxyUri && isSocksProxy(proxyUri))
+      throw new UnsupportedSocksProxyError(proxyUri)
+
+    if (!nodeFetchFn) nodeFetchFn = await loadNodeFetch()
+    if (agent === null) agent = await createProxyAgent(resolvedEnv)
+
+    const reqInit: RequestInit & {
+      agent?: RequestOptions['agent']
+    } = init
+      ? { ...init, agent: agent ?? undefined }
+      : { agent: agent ?? undefined }
+    return nodeFetchFn(input, reqInit)
   }
 
-  // ProxyAgent cache keyed by proxy URI to avoid rebuilding per request.
-  const dispatcherCache = new Map<string, UndiciDispatcher>()
-
   return async (input, init) => {
-    if (!Platform.isDesktop) {
+    if (!Platform.isDesktop)
       throw new Error(
         'MCP remote HTTP transport is only available on desktop Obsidian.',
       )
-    }
 
     const targetUrl =
       typeof input === 'string'
@@ -133,32 +207,30 @@ export const createDesktopMcpFetch = (
         : input instanceof URL
           ? input.toString()
           : input.url
+    const host = new URL(targetUrl).host
 
-    const proxyUri = await resolveProxyUri(targetUrl, resolvedEnv)
+    // Use cached transport preference for this host if available.
+    const cached = getCachedTransport(host)
+    if (cached === false) return makeNodeFetchRequest(input, init)
 
-    if (proxyUri && isSocksProxy(proxyUri)) {
-      throw new UnsupportedSocksProxyError(proxyUri)
-    }
-
-    const { fetch: undiciFetch, ProxyAgent } = await loadUndici()
-
-    let dispatcher: UndiciDispatcher | undefined
-    if (proxyUri) {
-      const cached = dispatcherCache.get(proxyUri)
-      if (cached) {
-        dispatcher = cached
-      } else {
-        dispatcher = new ProxyAgent(proxyUri)
-        dispatcherCache.set(proxyUri, dispatcher)
+    // Try globalThis.fetch first (streaming support). Fall back to
+    // node-fetch on CORS / network failures.
+    try {
+      const res = await globalThis.fetch(input, init)
+      // Success — cache that globalThis.fetch works for this host.
+      setCachedTransport(host, true)
+      return res
+    } catch (error) {
+      if (isCorsLikeError(error)) {
+        // CORS blocked — fall back to node-fetch and cache the decision.
+        setCachedTransport(host, false)
+        console.warn(
+          '[YOLO] MCP desktop fetch fell back to node-fetch. SSE streaming may not work until the server allows browser fetch/CORS.',
+          { url: targetUrl, error },
+        )
+        return makeNodeFetchRequest(input, init)
       }
+      throw error
     }
-
-    // undici's fetch accepts `dispatcher` on RequestInit but the standard
-    // RequestInit type doesn't include it; cast at the boundary only.
-    const undiciInit = dispatcher
-      ? ({ ...(init ?? {}), dispatcher } as RequestInit)
-      : init
-
-    return undiciFetch(input, undiciInit)
   }
 }


### PR DESCRIPTION
## Background

This is the MCP-only split from #275. The previous PR bundled unrelated embedding and fs_search changes; this branch keeps only the MCP remote transport change.

## Changes

- Use `globalThis.fetch` first for desktop MCP HTTP transport so Streamable HTTP can keep WHATWG stream support.
- Fall back to `node-fetch@2` for fetch/CORS-like TypeError failures.
- Cache the selected transport per host with a short TTL so server-side CORS fixes can take effect without restarting Obsidian.
- Keep SOCKS proxy fail-fast behavior for the fallback path.
- Add a warning when falling back to `node-fetch`, since SSE streaming may not work on that path.
- Add tests for primary `globalThis.fetch` success, fallback behavior, and cached fallback routing.

## Verification

- `npm test -- src/core/mcp/desktopMcpFetch.test.ts`
- `npm run build`
