### PR TITLE
使用 openai-compatible preset 时根据 base URL 自动检测并选择正确的 MessageAdapter

### DIFF
--- a/src/core/llm/baseUrlDetection.test.ts
+++ b/src/core/llm/baseUrlDetection.test.ts
@@ -1,0 +1,156 @@
+import {
+  isDeepSeekBaseUrl,
+  isMistralBaseUrl,
+  isMoonshotBaseUrl,
+  isPerplexityBaseUrl,
+  resolveAdapterForBaseUrl,
+} from './baseUrlDetection'
+import { DeepSeekMessageAdapter } from './deepseekMessageAdapter'
+import { KimiMessageAdapter } from './kimiMessageAdapter'
+import { MistralMessageAdapter } from './mistralMessageAdapter'
+import { OpenAIMessageAdapter } from './openaiMessageAdapter'
+import { PerplexityMessageAdapter } from './perplexityMessageAdapter'
+
+describe('isDeepSeekBaseUrl', () => {
+  it('returns true for api.deepseek.com', () => {
+    expect(isDeepSeekBaseUrl('https://api.deepseek.com')).toBe(true)
+    expect(isDeepSeekBaseUrl('https://api.deepseek.com/v1')).toBe(true)
+  })
+
+  it('returns true for subdomains of deepseek.com', () => {
+    expect(isDeepSeekBaseUrl('https://proxy.deepseek.com')).toBe(true)
+  })
+
+  it('returns false for undefined or empty', () => {
+    expect(isDeepSeekBaseUrl(undefined)).toBe(false)
+    expect(isDeepSeekBaseUrl('')).toBe(false)
+  })
+
+  it('returns false for unrelated URLs', () => {
+    expect(isDeepSeekBaseUrl('https://api.openai.com/v1')).toBe(false)
+    expect(isDeepSeekBaseUrl('https://example.com')).toBe(false)
+  })
+
+  it('returns false when deepseek.com appears only in path or query', () => {
+    expect(isDeepSeekBaseUrl('https://evil.com/redirect?to=deepseek.com')).toBe(
+      false,
+    )
+    expect(isDeepSeekBaseUrl('https://evil.com/deepseek.com/path')).toBe(false)
+  })
+})
+
+describe('isMoonshotBaseUrl', () => {
+  it('returns true for api.moonshot.cn', () => {
+    expect(isMoonshotBaseUrl('https://api.moonshot.cn')).toBe(true)
+    expect(isMoonshotBaseUrl('https://api.moonshot.cn/v1')).toBe(true)
+  })
+
+  it('returns true for subdomains of moonshot.cn', () => {
+    expect(isMoonshotBaseUrl('https://proxy.moonshot.cn')).toBe(true)
+  })
+
+  it('returns false for undefined or empty', () => {
+    expect(isMoonshotBaseUrl(undefined)).toBe(false)
+    expect(isMoonshotBaseUrl('')).toBe(false)
+  })
+
+  it('returns false for unrelated URLs', () => {
+    expect(isMoonshotBaseUrl('https://api.openai.com/v1')).toBe(false)
+  })
+
+  it('returns false when moonshot.cn appears only in path or query', () => {
+    expect(isMoonshotBaseUrl('https://evil.com/redirect?to=moonshot.cn')).toBe(
+      false,
+    )
+  })
+})
+
+describe('isMistralBaseUrl', () => {
+  it('returns true for api.mistral.ai', () => {
+    expect(isMistralBaseUrl('https://api.mistral.ai')).toBe(true)
+    expect(isMistralBaseUrl('https://api.mistral.ai/v1')).toBe(true)
+  })
+
+  it('returns true for subdomains of mistral.ai', () => {
+    expect(isMistralBaseUrl('https://proxy.mistral.ai')).toBe(true)
+  })
+
+  it('returns false for undefined or empty', () => {
+    expect(isMistralBaseUrl(undefined)).toBe(false)
+    expect(isMistralBaseUrl('')).toBe(false)
+  })
+
+  it('returns false for unrelated URLs', () => {
+    expect(isMistralBaseUrl('https://api.openai.com/v1')).toBe(false)
+  })
+
+  it('returns false when mistral.ai appears only in path or query', () => {
+    expect(isMistralBaseUrl('https://evil.com/redirect?to=mistral.ai')).toBe(
+      false,
+    )
+  })
+})
+
+describe('isPerplexityBaseUrl', () => {
+  it('returns true for api.perplexity.ai', () => {
+    expect(isPerplexityBaseUrl('https://api.perplexity.ai')).toBe(true)
+    expect(isPerplexityBaseUrl('https://api.perplexity.ai/v1')).toBe(true)
+  })
+
+  it('returns true for subdomains of perplexity.ai', () => {
+    expect(isPerplexityBaseUrl('https://proxy.perplexity.ai')).toBe(true)
+  })
+
+  it('returns false for undefined or empty', () => {
+    expect(isPerplexityBaseUrl(undefined)).toBe(false)
+    expect(isPerplexityBaseUrl('')).toBe(false)
+  })
+
+  it('returns false for unrelated URLs', () => {
+    expect(isPerplexityBaseUrl('https://api.openai.com/v1')).toBe(false)
+  })
+
+  it('returns false when perplexity.ai appears only in path or query', () => {
+    expect(
+      isPerplexityBaseUrl('https://evil.com/redirect?to=perplexity.ai'),
+    ).toBe(false)
+  })
+})
+
+describe('resolveAdapterForBaseUrl', () => {
+  it('returns DeepSeekMessageAdapter for DeepSeek URLs', () => {
+    expect(resolveAdapterForBaseUrl('https://api.deepseek.com')).toBeInstanceOf(
+      DeepSeekMessageAdapter,
+    )
+  })
+
+  it('returns KimiMessageAdapter for Moonshot URLs', () => {
+    expect(
+      resolveAdapterForBaseUrl('https://api.moonshot.cn/v1'),
+    ).toBeInstanceOf(KimiMessageAdapter)
+  })
+
+  it('returns MistralMessageAdapter for Mistral URLs', () => {
+    expect(
+      resolveAdapterForBaseUrl('https://api.mistral.ai/v1'),
+    ).toBeInstanceOf(MistralMessageAdapter)
+  })
+
+  it('returns PerplexityMessageAdapter for Perplexity URLs', () => {
+    expect(
+      resolveAdapterForBaseUrl('https://api.perplexity.ai'),
+    ).toBeInstanceOf(PerplexityMessageAdapter)
+  })
+
+  it('returns OpenAIMessageAdapter for unknown URLs', () => {
+    expect(
+      resolveAdapterForBaseUrl('https://api.openai.com/v1'),
+    ).toBeInstanceOf(OpenAIMessageAdapter)
+  })
+
+  it('returns OpenAIMessageAdapter for undefined', () => {
+    expect(resolveAdapterForBaseUrl(undefined)).toBeInstanceOf(
+      OpenAIMessageAdapter,
+    )
+  })
+})

