### PR TITLE
feat: add embedding dimensions and hybrid search fallbacks

### DIFF
--- a/src/core/llm/openaiCompatibleProvider.fallback.test.ts
+++ b/src/core/llm/openaiCompatibleProvider.fallback.test.ts
@@ -1,0 +1,209 @@
+import OpenAI from 'openai'
+
+import { OpenAICompatibleProvider } from './openaiCompatibleProvider'
+
+const apiError = (status: number, message: string) =>
+  OpenAI.APIError.generate(
+    status,
+    { error: { message } },
+    undefined,
+    {} as never,
+  )
+
+describe('OpenAICompatibleProvider dimensions fallback', () => {
+  const createProvider = () =>
+    new OpenAICompatibleProvider({
+      id: 'test-openai-compatible',
+      name: 'Test OpenAI Compatible',
+      presetType: 'openai-compatible',
+      apiType: 'openai-compatible',
+      apiKey: 'token',
+      baseUrl: 'https://example.com/v1',
+      enable: true,
+      models: [],
+      customHeaders: [],
+      additionalSettings: {
+        requestTransportMode: 'node',
+      },
+    } as never)
+
+  beforeEach(() => {
+    ;(
+      OpenAICompatibleProvider as unknown as {
+        clearEmbeddingDimensionsSupportCache?: () => void
+      }
+    ).clearEmbeddingDimensionsSupportCache?.()
+  })
+
+  it('retries embeddings without dimensions when the provider rejects the parameter', async () => {
+    const provider = createProvider()
+    const nodeCreate = jest
+      .fn()
+      .mockRejectedValueOnce(apiError(400, 'provider rejected request'))
+      .mockResolvedValueOnce({
+        data: [{ embedding: [0.1, 0.2, 0.3] }],
+      })
+
+    ;(
+      provider as unknown as {
+        nodeClient: { embeddings: { create: typeof nodeCreate } }
+        browserClient: { embeddings: { create: jest.Mock } }
+        obsidianClient: { embeddings: { create: jest.Mock } }
+      }
+    ).nodeClient = {
+      embeddings: { create: nodeCreate },
+    }
+    ;(
+      provider as unknown as {
+        browserClient: { embeddings: { create: jest.Mock } }
+      }
+    ).browserClient = {
+      embeddings: { create: jest.fn() },
+    }
+    ;(
+      provider as unknown as {
+        obsidianClient: { embeddings: { create: jest.Mock } }
+      }
+    ).obsidianClient = {
+      embeddings: { create: jest.fn() },
+    }
+
+    await expect(
+      provider.getEmbedding('text-embedding-3-small', 'hello', {
+        dimensions: 1536,
+      }),
+    ).resolves.toEqual([0.1, 0.2, 0.3])
+
+    expect(nodeCreate).toHaveBeenNthCalledWith(1, {
+      model: 'text-embedding-3-small',
+      input: 'hello',
+      encoding_format: 'float',
+      dimensions: 1536,
+    })
+    expect(nodeCreate).toHaveBeenNthCalledWith(2, {
+      model: 'text-embedding-3-small',
+      input: 'hello',
+      encoding_format: 'float',
+    })
+  })
+
+  it('rethrows non-dimension errors without retrying', async () => {
+    const provider = createProvider()
+    const nodeCreate = jest
+      .fn()
+      .mockRejectedValueOnce(apiError(401, 'invalid api key'))
+
+    ;(
+      provider as unknown as {
+        nodeClient: { embeddings: { create: typeof nodeCreate } }
+        browserClient: { embeddings: { create: jest.Mock } }
+        obsidianClient: { embeddings: { create: jest.Mock } }
+      }
+    ).nodeClient = {
+      embeddings: { create: nodeCreate },
+    }
+    ;(
+      provider as unknown as {
+        browserClient: { embeddings: { create: jest.Mock } }
+      }
+    ).browserClient = {
+      embeddings: { create: jest.fn() },
+    }
+    ;(
+      provider as unknown as {
+        obsidianClient: { embeddings: { create: jest.Mock } }
+      }
+    ).obsidianClient = {
+      embeddings: { create: jest.fn() },
+    }
+
+    await expect(
+      provider.getEmbedding('text-embedding-3-small', 'hello', {
+        dimensions: 1536,
+      }),
+    ).rejects.toThrow('invalid api key')
+    expect(nodeCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares dimensions fallback knowledge across provider instances', async () => {
+    const firstProvider = createProvider()
+    const firstNodeCreate = jest
+      .fn()
+      .mockRejectedValueOnce(apiError(422, 'provider rejected dimensions'))
+      .mockResolvedValueOnce({
+        data: [{ embedding: [0.1, 0.2, 0.3] }],
+      })
+
+    ;(
+      firstProvider as unknown as {
+        nodeClient: { embeddings: { create: typeof firstNodeCreate } }
+        browserClient: { embeddings: { create: jest.Mock } }
+        obsidianClient: { embeddings: { create: jest.Mock } }
+      }
+    ).nodeClient = {
+      embeddings: { create: firstNodeCreate },
+    }
+    ;(
+      firstProvider as unknown as {
+        browserClient: { embeddings: { create: jest.Mock } }
+      }
+    ).browserClient = {
+      embeddings: { create: jest.fn() },
+    }
+    ;(
+      firstProvider as unknown as {
+        obsidianClient: { embeddings: { create: jest.Mock } }
+      }
+    ).obsidianClient = {
+      embeddings: { create: jest.fn() },
+    }
+
+    await expect(
+      firstProvider.getEmbedding('text-embedding-3-small', 'hello', {
+        dimensions: 1536,
+      }),
+    ).resolves.toEqual([0.1, 0.2, 0.3])
+
+    const secondProvider = createProvider()
+    const secondNodeCreate = jest.fn().mockResolvedValue({
+      data: [{ embedding: [0.4, 0.5, 0.6] }],
+    })
+
+    ;(
+      secondProvider as unknown as {
+        nodeClient: { embeddings: { create: typeof secondNodeCreate } }
+        browserClient: { embeddings: { create: jest.Mock } }
+        obsidianClient: { embeddings: { create: jest.Mock } }
+      }
+    ).nodeClient = {
+      embeddings: { create: secondNodeCreate },
+    }
+    ;(
+      secondProvider as unknown as {
+        browserClient: { embeddings: { create: jest.Mock } }
+      }
+    ).browserClient = {
+      embeddings: { create: jest.fn() },
+    }
+    ;(
+      secondProvider as unknown as {
+        obsidianClient: { embeddings: { create: jest.Mock } }
+      }
+    ).obsidianClient = {
+      embeddings: { create: jest.fn() },
+    }
+
+    await expect(
+      secondProvider.getEmbedding('text-embedding-3-small', 'hello', {
+        dimensions: 1536,
+      }),
+    ).resolves.toEqual([0.4, 0.5, 0.6])
+
+    expect(secondNodeCreate).toHaveBeenCalledTimes(1)
+    expect(secondNodeCreate).toHaveBeenCalledWith({
+      model: 'text-embedding-3-small',
+      input: 'hello',
+      encoding_format: 'float',
+    })
+  })
+})

--- a/src/core/llm/openaiCompatibleProvider.ts
+++ b/src/core/llm/openaiCompatibleProvider.ts
@@ -57,7 +57,12 @@ type OpenAICompatibleStreamingRequest = LLMRequestStreaming &
   Record<string, unknown> &
   OpenAICompatibleExtras
 
+const isEmbeddingDimensionRejectionError = (error: unknown): boolean =>
+  error instanceof OpenAI.APIError &&
+  (error.status === 400 || error.status === 422)
+
 export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
+  private static embeddingDimensionsSupportCache = new Map<string, boolean>()
   private adapter: OpenAIMessageAdapter
   private browserClient: OpenAI
   private obsidianClient: OpenAI
@@ -66,6 +71,10 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
   private requestTransportMode: RequestTransportMode
   private requestTransportMemoryKey: string
   private onAutoPromoteTransportMode?: (mode: AutoPromotedTransportMode) => void
+
+  static clearEmbeddingDimensionsSupportCache() {
+    OpenAICompatibleProvider.embeddingDimensionsSupportCache.clear()
+  }
 
   private promoteTransportMode = (mode: AutoPromotedTransportMode) => {
     if (this.requestTransportMode === mode) {
@@ -127,6 +136,17 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
       ...clientOptions,
       fetch: createDesktopNodeFetch(),
     })
+  }
+
+  private getEmbeddingDimensionsSupportKey(model: string, dimensions?: number) {
+    return [
+      this.provider.apiType,
+      this.provider.presetType,
+      this.provider.id,
+      this.resolvedBaseUrl ?? '',
+      model,
+      dimensions ?? 'default',
+    ].join(':')
   }
 
   async generateResponse(
@@ -354,35 +374,73 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
     text: string,
     options?: { dimensions?: number },
   ): Promise<number[]> {
-    const dimensionsParam = options?.dimensions
-      ? { dimensions: options.dimensions }
-      : {}
-    const embedding = await runWithRequestTransport({
-      mode: this.requestTransportMode,
-      memoryKey: this.requestTransportMemoryKey,
-      onAutoPromoteTransportMode: this.promoteTransportMode,
-      runBrowser: () =>
-        this.browserClient.embeddings.create({
-          model: model,
-          input: text,
-          encoding_format: 'float',
-          ...dimensionsParam,
-        }),
-      runObsidian: () =>
-        this.obsidianClient.embeddings.create({
-          model: model,
-          input: text,
-          encoding_format: 'float',
-          ...dimensionsParam,
-        }),
-      runNode: () =>
-        this.nodeClient.embeddings.create({
-          model: model,
-          input: text,
-          encoding_format: 'float',
-          ...dimensionsParam,
-        }),
-    })
+    const runEmbedding = async (dimensions?: number) =>
+      runWithRequestTransport({
+        mode: this.requestTransportMode,
+        memoryKey: this.requestTransportMemoryKey,
+        onAutoPromoteTransportMode: this.promoteTransportMode,
+        runBrowser: () =>
+          this.browserClient.embeddings.create({
+            model,
+            input: text,
+            encoding_format: 'float',
+            ...(dimensions ? { dimensions } : {}),
+          }),
+        runObsidian: () =>
+          this.obsidianClient.embeddings.create({
+            model,
+            input: text,
+            encoding_format: 'float',
+            ...(dimensions ? { dimensions } : {}),
+          }),
+        runNode: () =>
+          this.nodeClient.embeddings.create({
+            model,
+            input: text,
+            encoding_format: 'float',
+            ...(dimensions ? { dimensions } : {}),
+          }),
+      })
+
+    const dimensions = options?.dimensions
+    const supportKey = this.getEmbeddingDimensionsSupportKey(model, dimensions)
+    let embedding
+
+    if (!dimensions) {
+      embedding = await runEmbedding()
+      return extractEmbeddingVector(embedding)
+    }
+
+    const knownSupport =
+      OpenAICompatibleProvider.embeddingDimensionsSupportCache.get(supportKey)
+
+    if (knownSupport === false) {
+      embedding = await runEmbedding()
+      return extractEmbeddingVector(embedding)
+    }
+
+    try {
+      embedding = await runEmbedding(dimensions)
+      OpenAICompatibleProvider.embeddingDimensionsSupportCache.set(
+        supportKey,
+        true,
+      )
+    } catch (errorWithDimensions) {
+      if (!isEmbeddingDimensionRejectionError(errorWithDimensions)) {
+        throw errorWithDimensions
+      }
+
+      try {
+        embedding = await runEmbedding()
+        OpenAICompatibleProvider.embeddingDimensionsSupportCache.set(
+          supportKey,
+          false,
+        )
+      } catch {
+        throw errorWithDimensions
+      }
+    }
+
     return extractEmbeddingVector(embedding)
   }
 }

