### PR TITLE
fix(ui): drop custom toggle override so switches use native Obsidian …

### DIFF
--- a/src/styles/chat/input.css
+++ b/src/styles/chat/input.css
@@ -1018,46 +1018,16 @@
   height: 18px;
 }
 
-/* 改进开关控件样式 */
+/* 与 ObsidianToggle 组件配套的外层容器 hook：
+   唯一作用是给 `.smtcmp-composer-option-control` 里右对齐规则提供命中目标
+   （见本文件 949 行附近的 margin-left: auto）。
+   以前这里有一整段覆写，把原本 opacity:0 的 <input> 强行画成紫色轨道 + 自定义白点，
+   导致和 Obsidian 原生 .checkbox-container::after 叠在一起出现白点凸出/偏下，
+   已移除。switch 外观完全沿用 Obsidian 原生实现。 */
 .smtcmp-checkbox-container {
   position: relative;
   display: inline-flex;
-  align-items: center;
   gap: var(--size-2-2);
-}
-
-.smtcmp-checkbox-container input[type='checkbox'] {
-  width: 44px;
-  height: 24px;
-  appearance: none;
-  background: var(--background-modifier-border);
-  border-radius: 12px;
-  position: relative;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  border: 2px solid transparent;
-}
-
-.smtcmp-checkbox-container input[type='checkbox']:checked {
-  background: var(--interactive-accent);
-  border-color: var(--interactive-accent);
-}
-
-.smtcmp-checkbox-container input[type='checkbox']::before {
-  content: '';
-  position: absolute;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: white;
-  top: 1px;
-  left: 1px;
-  transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-}
-
-.smtcmp-checkbox-container input[type='checkbox']:checked::before {
-  transform: translateX(20px);
 }
 
 /* 优先参考目录样式优化 */

--- a/styles.css
+++ b/styles.css
@@ -2343,15 +2343,15 @@
   white-space: pre-wrap;
 }
 
-.smtcmp-mcp-tool-description
-  > button.smtcmp-mcp-tool-description-toggle {
+.smtcmp-mcp-tool-description > button.smtcmp-mcp-tool-description-toggle {
   position: absolute;
   top: 0;
   right: 0;
 }
 
 .smtcmp-mcp-tool-description
-  > button.smtcmp-mcp-tool-description-toggle ~ .smtcmp-mcp-tool-description-text {
+  > button.smtcmp-mcp-tool-description-toggle
+  ~ .smtcmp-mcp-tool-description-text {
   padding-right: var(--size-4-6);
 }
 
@@ -6935,47 +6935,17 @@ button.smtcmp-agent-chip--more:hover {
   height: 18px;
 }
 
-/* 改进开关控件样式 */
+/* 与 ObsidianToggle 组件配套的外层容器 hook：
+   唯一作用是给 `.smtcmp-composer-option-control` 里右对齐规则提供命中目标
+   （见本文件 949 行附近的 margin-left: auto）。
+   以前这里有一整段覆写，把原本 opacity:0 的 <input> 强行画成紫色轨道 + 自定义白点，
+   导致和 Obsidian 原生 .checkbox-container::after 叠在一起出现白点凸出/偏下，
+   已移除。switch 外观完全沿用 Obsidian 原生实现。 */
 
 .smtcmp-checkbox-container {
   position: relative;
   display: inline-flex;
-  align-items: center;
   gap: var(--size-2-2);
-}
-
-.smtcmp-checkbox-container input[type='checkbox'] {
-  width: 44px;
-  height: 24px;
-  appearance: none;
-  background: var(--background-modifier-border);
-  border-radius: 12px;
-  position: relative;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  border: 2px solid transparent;
-}
-
-.smtcmp-checkbox-container input[type='checkbox']:checked {
-  background: var(--interactive-accent);
-  border-color: var(--interactive-accent);
-}
-
-.smtcmp-checkbox-container input[type='checkbox']::before {
-  content: '';
-  position: absolute;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: white;
-  top: 1px;
-  left: 1px;
-  transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-}
-
-.smtcmp-checkbox-container input[type='checkbox']:checked::before {
-  transform: translateX(20px);
 }
 
 /* 优先参考目录样式优化 */


### PR DESCRIPTION
## Description

The `.smtcmp-checkbox-container` styles were repainting the hidden
`<input>` as a 44×24 purple track with a custom `::before` thumb. Those
visuals stacked on top of Obsidian's native `.checkbox-container::after`
knob, which made the white thumb visibly protrude / drift downward in
toggles across the Composer panel, plugin Settings (RAG, Continuation,
Providers, Agents, Notifications, etc.).

**Root cause**
- Introduced in 189d2200 ("Composer 面板 ui 设计大修").
- Renamed from `.checkbox-container` to `.smtcmp-checkbox-container` in
  7c5b5d0d per upstream review to avoid polluting the core class, but
  the underlying visual conflict with the native `::after` knob was
  never addressed — the faux toggle kept stacking on top of the native one.

**Fix**
- Remove the repainted track / custom `::before` thumb entirely.
- Keep `.smtcmp-checkbox-container` as a layout hook so the existing
  `margin-left: auto` right-align rule in the Composer panel still works.
- `ObsidianToggle.tsx` stays unchanged.

**Result**
Toggles revert to Obsidian's native appearance, behave consistently with
every other native toggle, follow theme / accent variables, and work on
mobile sizes.

### Screenshots
<img width="594" height="275" alt="Xnip2026-05-08_10-20-52" src="https://github.com/user-attachments/assets/9e4d99bf-1fe0-41a8-9c2e-43e0fa596191" />
<img width="563" height="271" alt="Xnip2026-05-08_10-22-39" src="https://github.com/user-attachments/assets/5c124ec7-e5ec-42df-a2bc-062a70db03af" />




## Checklist before requesting a review
- [x] I have reviewed the guidelines for contributing to this repository.
- [x] I have performed a self-review of my code.
- [x] I have performed a code linting check and type check (`npm run type:check` passes; prettier passes on the files I edited; `npm run lint:check` reports only pre-existing warnings unrelated to this PR).
- [x] I have run the test suite (`npm test` — 135 suites / 833 tests all pass).
- [x] I have tested the functionality manually.
- [x] This PR changes CSS: I edited `src/styles/chat/input.css`, rebuilt `styles.css` via `npm run styles:build`, and verified no unintended style regressions.