--- a/src/core/llm/baseUrlDetection.ts
+++ b/src/core/llm/baseUrlDetection.ts
@@ -18,7 +18,7 @@ export const isDeepSeekBaseUrl = (baseUrl: string | undefined): boolean => {
     const host = new URL(baseUrl).hostname.toLowerCase()
     return host === 'api.deepseek.com' || host.endsWith('.deepseek.com')
   } catch {
-    return /\bdeepseek\.com\b/i.test(baseUrl)
+    return /(?:^|[./])deepseek\.com(?:[:/]|$)/i.test(baseUrl)
   }
 }
 
@@ -34,7 +34,7 @@ export const isMoonshotBaseUrl = (baseUrl: string | undefined): boolean => {
     const host = new URL(baseUrl).hostname.toLowerCase()
     return host === 'api.moonshot.cn' || host.endsWith('.moonshot.cn')
   } catch {
-    return /\bmoonshot\.cn\b/i.test(baseUrl)
+    return /(?:^|[./])moonshot\.cn(?:[:/]|$)/i.test(baseUrl)
   }
 }
 
@@ -49,7 +49,7 @@ export const isMistralBaseUrl = (baseUrl: string | undefined): boolean => {
     const host = new URL(baseUrl).hostname.toLowerCase()
     return host === 'api.mistral.ai' || host.endsWith('.mistral.ai')
   } catch {
-    return /\bmistral\.ai\b/i.test(baseUrl)
+    return /(?:^|[./])mistral\.ai(?:[:/]|$)/i.test(baseUrl)
   }
 }
 