--- a/src/core/mcp/localFileTools.test.ts
+++ b/src/core/mcp/localFileTools.test.ts
@@ -953,6 +953,77 @@ describe('local fs tool action helpers', () => {
     })
   })
 
+  it('falls back to keyword results when hybrid rag query fails', async () => {
+    const warnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+    const root = Object.assign(new TFolder(), { path: '' })
+    const file = Object.assign(new TFile(), {
+      path: 'workflow.md',
+      basename: 'workflow',
+      stat: { size: 200 },
+    })
+
+    try {
+      const result = await callLocalFileTool({
+        app: {
+          vault: {
+            getRoot: jest.fn().mockReturnValue(root),
+            getFiles: jest.fn().mockReturnValue([file]),
+            getAllLoadedFiles: jest.fn().mockReturnValue([root]),
+            getMarkdownFiles: jest.fn().mockReturnValue([file]),
+            read: jest.fn().mockResolvedValue('workflow fallback content'),
+          },
+        } as unknown as App,
+        settings: {
+          ragOptions: {
+            enabled: true,
+            limit: 10,
+          },
+          embeddingModelId: 'test-embedding',
+        } as unknown as SmartComposerSettings,
+        getRagEngine: async () =>
+          ({
+            processQuery: jest
+              .fn()
+              .mockRejectedValue(new Error('400 status code (no body)')),
+          }) as unknown as RAGEngine,
+        toolName: 'fs_search',
+        args: {
+          mode: 'hybrid',
+          query: 'workflow',
+          maxResults: 10,
+        },
+      })
+
+      expect(result.status).toBe(ToolCallResponseStatus.Success)
+      if (result.status !== ToolCallResponseStatus.Success) {
+        throw new Error('expected success')
+      }
+
+      expect(JSON.parse(result.text)).toMatchObject({
+        tool: 'fs_search',
+        requestedMode: 'hybrid',
+        effectiveMode: 'keyword',
+        fallbackReason:
+          'Semantic search failed: 400 status code (no body). Fell back to keyword search.',
+        results: [
+          {
+            kind: 'content_group',
+            path: 'workflow.md',
+            source: 'keyword',
+          },
+        ],
+      })
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[YOLO] fs_search hybrid semantic search failed; falling back to keyword search.',
+        { error: expect.any(Error) },
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
   it('supports context prune tool results for any successful text tool output', async () => {
     const result = await callLocalFileTool({
       app: {

--- a/src/core/mcp/localFileTools.ts
+++ b/src/core/mcp/localFileTools.ts
@@ -3029,12 +3029,53 @@ export async function callLocalFileTool({
           RAG_FETCH_LIMIT_MAX,
         )
 
-        const ragRows = await ragEngine.processQuery({
-          query,
-          scope: ragScope,
-          minSimilarity: ragMinSimilarity,
-          limit: effectiveRagLimit,
-        })
+        let ragRows: Awaited<ReturnType<RAGEngine['processQuery']>>
+        try {
+          ragRows = await ragEngine.processQuery({
+            query,
+            scope: ragScope,
+            minSimilarity: ragMinSimilarity,
+            limit: effectiveRagLimit,
+          })
+        } catch (error) {
+          if (effectiveMode !== 'hybrid') {
+            throw error
+          }
+
+          console.warn(
+            '[YOLO] fs_search hybrid semantic search failed; falling back to keyword search.',
+            { error },
+          )
+
+          const keywordLegacy = await collectKeywordFsSearchResults({
+            app,
+            scopeTarget,
+            scope: 'content',
+            query,
+            maxResults,
+            caseSensitive,
+            signal,
+          })
+          if (signal?.aborted) {
+            return { status: ToolCallResponseStatus.Aborted }
+          }
+          const results = legacyFsSearchItemsToSuper(keywordLegacy, 'keyword')
+          return {
+            status: ToolCallResponseStatus.Success,
+            text: formatJsonResult({
+              tool: 'fs_search',
+              requestedMode,
+              effectiveMode: 'keyword',
+              fallbackReason: `Semantic search failed: ${
+                error instanceof Error ? error.message : String(error)
+              }. Fell back to keyword search.`,
+              scope: 'content',
+              query,
+              path: scopeTarget.normalizedPath,
+              results: aggregateSearchResults({ results, maxResults }),
+            }),
+          }
+        }
 
         const ragMapped = applyWorkspaceScopeFilter(
           mapRagRowsToSuper(ragRows as RagEmbeddingRow[], 'rag'),

--- a/src/core/rag/embedding.test.ts
+++ b/src/core/rag/embedding.test.ts
@@ -1,0 +1,67 @@
+import { getEmbeddingModelClient } from './embedding'
+
+jest.mock('../llm/manager', () => ({
+  getProviderClient: jest.fn(),
+}))
+
+import { getProviderClient } from '../llm/manager'
+
+describe('getEmbeddingModelClient', () => {
+  const settings = {
+    providers: [{ id: 'provider-a' }],
+    embeddingModels: [
+      {
+        id: 'embed-a',
+        providerId: 'provider-a',
+        model: 'text-embedding-3-small',
+        dimension: 1536,
+      },
+    ],
+  } as never
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('passes the configured dimensions to the provider embedding call', async () => {
+    const getEmbedding = jest.fn().mockResolvedValue(new Array(1536).fill(0))
+    ;(getProviderClient as jest.Mock).mockReturnValue({
+      getEmbedding,
+    })
+
+    const client = getEmbeddingModelClient({
+      settings,
+      embeddingModelId: 'embed-a',
+    })
+
+    await client.getEmbedding('hello')
+
+    expect(getEmbedding).toHaveBeenCalledWith(
+      'text-embedding-3-small',
+      'hello',
+      { dimensions: 1536 },
+    )
+  })
+
+  it('keeps the dimension mismatch guard after provider returns a fallback-sized vector', async () => {
+    const getEmbedding = jest.fn().mockResolvedValue([0.1, 0.2, 0.3])
+    ;(getProviderClient as jest.Mock).mockReturnValue({
+      getEmbedding,
+    })
+
+    const client = getEmbeddingModelClient({
+      settings,
+      embeddingModelId: 'embed-a',
+    })
+
+    await expect(client.getEmbedding('hello')).rejects.toThrow(
+      'returned 3-dimensional vector, but it is configured as 1536-dimensional',
+    )
+    expect(getEmbedding).toHaveBeenNthCalledWith(
+      1,
+      'text-embedding-3-small',
+      'hello',
+      { dimensions: 1536 },
+    )
+  })
+})


### PR DESCRIPTION
## Background

This is the embedding/fs_search split from #275, separated from the MCP transport fix for independent review.

## Changes

- Detect providers that reject the embeddings `dimensions` parameter and retry without dimensions.
- Cache dimensions support by provider/model/dimensions to avoid repeated rejected requests.
- Restrict the retry to 400/422 API errors so auth, rate-limit, server, and network failures are not masked.
- Allow `fs_search` hybrid mode to fall back to keyword search when the semantic query fails.
- Include a `fallbackReason` in the tool response and log a warning when hybrid search degrades.
- Add focused tests for embedding fallback/cache behavior, RAG embedding handling, and hybrid keyword fallback.

## Verification

- `npm test -- src/core/llm/openaiCompatibleProvider.fallback.test.ts src/core/mcp/localFileTools.test.ts src/core/rag/embedding.test.ts`
- `npm run build`