@@ -64,14 +64,16 @@ export const isPerplexityBaseUrl = (baseUrl: string | undefined): boolean => {
     const host = new URL(baseUrl).hostname.toLowerCase()
     return host === 'api.perplexity.ai' || host.endsWith('.perplexity.ai')
   } catch {
-    return /\bperplexity\.ai\b/i.test(baseUrl)
+    return /(?:^|[./])perplexity\.ai(?:[:/]|$)/i.test(baseUrl)
   }
 }
 
 /**
- * Resolves the appropriate MessageAdapter based on the base URL when no explicit
- * adapter is provided. This allows users who configure providers via the generic
- * `openai-compatible` preset to still get correct behavior for known services.
+ * Resolves the appropriate MessageAdapter based on the base URL. Used by
+ * `OpenAICompatibleProvider` when no explicit adapter is passed via the
+ * constructor `options.adapter` parameter. This allows users who configure
+ * providers via the generic `openai-compatible` preset to still get correct
+ * behavior for known services.
  */
 export const resolveAdapterForBaseUrl = (
   baseUrl: string | undefined,

--- a/src/core/llm/baseUrlDetection.ts
+++ b/src/core/llm/baseUrlDetection.ts
@@ -1,0 +1,84 @@
+import { DeepSeekMessageAdapter } from './deepseekMessageAdapter'
+import { KimiMessageAdapter } from './kimiMessageAdapter'
+import { MistralMessageAdapter } from './mistralMessageAdapter'
+import { OpenAIMessageAdapter } from './openaiMessageAdapter'
+import { PerplexityMessageAdapter } from './perplexityMessageAdapter'
+
+/**
+ * Detects DeepSeek-compatible gateways by base URL. DeepSeek's thinking mode
+ * returns responses with a non-standard `reasoning_content` field and requires
+ * that field to be echoed back on assistant tool-call messages. Generic
+ * OpenAIMessageAdapter neither reads nor forwards it, so when users configure
+ * DeepSeek via the generic `openai-compatible` preset we silently swap in the
+ * DeepSeek-aware adapter to keep multi-turn tool calls working.
+ */
+export const isDeepSeekBaseUrl = (baseUrl: string | undefined): boolean => {
+  if (!baseUrl) return false
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase()
+    return host === 'api.deepseek.com' || host.endsWith('.deepseek.com')
+  } catch {
+    return /\bdeepseek\.com\b/i.test(baseUrl)
+  }
+}
+
+/**
+ * Detects Moonshot/Kimi gateways by base URL. Kimi's thinking models require
+ * `reasoning_content` on assistant tool-call messages (similar to DeepSeek) and
+ * reject empty-string `content` on tool-call messages. Without the KimiMessageAdapter,
+ * multi-turn tool calls with thinking models fail with 400 errors.
+ */
+export const isMoonshotBaseUrl = (baseUrl: string | undefined): boolean => {
+  if (!baseUrl) return false
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase()
+    return host === 'api.moonshot.cn' || host.endsWith('.moonshot.cn')
+  } catch {
+    return /\bmoonshot\.cn\b/i.test(baseUrl)
+  }
+}
+
+/**
+ * Detects Mistral gateways by base URL. Mistral's API does not support the
+ * `stream_options` parameter; including it causes streaming requests to fail.
+ * The MistralMessageAdapter omits this field to prevent errors.
+ */
+export const isMistralBaseUrl = (baseUrl: string | undefined): boolean => {
+  if (!baseUrl) return false
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase()
+    return host === 'api.mistral.ai' || host.endsWith('.mistral.ai')
+  } catch {
+    return /\bmistral\.ai\b/i.test(baseUrl)
+  }
+}
+
+/**
+ * Detects Perplexity gateways by base URL. Perplexity returns citations in a
+ * non-standard top-level `citations` array. The PerplexityMessageAdapter maps
+ * these into the unified `annotations` format so the UI can display sources.
+ */
+export const isPerplexityBaseUrl = (baseUrl: string | undefined): boolean => {
+  if (!baseUrl) return false
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase()
+    return host === 'api.perplexity.ai' || host.endsWith('.perplexity.ai')
+  } catch {
+    return /\bperplexity\.ai\b/i.test(baseUrl)
+  }
+}
+
+/**
+ * Resolves the appropriate MessageAdapter based on the base URL when no explicit
+ * adapter is provided. This allows users who configure providers via the generic
+ * `openai-compatible` preset to still get correct behavior for known services.
+ */
+export const resolveAdapterForBaseUrl = (
+  baseUrl: string | undefined,
+): OpenAIMessageAdapter => {
+  if (isDeepSeekBaseUrl(baseUrl)) return new DeepSeekMessageAdapter()
+  if (isMoonshotBaseUrl(baseUrl)) return new KimiMessageAdapter()
+  if (isMistralBaseUrl(baseUrl)) return new MistralMessageAdapter()
+  if (isPerplexityBaseUrl(baseUrl)) return new PerplexityMessageAdapter()
+  return new OpenAIMessageAdapter()
+}

--- a/src/core/llm/openaiCompatibleProvider.ts
+++ b/src/core/llm/openaiCompatibleProvider.ts
@@ -20,6 +20,7 @@ import { toProviderHeadersRecord } from '../../utils/llm/provider-headers'
 import { formatMessages } from '../../utils/llm/request'
 
 import { BaseLLMProvider } from './base'
+import { resolveAdapterForBaseUrl } from './baseUrlDetection'
 import { extractEmbeddingVector } from './embedding-utils'
 import { LLMBaseUrlNotSetException } from './exception'
 import { NoStainlessOpenAI } from './NoStainlessOpenAI'
@@ -90,8 +91,9 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<LLMProvider> {
   ) {
     super(provider)
     this.onAutoPromoteTransportMode = options?.onAutoPromoteTransportMode
-    this.adapter = options?.adapter ?? new OpenAIMessageAdapter()
     this.resolvedBaseUrl = resolveProviderBaseUrl(provider)
+    this.adapter =
+      options?.adapter ?? resolveAdapterForBaseUrl(this.resolvedBaseUrl)
     const defaultHeaders = toProviderHeadersRecord(provider.customHeaders)
     this.requestTransportMemoryKey = createRequestTransportMemoryKey({
       providerType: provider.presetType,

--- a/src/utils/chat/requestContextBuilder.test.ts
+++ b/src/utils/chat/requestContextBuilder.test.ts
@@ -984,7 +984,9 @@ describe('RequestContextBuilder generateRequestMessages', () => {
     const builder = new RequestContextBuilder(app as never, settings)
 
     // Build 34 messages (17 user + 17 assistant alternating), first user is the one we track
-    const historyMessages: Parameters<typeof builder.generateRequestMessages>[0]['messages'] = []
+    const historyMessages: Parameters<
+      typeof builder.generateRequestMessages
+    >[0]['messages'] = []
     for (let i = 0; i < 34; i++) {
       if (i % 2 === 0) {
         historyMessages.push({


### PR DESCRIPTION
## 概述

当用户通过通用的 `openai-compatible` preset 配置 Provider，但 base URL 指向已知有特殊 API 行为的服务商时，系统现在会根据 base URL 自动选择正确的 MessageAdapter，避免请求失败或功能缺失。

## 优化必要性

不同 LLM 服务商虽然都兼容 OpenAI Chat Completions API，但各自存在不兼容的怪癖：

| 服务商 | 怪癖 | 不使用正确 adapter 的后果 |
|--------|------|--------------------------|
| DeepSeek | assistant tool-call 消息必须携带 `reasoning_content` 字段 | 多轮 tool call 直接 400 报错 |
| Moonshot/Kimi | 同 DeepSeek + 拒绝空字符串 `content` 的 tool-call 消息 | 思维模型多轮对话 400 报错 |
| Mistral | 不支持 `stream_options` 参数 | 所有流式请求直接报错 |
| Perplexity | 引用来源通过非标准 `citations` 字段返回 | 引用信息丢失，UI 不显示来源 |

用户容易误选 `openai-compatible` 的原因：
1. 不了解各 preset 之间的区别，看到"通用兼容"就选了
2. 通过第三方代理/网关访问这些服务，不确定该选哪个 preset
3. 从其他工具迁移配置时习惯性选通用选项
## 截图
<img width="383" height="185" alt="Xnip2026-05-08_19-00-37" src="https://github.com/user-attachments/assets/581b585b-8345-4512-8cc8-0df27ae0d201" />

## 改动内容

1. **新增 `src/core/llm/baseUrlDetection.ts`** — 将 base URL 检测逻辑抽取为独立模块：
   - `isDeepSeekBaseUrl()` — 检测 `*.deepseek.com`
   - `isMoonshotBaseUrl()` — 检测 `*.moonshot.cn`
   - `isMistralBaseUrl()` — 检测 `*.mistral.ai`
   - `isPerplexityBaseUrl()` — 检测 `*.perplexity.ai`
   - `resolveAdapterForBaseUrl()` — 统一入口，按优先级匹配

2. **修改 `src/core/llm/openaiCompatibleProvider.ts`** — 用 `resolveAdapterForBaseUrl()` 替换原来内联的 adapter 选择逻辑

## 设计决策

- **仅做 adapter 层兜底**：不改变 Provider 类的选择逻辑，影响范围最小
- **不加 Qwen/DashScope 检测**：`dashscope.aliyuncs.com` 是阿里云通用平台，非 Qwen 专属，加上去可能误伤其他模型
- **抽取为独立模块**：便于后续新增服务商检测，便于单独编写单元测试

## 测试

- [x] TypeScript 编译通过
- [x] 全量测试通过（135 suites，833 tests，0 failures）
- [x] 现有 `openaiCompatibleProvider.test.ts` 通过
