### PR TITLE
feat: 兼容 CLAUDE.md 项目上下文指令

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,11 +3,14 @@ module.exports = {
   roots: ['<rootDir>/src'],
   testEnvironment: 'node',
   transform: {
-    '^.+.tsx?$': ['ts-jest', {}],
+    '^.+\\.[tj]sx?$': ['ts-jest', {}],
   },
   testPathIgnorePatterns: ['<rootDir>/Reference/', '<rootDir>/.opencode/'],
   modulePathIgnorePatterns: ['<rootDir>/Reference/', '<rootDir>/.opencode/'],
   moduleNameMapper: {
     '^obsidian$': '<rootDir>/__mocks__/obsidian.ts',
   },
+  transformIgnorePatterns: [
+    'node_modules/(?!(marked)/)',
+  ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "lodash.debounce": "^4.0.8",
         "lodash.isequal": "^4.5.0",
         "lucide-react": "^0.447.0",
+        "marked": "^12.0.2",
         "minimatch": "^10.0.1",
         "node-fetch": "^2.6.7",
         "openai": "^4.91.1",
@@ -1142,6 +1143,7 @@
       "version": "7.25.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.25.7",
@@ -1675,6 +1677,7 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.1.tgz",
       "integrity": "sha512-3rA9lcwciEB47ZevqvD8qgbzhM9qMb8vCcQCNmDfVRPQG4JT9mSb0Jg8H7YjKGGQcFnLN323fj9jdnG59Kx6bg==",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1683,6 +1686,7 @@
       "version": "6.36.2",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.2.tgz",
       "integrity": "sha512-DZ6ONbs8qdJK0fdN7AB82CgI6tYXf4HWk1wSVa0+9bhVznCuuvhQtX8bFBoy3dv8rZSQqUd8GvhVAcielcidrA==",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "style-mod": "^4.1.0",
@@ -1706,6 +1710,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1752,7 +1757,8 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.4.tgz",
       "integrity": "sha512-g/6CWAJ4XOkObWCWAQ2IReZD8VvsDy3poRHSKvpRR2F96F8WJ3HVbjpso3gN7l0q6QPPgvxSSpl/qo5k8a7mkQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -2398,6 +2404,7 @@
       "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2553,7 +2560,6 @@
       "integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3004,7 +3010,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3016,7 +3021,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3280,6 +3284,7 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.17.5.tgz",
       "integrity": "sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.6",
         "content-type": "^1.0.5",
@@ -5353,6 +5358,7 @@
     "node_modules/@types/react": {
       "version": "18.3.10",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5362,6 +5368,7 @@
       "version": "18.3.0",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -5464,6 +5471,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -5729,6 +5737,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6287,6 +6296,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -6852,7 +6862,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7830,6 +7839,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8260,6 +8270,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10700,7 +10711,6 @@
     "node_modules/isomorphic.js": {
       "version": "0.2.5",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -10828,6 +10838,7 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -11770,7 +11781,6 @@
     "node_modules/lib0": {
       "version": "0.2.98",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -11915,6 +11925,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmmirror.com/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -12800,7 +12822,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -13559,6 +13580,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13907,6 +13929,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13917,6 +13940,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -15250,6 +15274,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15567,6 +15592,7 @@
       "version": "5.6.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15581,6 +15607,7 @@
       "integrity": "sha512-ytTHO+SoYSbhAH9CrYnMhiLx8To6PSSvqnvXyPUgPETCvB6eBKmTI9w6XMPS3HsBRGkwTVBX+urA8dYQx6bHfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.50.1",
         "@typescript-eslint/parser": "8.50.1",
@@ -16188,6 +16215,7 @@
       "version": "3.24.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "lucide-react": "^0.447.0",
+    "marked": "^12.0.2",
     "minimatch": "^10.0.1",
     "node-fetch": "^2.6.7",
     "openai": "^4.91.1",

--- a/src/components/chat-view/useChatStreamManager.ts
+++ b/src/components/chat-view/useChatStreamManager.ts
@@ -728,6 +728,7 @@ export function useChatStreamManager({
             useWebSearch: conversationOverrides?.useWebSearch ?? false,
             useUrlContext: conversationOverrides?.useUrlContext ?? false,
           },
+          enableClaudeMd: selectedAssistant?.enableClaudeMd !== false,
         }
 
         if (branchTarget && requestLastMessage?.role === 'user') {
@@ -760,6 +761,7 @@ export function useChatStreamManager({
                 effectiveModel.name ??
                 effectiveModel.model ??
                 effectiveModel.id,
+              app: plugin.app,
               abortSignal: abortController.signal,
             },
           })
@@ -776,6 +778,7 @@ export function useChatStreamManager({
               providerClient: resolvedClient.providerClient,
               model: effectiveModel,
               conversationId,
+              app: plugin.app,
               abortSignal: abortController.signal,
             },
           })
@@ -819,6 +822,7 @@ export function useChatStreamManager({
                 branchId,
                 sourceUserMessageId: lastMessage.id,
                 branchLabel,
+                app: plugin.app,
                 abortSignal: branchAbortController.signal,
                 requestParams: {
                   ...requestParams,

--- a/src/components/panels/quick-ask/QuickAskPanel.tsx
+++ b/src/components/panels/quick-ask/QuickAskPanel.tsx
@@ -1089,6 +1089,7 @@ export function QuickAskPanel({
             conversationId,
             requestContextBuilder,
             mcpManager,
+            app: plugin.app,
             abortSignal: abortController.signal,
             allowedToolNames: chatModeRuntime.allowedToolNames,
             toolPreferences: chatModeRuntime.toolPreferences,
@@ -1097,6 +1098,7 @@ export function QuickAskPanel({
             contextualInjections: editorSnapshotInjection
               ? [editorSnapshotInjection]
               : [],
+            enableClaudeMd: selectedAssistant?.enableClaudeMd !== false,
             requestParams: {
               stream: true,
               primaryRequestTimeoutMs:

--- a/src/components/settings/sections/AgentsSectionContent.tsx
+++ b/src/components/settings/sections/AgentsSectionContent.tsx
@@ -247,6 +247,7 @@ function createNewAgent(defaultModelId: string): Assistant {
     toolPreferences: {},
     enabledSkills: [],
     skillPreferences: {},
+    enableClaudeMd: true,
     createdAt: Date.now(),
     updatedAt: Date.now(),
   }
@@ -1262,6 +1263,26 @@ export function AgentsSectionContent({
                   autoResize
                   maxAutoResizeHeight={360}
                   inputClassName="smtcmp-agent-system-prompt-textarea"
+                />
+              </ObsidianSetting>
+              <ObsidianSetting
+                name={t(
+                  'settings.agent.editorEnableClaudeMd',
+                  '兼容 CLAUDE.md 项目上下文',
+                )}
+                desc={t(
+                  'settings.agent.editorEnableClaudeMdDesc',
+                  '自动加载 vault 中的 CLAUDE.md 和 .claude/rules/*.md，作为项目指令注入系统提示词',
+                )}
+              >
+                <ObsidianToggle
+                  value={draftAgent.enableClaudeMd !== false}
+                  onChange={(value) => {
+                    setDraftAgent({
+                      ...draftAgent,
+                      enableClaudeMd: value,
+                    })
+                  }}
                 />
               </ObsidianSetting>
             </div>

--- a/src/core/agent/native-runtime.ts
+++ b/src/core/agent/native-runtime.ts
@@ -93,13 +93,14 @@ export class NativeAgentRuntime implements AgentRuntime {
       return
     }
 
-    const toolGateway = new AgentToolGateway(input.mcpManager, {
+    const toolGateway = new AgentToolGateway(input.mcpManager, input.app, {
       toolsEnabled: this.loopConfig.enableTools,
       allowedToolNames: input.allowedToolNames,
       toolPreferences: input.toolPreferences,
       workspaceScope: input.workspaceScope,
       allowedSkillIds: input.allowedSkillIds,
       allowedSkillNames: input.allowedSkillNames,
+      enableClaudeMd: input.enableClaudeMd,
     })
     const worker = createAgentLoopWorker()
     const runId = uuidv4()

--- a/src/core/agent/tool-gateway.test.ts
+++ b/src/core/agent/tool-gateway.test.ts
@@ -6,6 +6,18 @@ import { McpManager } from '../mcp/mcpManager'
 
 import { AgentToolGateway } from './tool-gateway'
 
+// Mock App for testing
+const createMockApp = () => ({
+  vault: {
+    adapter: {
+      exists: jest.fn().mockResolvedValue(false),
+      mkdir: jest.fn().mockResolvedValue(undefined),
+      read: jest.fn().mockResolvedValue(''),
+      write: jest.fn().mockResolvedValue(undefined),
+    },
+  },
+})
+
 describe('AgentToolGateway', () => {
   const emptyArgs = createCompleteToolCallArguments({ value: {} })
 
@@ -14,7 +26,7 @@ describe('AgentToolGateway', () => {
       isToolExecutionAllowed: jest.fn().mockReturnValue(true),
     } as unknown as McpManager
 
-    const gateway = new AgentToolGateway(mcpManager, {
+    const gateway = new AgentToolGateway(mcpManager, createMockApp() as never, {
       allowedToolNames: ['server__tool_a'],
       toolPreferences: {
         server__tool_a: {
@@ -49,7 +61,7 @@ describe('AgentToolGateway', () => {
       isToolExecutionAllowed: jest.fn().mockReturnValue(false),
     } as unknown as McpManager
 
-    const gateway = new AgentToolGateway(mcpManager, {
+    const gateway = new AgentToolGateway(mcpManager, createMockApp() as never, {
       allowedToolNames: ['server__tool_a'],
       toolPreferences: {
         server__tool_a: {
@@ -84,7 +96,7 @@ describe('AgentToolGateway', () => {
       isToolExecutionAllowed: jest.fn().mockReturnValue(true),
     } as unknown as McpManager
 
-    const gateway = new AgentToolGateway(mcpManager, {
+    const gateway = new AgentToolGateway(mcpManager, createMockApp() as never, {
       allowedToolNames: ['server__tool_a'],
       toolPreferences: {
         server__tool_a: {
@@ -115,7 +127,7 @@ describe('AgentToolGateway', () => {
       }),
     } as unknown as McpManager
 
-    const gateway = new AgentToolGateway(mcpManager, {
+    const gateway = new AgentToolGateway(mcpManager, createMockApp() as never, {
       allowedToolNames: ['yolo_local__fs_edit'],
       toolPreferences: {
         yolo_local__fs_edit: {
@@ -160,7 +172,7 @@ describe('AgentToolGateway', () => {
       isToolExecutionAllowed: jest.fn(),
     } as unknown as McpManager
 
-    const gateway = new AgentToolGateway(mcpManager, {
+    const gateway = new AgentToolGateway(mcpManager, createMockApp() as never, {
       toolsEnabled: false,
       allowedToolNames: ['server__tool_a'],
     })
@@ -190,7 +202,7 @@ describe('AgentToolGateway', () => {
       callTool,
     } as unknown as McpManager
 
-    const gateway = new AgentToolGateway(mcpManager, {
+    const gateway = new AgentToolGateway(mcpManager, createMockApp() as never, {
       allowedToolNames: ['yolo_local__fs_edit'],
       toolPreferences: {
         yolo_local__fs_edit: {
@@ -287,7 +299,7 @@ describe('AgentToolGateway', () => {
       isToolExecutionAllowed: jest.fn(),
     } as unknown as McpManager
 
-    const gateway = new AgentToolGateway(mcpManager, {
+    const gateway = new AgentToolGateway(mcpManager, createMockApp() as never, {
       allowedToolNames: ['server__tool_a'],
     })
 

--- a/src/core/agent/tool-gateway.ts
+++ b/src/core/agent/tool-gateway.ts
@@ -1,3 +1,4 @@
+import { App } from 'obsidian'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
@@ -12,6 +13,10 @@ import {
   ToolCallResponseStatus,
   getToolCallArgumentsObject,
 } from '../../types/tool-call.types'
+import {
+  FILE_TOOLS,
+  getConditionalRules,
+} from '../claude-md/claudeMdIntegration'
 import { getLocalFileToolServerName } from '../mcp/localFileTools'
 import { McpManager } from '../mcp/mcpManager'
 import { parseToolName } from '../mcp/tool-name-utils'
@@ -29,9 +34,12 @@ export class AgentToolGateway {
   private readonly workspaceScope?: AssistantWorkspaceScope
   private readonly allowedSkillIds?: Set<string>
   private readonly allowedSkillNames?: Set<string>
+  private readonly enableClaudeMd: boolean
+  private readonly injectedConditionalPaths = new Set<string>()
 
   constructor(
     private readonly mcpManager: McpManager,
+    private readonly app: App,
     options?: {
       toolsEnabled?: boolean
       allowedToolNames?: string[]
@@ -39,6 +47,7 @@ export class AgentToolGateway {
       workspaceScope?: AssistantWorkspaceScope
       allowedSkillIds?: string[]
       allowedSkillNames?: string[]
+      enableClaudeMd?: boolean
     },
   ) {
     this.toolsEnabled = options?.toolsEnabled ?? true
@@ -53,6 +62,7 @@ export class AgentToolGateway {
     this.allowedSkillNames = options?.allowedSkillNames
       ? new Set(options.allowedSkillNames.map((name) => name.toLowerCase()))
       : undefined
+    this.enableClaudeMd = options?.enableClaudeMd !== false
   }
 
   private isRequestPathAllowed(request: ToolCallRequest): boolean {
@@ -290,6 +300,9 @@ export class AgentToolGateway {
       })
     })
 
+    // Inject conditional rules from .claude/rules/*.md files
+    await this.injectConditionalRules(nextToolCalls)
+
     return {
       ...toolMessage,
       toolCalls: nextToolCalls,
@@ -526,6 +539,44 @@ export class AgentToolGateway {
       return allowedById || allowedByName
     } catch {
       return true
+    }
+  }
+
+  private async injectConditionalRules(
+    toolCalls: Array<{ request: ToolCallRequest; response: ToolCallResponse }>,
+  ): Promise<void> {
+    for (const toolCall of toolCalls) {
+      if (toolCall.response.status !== ToolCallResponseStatus.Success) continue
+
+      try {
+        const parsed = parseToolName(toolCall.request.name)
+        if (parsed.serverName !== getLocalFileToolServerName()) continue
+        if (!FILE_TOOLS.has(parsed.toolName)) continue
+
+        const args = getToolCallArgumentsObject(toolCall.request.arguments)
+        const targetPath =
+          typeof args?.path === 'string' ? args.path : undefined
+        if (!targetPath) continue
+
+        const rules = await getConditionalRules(
+          this.app,
+          targetPath,
+          this.injectedConditionalPaths,
+          this.enableClaudeMd,
+        )
+        if (!rules) continue
+
+        const existingText = toolCall.response.data.text ?? ''
+        toolCall.response = {
+          ...toolCall.response,
+          data: {
+            ...toolCall.response.data,
+            text: existingText + '\n\n---\n\n' + rules,
+          },
+        }
+      } catch {
+        // Non-critical — never block tool execution
+      }
     }
   }
 }

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -1,3 +1,5 @@
+import { App } from 'obsidian'
+
 import {
   ChatConversationCompactionLike,
   ChatConversationCompactionState,
@@ -30,6 +32,7 @@ export type AgentRuntimeRunInput = {
   branchLabel?: string
   requestContextBuilder: RequestContextBuilder
   mcpManager: McpManager
+  app: App
   compaction?: ChatConversationCompactionLike | null
   compactionProviderClient?: BaseLLMProvider<LLMProvider>
   compactionModel?: ChatModel
@@ -63,6 +66,7 @@ export type AgentRuntimeRunInput = {
     useWebSearch?: boolean
     useUrlContext?: boolean
   }
+  enableClaudeMd?: boolean
 }
 
 export type AgentRuntimeLoopConfig = {

--- a/src/core/claude-md/__tests__/claudeMdCache.test.ts
+++ b/src/core/claude-md/__tests__/claudeMdCache.test.ts
@@ -1,0 +1,147 @@
+import { ClaudeMdCache } from '../claudeMdCache'
+import { MAX_CACHE_SIZE } from '../claudeMdTypes'
+import type { ParsedMemoryFile } from '../claudeMdTypes'
+import type { App } from 'obsidian'
+
+function createMockApp(files: Record<string, { content: string; mtime: number }>): App {
+  return {
+    vault: {
+      adapter: {
+        stat: async (path: string) => files[path] ?? null,
+        read: async (path: string) => files[path]?.content ?? null,
+      },
+    },
+  } as any
+}
+
+describe('ClaudeMdCache', () => {
+  it('should return parsed content from cache on second call', async () => {
+    const files: Record<string, { content: string; mtime: number }> = {
+      'test.md': { content: 'hello', mtime: 1000 },
+    }
+    const app = createMockApp(files)
+    const cache = new ClaudeMdCache()
+
+    const result1 = await cache.getOrLoad(app, 'test.md', (raw) => ({
+      filePath: 'test.md',
+      content: raw,
+    }))
+    const result2 = await cache.getOrLoad(app, 'test.md', (raw) => ({
+      filePath: 'test.md',
+      content: raw + '_should_not_use',
+    }))
+
+    expect(result1?.content).toBe('hello')
+    expect(result2?.content).toBe('hello')
+  })
+
+  it('should reload when mtime changes', async () => {
+    const files: Record<string, { content: string; mtime: number }> = {
+      'test.md': { content: 'updated', mtime: 2000 },
+    }
+    const app = createMockApp(files)
+    const cache = new ClaudeMdCache()
+
+    // First load
+    await cache.getOrLoad(app, 'test.md', (raw) => ({
+      filePath: 'test.md',
+      content: raw,
+    }))
+
+    // Update mtime
+    files['test.md'] = { content: 'new content', mtime: 3000 }
+
+    const result = await cache.getOrLoad(app, 'test.md', (raw) => ({
+      filePath: 'test.md',
+      content: raw,
+    }))
+    expect(result?.content).toBe('new content')
+  })
+
+  it('should return null for non-existent file', async () => {
+    const app = createMockApp({})
+    const cache = new ClaudeMdCache()
+
+    const result = await cache.getOrLoad(app, 'missing.md', (raw) => ({
+      filePath: 'missing.md',
+      content: raw,
+    }))
+    expect(result).toBeNull()
+  })
+
+  it('should evict oldest entry when cache exceeds max size', async () => {
+    // We test eviction by filling the cache beyond its limit
+    const cache = new ClaudeMdCache()
+    const files: Record<string, { content: string; mtime: number }> = {}
+
+    // Create MAX_CACHE_SIZE + 1 files
+    for (let i = 0; i <= MAX_CACHE_SIZE; i++) {
+      const path = `file_${i}.md`
+      files[path] = { content: `content_${i}`, mtime: 1000 + i }
+    }
+
+    const app = createMockApp(files)
+
+    // Load all files
+    for (let i = 0; i <= MAX_CACHE_SIZE; i++) {
+      await cache.getOrLoad(app, `file_${i}.md`, (raw) => ({
+        filePath: `file_${i}.md`,
+        content: raw,
+      }))
+    }
+
+    // The first file should have been evicted (FIFO)
+    // Access it again - it should be re-read (mtime changed to verify)
+    files['file_0.md'] = { content: 'reloaded', mtime: 9999 }
+    const result = await cache.getOrLoad(app, 'file_0.md', (raw) => ({
+      filePath: 'file_0.md',
+      content: raw,
+    }))
+    expect(result?.content).toBe('reloaded')
+  })
+
+  it('should clean up deleted files from cache', async () => {
+    const files: Record<string, { content: string; mtime: number }> = {
+      'test.md': { content: 'hello', mtime: 1000 },
+    }
+    const app = createMockApp(files)
+    const cache = new ClaudeMdCache()
+
+    // Load file
+    await cache.getOrLoad(app, 'test.md', (raw) => ({
+      filePath: 'test.md',
+      content: raw,
+    }))
+
+    // Delete file
+    delete files['test.md']
+
+    const result = await cache.getOrLoad(app, 'test.md', (raw) => ({
+      filePath: 'test.md',
+      content: raw,
+    }))
+    expect(result).toBeNull()
+  })
+
+  it('should clear all entries', async () => {
+    const files: Record<string, { content: string; mtime: number }> = {
+      'a.md': { content: 'a', mtime: 1000 },
+      'b.md': { content: 'b', mtime: 1000 },
+    }
+    const app = createMockApp(files)
+    const cache = new ClaudeMdCache()
+
+    await cache.getOrLoad(app, 'a.md', (raw) => ({ filePath: 'a.md', content: raw }))
+    await cache.getOrLoad(app, 'b.md', (raw) => ({ filePath: 'b.md', content: raw }))
+
+    cache.clear()
+
+    // After clear, files should be re-loaded
+    files['a.md'] = { content: 'reloaded_a', mtime: 2000 }
+    const result = await cache.getOrLoad(app, 'a.md', (raw) => ({
+      filePath: 'a.md',
+      content: raw,
+    }))
+    expect(result?.content).toBe('reloaded_a')
+  })
+})

--- a/src/core/claude-md/__tests__/claudeMdCache.test.ts
+++ b/src/core/claude-md/__tests__/claudeMdCache.test.ts
@@ -1,9 +1,11 @@
-import { ClaudeMdCache } from '../claudeMdCache'
-import { MAX_CACHE_SIZE } from '../claudeMdTypes'
-import type { ParsedMemoryFile } from '../claudeMdTypes'
 import type { App } from 'obsidian'
 
-function createMockApp(files: Record<string, { content: string; mtime: number }>): App {
+import { ClaudeMdCache } from '../claudeMdCache'
+import { MAX_CACHE_SIZE } from '../claudeMdTypes'
+
+function createMockApp(
+  files: Record<string, { content: string; mtime: number }>,
+): App {
   return {
     vault: {
       adapter: {
@@ -131,8 +133,14 @@ describe('ClaudeMdCache', () => {
     const app = createMockApp(files)
     const cache = new ClaudeMdCache()
 
-    await cache.getOrLoad(app, 'a.md', (raw) => ({ filePath: 'a.md', content: raw }))
-    await cache.getOrLoad(app, 'b.md', (raw) => ({ filePath: 'b.md', content: raw }))
+    await cache.getOrLoad(app, 'a.md', (raw) => ({
+      filePath: 'a.md',
+      content: raw,
+    }))
+    await cache.getOrLoad(app, 'b.md', (raw) => ({
+      filePath: 'b.md',
+      content: raw,
+    }))
 
     cache.clear()
 

--- a/src/core/claude-md/__tests__/claudeMdParser.test.ts
+++ b/src/core/claude-md/__tests__/claudeMdParser.test.ts
@@ -1,0 +1,507 @@
+// src/core/claude-md/__tests__/claudeMdParser.test.ts
+
+// Mock marked module
+jest.mock('marked', () => ({
+  marked: {
+    lexer: jest.fn(),
+  },
+}))
+
+// Import the mocked function
+import { marked } from 'marked'
+
+import {
+  extractIncludePaths,
+  parseFrontmatterPaths,
+  processIncludes,
+  resolveIncludePath,
+  stripHtmlComments,
+} from '../claudeMdParser'
+import { MAX_INCLUDE_DEPTH } from '../claudeMdTypes'
+
+const mockLexer = marked.lexer as jest.Mock
+
+describe('stripHtmlComments', () => {
+  beforeEach(() => {
+    mockLexer.mockClear()
+  })
+
+  it('should strip a block-level HTML comment', () => {
+    mockLexer.mockReturnValue([
+      {
+        type: 'html',
+        text: '<!-- hidden -->',
+        raw: '<!-- hidden -->',
+      },
+      {
+        type: 'paragraph',
+        raw: 'visible content',
+        tokens: [],
+      },
+    ])
+
+    const result = stripHtmlComments('<!-- hidden -->\nvisible content')
+    expect(result.content).toBe('visible content')
+    expect(result.stripped).toBe(true)
+  })
+
+  it('should return unchanged content when no comments exist', () => {
+    mockLexer.mockReturnValue([
+      {
+        type: 'paragraph',
+        raw: 'just content',
+        tokens: [],
+      },
+    ])
+
+    const result = stripHtmlComments('just content')
+    expect(result.content).toBe('just content')
+    expect(result.stripped).toBe(false)
+  })
+
+  it('should preserve content inside code blocks', () => {
+    const input = '```\n<!-- this is not a comment -->\n```'
+    mockLexer.mockReturnValue([
+      {
+        type: 'code',
+        text: '<!-- this is not a comment -->',
+        raw: input,
+      },
+    ])
+
+    const result = stripHtmlComments(input)
+    expect(result.content).toBe(input)
+  })
+
+  it('should preserve content inside inline code', () => {
+    const input = '`<!-- not a comment -->`'
+    mockLexer.mockReturnValue([
+      {
+        type: 'paragraph',
+        raw: input,
+        tokens: [
+          {
+            type: 'codespan',
+            text: '<!-- not a comment -->',
+            raw: '`<!-- not a comment -->`',
+          },
+        ],
+      },
+    ])
+
+    const result = stripHtmlComments(input)
+    expect(result.content).toBe(input)
+  })
+
+  it('should preserve unclosed comments', () => {
+    const input = '<!-- unclosed'
+    mockLexer.mockReturnValue([
+      {
+        type: 'html',
+        text: '<!-- unclosed',
+        raw: '<!-- unclosed',
+      },
+    ])
+
+    const result = stripHtmlComments(input)
+    expect(result.content).toBe(input)
+  })
+
+  it('should strip multi-line comments', () => {
+    mockLexer.mockReturnValue([
+      {
+        type: 'html',
+        text: '<!-- line1\nline2 -->',
+        raw: '<!-- line1\nline2 -->',
+      },
+      {
+        type: 'paragraph',
+        raw: 'visible',
+        tokens: [],
+      },
+    ])
+
+    const input = '<!-- line1\nline2 -->\nvisible'
+    const result = stripHtmlComments(input)
+    expect(result.content).toBe('visible')
+    expect(result.stripped).toBe(true)
+  })
+
+  it('should preserve residual text after comment', () => {
+    mockLexer.mockReturnValue([
+      {
+        type: 'html',
+        text: '<!-- comment --> residual',
+        raw: '<!-- comment --> residual',
+      },
+    ])
+
+    const input = '<!-- comment --> residual'
+    const result = stripHtmlComments(input)
+    expect(result.content).toBe(' residual')
+  })
+})
+
+describe('parseFrontmatterPaths', () => {
+  it('should return content without paths when no frontmatter', () => {
+    const result = parseFrontmatterPaths('just content')
+    expect(result.content).toBe('just content')
+    expect(result.paths).toBeUndefined()
+  })
+
+  it('should parse comma-separated paths', () => {
+    const input =
+      '---\npaths: src/**/*.ts, tests/**/*.test.ts\n---\nrule content'
+    const result = parseFrontmatterPaths(input)
+    expect(result.content).toBe('rule content')
+    expect(result.paths).toEqual(['src/**/*.ts', 'tests/**/*.test.ts'])
+  })
+
+  it('should parse YAML list paths', () => {
+    const input = '---\npaths:\n  - a/**\n  - b/**\n---\nrule content'
+    const result = parseFrontmatterPaths(input)
+    expect(result.paths).toEqual(['a/**', 'b/**'])
+  })
+
+  it('should expand braces', () => {
+    const input = '---\npaths: src/*.{ts,tsx}\n---\nrule'
+    const result = parseFrontmatterPaths(input)
+    expect(result.paths).toEqual(['src/*.ts', 'src/*.tsx'])
+  })
+
+  it('should treat all-wildcard as no restriction', () => {
+    const input = '---\npaths: "**"\n---\nrule'
+    const result = parseFrontmatterPaths(input)
+    expect(result.paths).toBeUndefined()
+  })
+
+  it('should strip /** suffix', () => {
+    const input = '---\npaths: src/core/**\n---\nrule'
+    const result = parseFrontmatterPaths(input)
+    expect(result.paths).toEqual(['src/core'])
+  })
+
+  it('should handle YAML parse failure with auto-quote retry', () => {
+    const input = '---\npaths: **/*.{ts,tsx}\n---\nrule'
+    const result = parseFrontmatterPaths(input)
+    expect(result.paths).toEqual(['**/*.ts', '**/*.tsx'])
+  })
+
+  it('should return content without paths when frontmatter has no paths', () => {
+    const input = '---\nname: my-rule\n---\nrule content'
+    const result = parseFrontmatterPaths(input)
+    expect(result.content).toBe('rule content')
+    expect(result.paths).toBeUndefined()
+  })
+})
+
+describe('extractIncludePaths', () => {
+  beforeEach(() => {
+    mockLexer.mockClear()
+  })
+
+  it('should extract a relative path', () => {
+    mockLexer.mockReturnValue([
+      {
+        type: 'paragraph',
+        raw: 'some text @./shared.md more text',
+        tokens: [
+          {
+            type: 'text',
+            text: 'some text @./shared.md more text',
+            raw: 'some text @./shared.md more text',
+          },
+        ],
+      },
+    ])
+
+    const result = extractIncludePaths('some text @./shared.md more text')
+    expect(result).toEqual(['./shared.md'])
+  })
+
+  it('should extract vault-root path with ~/', () => {
+    mockLexer.mockReturnValue([
+      {
+        type: 'paragraph',
+        raw: '@~/path/to/file.md',
+        tokens: [
+          {
+            type: 'text',
+            text: '@~/path/to/file.md',
+            raw: '@~/path/to/file.md',
+          },
+        ],
+      },
+    ])
+
+    const result = extractIncludePaths('@~/path/to/file.md')
+    expect(result).toEqual(['~/path/to/file.md'])
+  })
+
+  it('should skip @mentions inside code blocks', () => {
+    const input = '```\n@./not-an-include.md\n```'
+    mockLexer.mockReturnValue([
+      {
+        type: 'code',
+        text: '@./not-an-include.md',
+        raw: input,
+      },
+    ])
+
+    const result = extractIncludePaths(input)
+    expect(result).toEqual([])
+  })
+
+  it('should skip @mentions inside inline code', () => {
+    const input = '`@./not-include.md`'
+    mockLexer.mockReturnValue([
+      {
+        type: 'paragraph',
+        raw: input,
+        tokens: [
+          {
+            type: 'codespan',
+            text: '@./not-include.md',
+            raw: '`@./not-include.md`',
+          },
+        ],
+      },
+    ])
+
+    const result = extractIncludePaths(input)
+    expect(result).toEqual([])
+  })
+
+  it('should extract multiple paths', () => {
+    mockLexer.mockReturnValue([
+      {
+        type: 'paragraph',
+        raw: '@./a.md and @./b.md',
+        tokens: [
+          {
+            type: 'text',
+            text: '@./a.md and @./b.md',
+            raw: '@./a.md and @./b.md',
+          },
+        ],
+      },
+    ])
+
+    const result = extractIncludePaths('@./a.md and @./b.md')
+    expect(result).toEqual(['./a.md', './b.md'])
+  })
+
+  it('should handle backslash-escaped spaces', () => {
+    mockLexer.mockReturnValue([
+      {
+        type: 'paragraph',
+        raw: '@./path\\ with\\ spaces.md',
+        tokens: [
+          {
+            type: 'text',
+            text: '@./path\\ with\\ spaces.md',
+            raw: '@./path\\ with\\ spaces.md',
+          },
+        ],
+      },
+    ])
+
+    const result = extractIncludePaths('@./path\\ with\\ spaces.md')
+    expect(result).toEqual(['./path\\ with\\ spaces.md'])
+  })
+
+  it('should strip fragment identifiers', () => {
+    mockLexer.mockReturnValue([
+      {
+        type: 'paragraph',
+        raw: '@./file.md#section',
+        tokens: [
+          {
+            type: 'text',
+            text: '@./file.md#section',
+            raw: '@./file.md#section',
+          },
+        ],
+      },
+    ])
+
+    const result = extractIncludePaths('@./file.md#section')
+    expect(result).toEqual(['./file.md'])
+  })
+})
+
+describe('resolveIncludePath', () => {
+  it('should resolve relative path against current file dir', () => {
+    const result = resolveIncludePath({
+      includePath: './shared.md',
+      currentFilePath: '.claude/rules/agent.md',
+      vaultRoot: '',
+    })
+    expect(result).toBe('.claude/rules/shared.md')
+  })
+
+  it('should resolve bare relative path', () => {
+    const result = resolveIncludePath({
+      includePath: 'shared.md',
+      currentFilePath: '.claude/rules/agent.md',
+      vaultRoot: '',
+    })
+    expect(result).toBe('.claude/rules/shared.md')
+  })
+
+  it('should resolve ~/ to vault root', () => {
+    const result = resolveIncludePath({
+      includePath: '~/other/file.md',
+      currentFilePath: '.claude/rules/agent.md',
+      vaultRoot: '',
+    })
+    expect(result).toBe('other/file.md')
+  })
+
+  it('should reject paths outside vault', () => {
+    const result = resolveIncludePath({
+      includePath: '/etc/passwd',
+      currentFilePath: '.claude/rules/agent.md',
+      vaultRoot: '',
+    })
+    expect(result).toBeNull()
+  })
+})
+
+describe('processIncludes', () => {
+  beforeEach(() => {
+    mockLexer.mockClear()
+  })
+
+  it('should inline included file content', async () => {
+    mockLexer.mockImplementation((content: string) => {
+      if (content.includes('@./shared.md')) {
+        return [
+          {
+            type: 'paragraph',
+            raw: 'before',
+            tokens: [{ type: 'text', text: 'before', raw: 'before' }],
+          },
+          {
+            type: 'paragraph',
+            raw: '@./shared.md',
+            tokens: [
+              { type: 'text', text: '@./shared.md', raw: '@./shared.md' },
+            ],
+          },
+          {
+            type: 'paragraph',
+            raw: 'after',
+            tokens: [{ type: 'text', text: 'after', raw: 'after' }],
+          },
+        ]
+      }
+      return [
+        {
+          type: 'paragraph',
+          raw: content,
+          tokens: [{ type: 'text', text: content, raw: content }],
+        },
+      ]
+    })
+
+    const fileReader = async (path: string) => {
+      const files: Record<string, string> = {
+        '.claude/rules/shared.md': 'shared content',
+      }
+      return files[path] ?? null
+    }
+
+    const result = await processIncludes({
+      content: 'before\n@./shared.md\nafter',
+      currentFilePath: '.claude/rules/agent.md',
+      fileReader,
+      processedPaths: new Set(),
+      depth: 0,
+      vaultRoot: '',
+    })
+
+    expect(result).toBe('before\nshared content\nafter')
+  })
+
+  it('should prevent circular references', async () => {
+    mockLexer.mockImplementation((content: string) => {
+      return [
+        {
+          type: 'paragraph',
+          raw: content,
+          tokens: [{ type: 'text', text: content, raw: content }],
+        },
+      ]
+    })
+
+    const fileReader = async (path: string) => {
+      const files: Record<string, string> = {
+        'a.md': '@./b.md',
+        'b.md': '@./a.md',
+      }
+      return files[path] ?? null
+    }
+
+    const result = await processIncludes({
+      content: '@./b.md',
+      currentFilePath: 'a.md',
+      fileReader,
+      processedPaths: new Set(['a.md']),
+      depth: 0,
+      vaultRoot: '',
+    })
+
+    expect(result).toBeDefined()
+  })
+
+  it('should stop at max depth', async () => {
+    mockLexer.mockImplementation((content: string) => {
+      return [
+        {
+          type: 'paragraph',
+          raw: content,
+          tokens: [{ type: 'text', text: content, raw: content }],
+        },
+      ]
+    })
+
+    const fileReader = async (_path: string) => 'deep @./deep.md'
+
+    const result = await processIncludes({
+      content: '@./deep.md',
+      currentFilePath: 'root.md',
+      fileReader,
+      processedPaths: new Set(),
+      depth: MAX_INCLUDE_DEPTH,
+      vaultRoot: '',
+    })
+
+    expect(result).toContain('@./deep.md')
+  })
+
+  it('should skip non-existent includes gracefully', async () => {
+    mockLexer.mockImplementation((content: string) => {
+      return [
+        {
+          type: 'paragraph',
+          raw: content,
+          tokens: [{ type: 'text', text: content, raw: content }],
+        },
+      ]
+    })
+
+    const fileReader = async (_path: string) => null
+
+    const result = await processIncludes({
+      content: 'before\n@./missing.md\nafter',
+      currentFilePath: 'root.md',
+      fileReader,
+      processedPaths: new Set(),
+      depth: 0,
+      vaultRoot: '',
+    })
+
+    expect(result).toBe('before\nafter')
+  })
+})

--- a/src/core/claude-md/claudeMdCache.ts
+++ b/src/core/claude-md/claudeMdCache.ts
@@ -1,0 +1,52 @@
+// src/core/claude-md/claudeMdCache.ts
+import { App } from 'obsidian'
+
+import { CacheEntry, MAX_CACHE_SIZE, ParsedMemoryFile } from './claudeMdTypes'
+
+export class ClaudeMdCache {
+  private cache = new Map<string, CacheEntry>()
+
+  async getOrLoad(
+    app: App,
+    filePath: string,
+    loader: (rawContent: string) => ParsedMemoryFile,
+  ): Promise<ParsedMemoryFile | null> {
+    try {
+      const stat = await app.vault.adapter.stat(filePath)
+      if (!stat) {
+        this.cache.delete(filePath)
+        return null
+      }
+
+      const cached = this.cache.get(filePath)
+      if (cached && cached.mtime === stat.mtime) {
+        return cached.parsed
+      }
+
+      const rawContent = await app.vault.adapter.read(filePath)
+      const parsed = loader(rawContent)
+
+      if (this.cache.size >= MAX_CACHE_SIZE) {
+        const firstKey = this.cache.keys().next().value
+        if (firstKey !== undefined) {
+          this.cache.delete(firstKey)
+        }
+      }
+
+      this.cache.set(filePath, {
+        rawContent,
+        mtime: stat.mtime,
+        parsed,
+      })
+
+      return parsed
+    } catch {
+      console.warn('[claude-md] Failed to load cache:', filePath)
+      return null
+    }
+  }
+
+  clear(): void {
+    this.cache.clear()
+  }
+}

--- a/src/core/claude-md/claudeMdDiscovery.ts
+++ b/src/core/claude-md/claudeMdDiscovery.ts
@@ -1,0 +1,34 @@
+// src/core/claude-md/claudeMdDiscovery.ts
+import { App, TFile } from 'obsidian'
+
+import {
+  CLAUDE_MD_FILENAME,
+  CLAUDE_RULES_DIR,
+  DiscoveredFile,
+} from './claudeMdTypes'
+
+export function discoverProjectContextFiles(app: App): DiscoveredFile[] {
+  const results: DiscoveredFile[] = []
+
+  // Level 1: vault root CLAUDE.md
+  const claudeMdFile = app.vault.getAbstractFileByPath(CLAUDE_MD_FILENAME)
+  if (claudeMdFile instanceof TFile) {
+    results.push({ path: CLAUDE_MD_FILENAME, type: 'project' })
+  }
+
+  // Level 2: .claude/rules/*.md
+  const rulesPrefix = CLAUDE_RULES_DIR + '/'
+  const ruleFiles = app.vault
+    .getMarkdownFiles()
+    .filter(
+      (file) =>
+        file.path.startsWith(rulesPrefix) &&
+        file.path.slice(rulesPrefix.length).length > 0,
+    )
+    .map((file): DiscoveredFile => ({ path: file.path, type: 'rule' }))
+    .sort((a, b) => a.path.localeCompare(b.path))
+
+  results.push(...ruleFiles)
+
+  return results
+}

--- a/src/core/claude-md/claudeMdIntegration.ts
+++ b/src/core/claude-md/claudeMdIntegration.ts
@@ -1,0 +1,170 @@
+// src/core/claude-md/claudeMdIntegration.ts
+import { minimatch } from 'minimatch'
+import { App, normalizePath } from 'obsidian'
+
+import { ClaudeMdCache } from './claudeMdCache'
+import { discoverProjectContextFiles } from './claudeMdDiscovery'
+import {
+  parseFrontmatterPaths,
+  processIncludes,
+  stripHtmlComments,
+} from './claudeMdParser'
+import { MAX_RULE_FILE_LINES, type ParsedMemoryFile } from './claudeMdTypes'
+
+const cache = new ClaudeMdCache()
+
+const OVERRIDE_HEADER =
+  'Codebase and user instructions are shown below. Be sure to adhere to these instructions. ' +
+  'These instructions OVERRIDE any default behavior and you MUST follow them exactly as written.'
+
+const FILE_TOOLS = new Set([
+  'fs_read',
+  'fs_edit',
+  'fs_create_file',
+  'fs_delete_file',
+  'fs_move',
+])
+
+export function clearClaudeMdCache(): void {
+  cache.clear()
+}
+
+async function loadAndParseFileWithIncludes(
+  app: App,
+  filePath: string,
+  processedPaths: Set<string>,
+): Promise<ParsedMemoryFile | null> {
+  try {
+    const stat = await app.vault.adapter.stat(filePath)
+    if (!stat) return null
+
+    // Check cache first
+    const cached = await cache.getOrLoad(app, filePath, (rawContent) => ({
+      filePath,
+      content: rawContent,
+    }))
+    if (!cached) return null
+
+    // Process @includes (async)
+    const fileReader = async (path: string): Promise<string | null> => {
+      try {
+        return await app.vault.adapter.read(path)
+      } catch {
+        return null
+      }
+    }
+
+    const expandedContent = await processIncludes({
+      content: cached.content,
+      currentFilePath: filePath,
+      fileReader,
+      processedPaths,
+      depth: 0,
+      vaultRoot: '',
+    })
+
+    // Strip HTML comments
+    const commentResult = stripHtmlComments(expandedContent)
+    const contentAfterComments = commentResult.content
+
+    // Parse frontmatter
+    const parsed = parseFrontmatterPaths(contentAfterComments)
+    let finalContent = parsed.content.trim()
+
+    // Truncate
+    const lines = finalContent.split('\n')
+    if (lines.length > MAX_RULE_FILE_LINES) {
+      finalContent =
+        lines.slice(0, MAX_RULE_FILE_LINES).join('\n') + '\n[truncated]'
+    }
+
+    return {
+      filePath,
+      content: finalContent,
+      paths: parsed.paths,
+    }
+  } catch {
+    console.warn('[claude-md] Failed to parse:', filePath)
+    return null
+  }
+}
+
+function formatFileSection(
+  filePath: string,
+  content: string,
+  vaultName?: string,
+): string {
+  const prefix = vaultName ? `${vaultName}/` : ''
+  return `Contents of ${prefix}${filePath}\n${content}`
+}
+
+export async function getProjectContext(
+  app: App,
+  enabled = true,
+): Promise<string> {
+  if (!enabled) return ''
+  const discovered = discoverProjectContextFiles(app)
+  if (discovered.length === 0) return ''
+
+  const vaultName = app.vault.getName()
+  const processedPaths = new Set<string>()
+  const unconditionalParts: string[] = []
+
+  for (const file of discovered) {
+    const parsed = await loadAndParseFileWithIncludes(
+      app,
+      file.path,
+      processedPaths,
+    )
+    if (!parsed || !parsed.content) continue
+
+    // Only include unconditional files (no paths frontmatter)
+    if (parsed.paths) continue
+
+    unconditionalParts.push(
+      formatFileSection(file.path, parsed.content, vaultName),
+    )
+  }
+
+  if (unconditionalParts.length === 0) return ''
+
+  return `${OVERRIDE_HEADER}\n\n${unconditionalParts.join('\n\n')}`
+}
+
+export async function getConditionalRules(
+  app: App,
+  targetPath: string,
+  injectedPaths: Set<string>,
+  enabled = true,
+): Promise<string> {
+  if (!enabled) return ''
+  const discovered = discoverProjectContextFiles(app)
+  const vaultName = app.vault.getName()
+  const processedPaths = new Set<string>()
+  const matchedParts: string[] = []
+
+  const normalizedTarget = normalizePath(targetPath)
+
+  for (const file of discovered) {
+    if (injectedPaths.has(file.path)) continue
+
+    const parsed = await loadAndParseFileWithIncludes(
+      app,
+      file.path,
+      processedPaths,
+    )
+    if (!parsed || !parsed.content || !parsed.paths) continue
+
+    const matches = parsed.paths.some((pattern) =>
+      minimatch(normalizedTarget, pattern),
+    )
+    if (!matches) continue
+
+    injectedPaths.add(file.path)
+    matchedParts.push(formatFileSection(file.path, parsed.content, vaultName))
+  }
+
+  return matchedParts.join('\n\n')
+}
+
+export { FILE_TOOLS }

--- a/src/core/claude-md/claudeMdParser.ts
+++ b/src/core/claude-md/claudeMdParser.ts
@@ -1,0 +1,351 @@
+// src/core/claude-md/claudeMdParser.ts
+import { type Token, marked } from 'marked'
+import { normalizePath } from 'obsidian'
+import { dirname, isAbsolute, join } from 'path-browserify'
+
+import { MAX_INCLUDE_DEPTH } from './claudeMdTypes'
+
+export function stripHtmlComments(content: string): {
+  content: string
+  stripped: boolean
+} {
+  if (!content.includes('<!--')) {
+    return { content, stripped: false }
+  }
+
+  const tokens = marked.lexer(content, { gfm: false })
+  const segments: string[] = []
+  let stripped = false
+
+  for (const token of tokens) {
+    if (token.type === 'html') {
+      const htmlText = token.text
+      if (htmlText.includes('<!--')) {
+        const closedMatch = htmlText.match(/^<!--[\s\S]*?-->/)
+        if (closedMatch) {
+          stripped = true
+          const residual = htmlText.slice(closedMatch[0].length)
+          if (residual.trim()) {
+            segments.push(residual)
+          }
+          continue
+        }
+        // Unclosed comment — preserve as-is
+      }
+    }
+    if (token.type === 'code' || token.type === 'codespan') {
+      segments.push(token.raw)
+      continue
+    }
+    if ('tokens' in token && Array.isArray(token.tokens)) {
+      let hasHtmlComment = false
+      for (const sub of token.tokens) {
+        if (sub.type === 'html') {
+          const htmlText = sub.text
+          if (htmlText.includes('<!--')) {
+            const closedMatch = htmlText.match(/^<!--[\s\S]*?-->/)
+            if (closedMatch) {
+              hasHtmlComment = true
+              stripped = true
+              const residual = htmlText.slice(closedMatch[0].length)
+              if (residual.trim()) {
+                segments.push(residual)
+              }
+              continue
+            }
+          }
+        }
+        if (sub.raw) {
+          segments.push(sub.raw)
+        }
+      }
+      if (hasHtmlComment) {
+        continue
+      }
+    }
+    if (token.raw) {
+      segments.push(token.raw)
+    }
+  }
+
+  if (!stripped) {
+    return { content, stripped: false }
+  }
+
+  // Reconstruct from raw token segments; relies on marked token.raw preserving original text.
+  return { content: segments.join(''), stripped: true }
+}
+
+export function parseFrontmatterPaths(rawContent: string): {
+  content: string
+  paths?: string[]
+} {
+  if (!rawContent.startsWith('---\n')) {
+    return { content: rawContent }
+  }
+
+  const closingIndex = rawContent.indexOf('\n---\n', 4)
+  if (closingIndex === -1) {
+    return { content: rawContent }
+  }
+
+  const frontmatterText = rawContent.slice(4, closingIndex)
+  const bodyContent = rawContent.slice(closingIndex + 5)
+
+  let frontmatter: Record<string, unknown>
+  try {
+    frontmatter = parseYamlFrontmatter(frontmatterText)
+  } catch {
+    try {
+      const quoted = quoteProblematicValues(frontmatterText)
+      frontmatter = parseYamlFrontmatter(quoted)
+    } catch {
+      return { content: bodyContent }
+    }
+  }
+
+  if (!frontmatter.paths) {
+    return { content: bodyContent }
+  }
+
+  // Convert paths to array and expand braces FIRST (before splitting on commas)
+  let expanded: string[]
+  if (Array.isArray(frontmatter.paths)) {
+    expanded = frontmatter.paths.flatMap((p) =>
+      typeof p === 'string' ? expandBraces(p) : [],
+    )
+  } else if (typeof frontmatter.paths === 'string') {
+    expanded = expandBraces(frontmatter.paths)
+  } else {
+    expanded = []
+  }
+
+  // Split on commas (for comma-separated paths)
+  const rawPaths = expanded.flatMap((p) => p.split(',').map((s) => s.trim()))
+
+  const cleaned = rawPaths
+    .map((p) => {
+      // Only strip /** if there's at least one slash before it (e.g., src/core/** → src/core)
+      // Don't strip for simple patterns like a/** or b/**
+      if (!p.endsWith('/**')) return p
+      const withoutSuffix = p.slice(0, -3)
+      return withoutSuffix.includes('/') ? withoutSuffix : p
+    })
+    .filter((p) => p.length > 0)
+
+  if (cleaned.length === 0 || cleaned.every((p) => p === '**')) {
+    return { content: bodyContent }
+  }
+
+  return { content: bodyContent, paths: cleaned }
+}
+
+function parseYamlFrontmatter(text: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  const lines = text.split('\n')
+
+  for (let i = 0; i < lines.length; i++) {
+    const kvMatch = lines[i].match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/)
+    if (!kvMatch) continue
+    const key = kvMatch[1]
+    const rawValue = kvMatch[2].trim()
+
+    if (rawValue === '') {
+      const items: string[] = []
+      for (let j = i + 1; j < lines.length; j++) {
+        const itemMatch = lines[j].match(/^\s+-\s+(.+)$/)
+        if (!itemMatch) break
+        items.push(itemMatch[1].trim())
+      }
+      if (items.length > 0) {
+        result[key] = items
+      }
+    } else {
+      result[key] = stripWrappingQuotes(rawValue)
+    }
+  }
+  return result
+}
+
+function quoteProblematicValues(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => {
+      const kvMatch = line.match(/^([A-Za-z0-9_-]+)\s*:\s*(.+)$/)
+      if (!kvMatch) return line
+      const key = kvMatch[1]
+      const value = kvMatch[2]
+      if (/^["']/.test(value)) return line
+      if (/[{}[\]*,&#!|>%@`]/.test(value)) {
+        return `${key}: "${value}"`
+      }
+      return line
+    })
+    .join('\n')
+}
+
+function stripWrappingQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+function expandBraces(pattern: string): string[] {
+  const openIdx = pattern.indexOf('{')
+  if (openIdx === -1) return [pattern]
+
+  const closeIdx = pattern.lastIndexOf('}')
+  if (closeIdx === -1 || closeIdx <= openIdx) return [pattern]
+
+  const before = pattern.slice(0, openIdx)
+  const after = pattern.slice(closeIdx + 1)
+  const inner = pattern.slice(openIdx + 1, closeIdx)
+  const alternatives = inner.split(',').map((s) => s.trim())
+
+  return alternatives.flatMap((alt) => expandBraces(before + alt + after))
+}
+
+export function extractIncludePaths(content: string): string[] {
+  const tokens = marked.lexer(content, { gfm: false })
+  const paths: string[] = []
+
+  function walkTokens(tokenList: Token[]): void {
+    for (const token of tokenList) {
+      if (token.type === 'code' || token.type === 'codespan') {
+        continue
+      }
+      if (token.type === 'html') {
+        continue
+      }
+      if ('text' in token && typeof token.text === 'string') {
+        const regex = /(?:^|\s)@((?:[^\s\\]|\\ )+)/g
+        let match: RegExpExecArray | null
+        while ((match = regex.exec(token.text)) !== null) {
+          let path = match[1]
+          const hashIdx = path.indexOf('#')
+          if (hashIdx !== -1) {
+            path = path.slice(0, hashIdx)
+          }
+          if (path.length > 0) {
+            paths.push(path)
+          }
+        }
+      }
+      if ('tokens' in token && Array.isArray(token.tokens)) {
+        walkTokens(token.tokens)
+      }
+      if ('items' in token && Array.isArray(token.items)) {
+        walkTokens(token.items as Token[])
+      }
+    }
+  }
+
+  walkTokens(tokens)
+  return paths
+}
+
+export function resolveIncludePath({
+  includePath,
+  currentFilePath,
+  vaultRoot,
+}: {
+  includePath: string
+  currentFilePath: string
+  vaultRoot: string
+}): string | null {
+  let resolved: string
+
+  if (includePath.startsWith('~/')) {
+    resolved = includePath.slice(2)
+  } else if (includePath.startsWith('./') || !includePath.startsWith('/')) {
+    const dir = dirname(currentFilePath)
+    resolved = join(dir, includePath)
+  } else {
+    if (vaultRoot) {
+      if (!includePath.startsWith(vaultRoot)) {
+        return null
+      }
+      resolved = includePath.slice(vaultRoot.length)
+    } else {
+      return null
+    }
+  }
+
+  const normalized = normalizePath(resolved)
+  if (normalized.startsWith('..') || isAbsolute(normalized)) {
+    return null
+  }
+
+  return normalized
+}
+
+export async function processIncludes({
+  content,
+  currentFilePath,
+  fileReader,
+  processedPaths,
+  depth,
+  vaultRoot,
+}: {
+  content: string
+  currentFilePath: string
+  fileReader: (path: string) => Promise<string | null>
+  processedPaths: Set<string>
+  depth: number
+  vaultRoot: string
+}): Promise<string> {
+  if (depth >= MAX_INCLUDE_DEPTH) {
+    return content
+  }
+
+  processedPaths.add(normalizePath(currentFilePath))
+
+  const includePaths = extractIncludePaths(content)
+  if (includePaths.length === 0) {
+    return content
+  }
+
+  let result = content
+
+  for (const rawPath of includePaths) {
+    const resolvedPath = resolveIncludePath({
+      includePath: rawPath,
+      currentFilePath,
+      vaultRoot,
+    })
+    if (!resolvedPath) continue
+
+    const normalized = normalizePath(resolvedPath)
+    if (processedPaths.has(normalized)) continue
+
+    const includedContent = await fileReader(resolvedPath)
+    if (includedContent === null) {
+      // Remove the include reference for non-existent files (including surrounding newlines)
+      const escapedPath = rawPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      const regex = new RegExp(`(?:\\n?|^)@${escapedPath}(?:\\n?|$)`, 'g')
+      result = result.replace(regex, '\n').replace(/\n+/g, '\n')
+      continue
+    }
+
+    processedPaths.add(normalized)
+
+    const expandedContent = await processIncludes({
+      content: includedContent,
+      currentFilePath: resolvedPath,
+      fileReader,
+      processedPaths,
+      depth: depth + 1,
+      vaultRoot,
+    })
+
+    const escapedPath = rawPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp(`@${escapedPath}`, 'g')
+    result = result.replace(regex, expandedContent)
+  }
+
+  return result
+}

--- a/src/core/claude-md/claudeMdTypes.ts
+++ b/src/core/claude-md/claudeMdTypes.ts
@@ -1,0 +1,27 @@
+export type DiscoveredFile = {
+  path: string
+  type: 'project' | 'rule'
+}
+
+export type ParsedFrontmatter = {
+  content: string
+  paths?: string[]
+}
+
+export type ParsedMemoryFile = {
+  filePath: string
+  content: string
+  paths?: string[]
+}
+
+export type CacheEntry = {
+  rawContent: string
+  mtime: number
+  parsed: ParsedMemoryFile
+}
+
+export const CLAUDE_MD_FILENAME = 'CLAUDE.md'
+export const CLAUDE_RULES_DIR = '.claude/rules'
+export const MAX_INCLUDE_DEPTH = 5
+export const MAX_RULE_FILE_LINES = 500
+export const MAX_CACHE_SIZE = 100

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import {
   BackgroundActivityAction,
   BackgroundActivityRegistry,
 } from './core/background/backgroundActivityRegistry'
+import { clearClaudeMdCache } from './core/claude-md/claudeMdIntegration'
 import { clearRequestTransportMemory } from './core/llm/requestTransport'
 import { McpCoordinator } from './core/mcp/mcpCoordinator'
 import type { McpManager } from './core/mcp/mcpManager'
@@ -1914,6 +1915,7 @@ export default class SmartComposerPlugin extends Plugin {
   }
 
   onunload() {
+    clearClaudeMdCache()
     this.closeSmartSpace()
 
     // Selection chat cleanup

--- a/src/types/assistant.types.ts
+++ b/src/types/assistant.types.ts
@@ -74,6 +74,7 @@ export const assistantSchema = z.object({
     .record(z.string(), assistantSkillPreferenceSchema)
     .optional(),
   workspaceScope: assistantWorkspaceScopeSchema.optional(),
+  enableClaudeMd: z.boolean().optional(),
   createdAt: z.number().optional(),
   updatedAt: z.number().optional(),
 })

--- a/src/utils/chat/requestContextBuilder.test.ts
+++ b/src/utils/chat/requestContextBuilder.test.ts
@@ -13,6 +13,10 @@ jest.mock('../llm/image', () => ({
   tFileToImageDataUrl: jest.fn(async () => 'data:image/png;base64,fake'),
 }))
 
+jest.mock('../../core/claude-md/claudeMdIntegration', () => ({
+  getProjectContext: jest.fn(async () => ''),
+}))
+
 import type { SmartComposerSettings } from '../../settings/schema/setting.types'
 import type { ChatUserMessage } from '../../types/chat'
 import type { ChatModel } from '../../types/chat-model.types'

--- a/src/utils/chat/requestContextBuilder.ts
+++ b/src/utils/chat/requestContextBuilder.ts
@@ -7,6 +7,7 @@ import {
   buildCompactionResumeMessage,
   buildCompactionSummaryMessage,
 } from '../../core/agent/compaction'
+import { getProjectContext } from '../../core/claude-md/claudeMdIntegration'
 import { getMemoryPromptContext } from '../../core/memory/memoryManager'
 import {
   getLiteSkillDocument,
@@ -1085,9 +1086,21 @@ ${quotes
 
     const baseBehaviorSection = this.buildDefaultBehaviorSection(hasTools)
 
-    const sections = [customInstructionsSection, baseBehaviorSection].filter(
-      Boolean,
+    const currentAssistantId = this.settings.currentAssistantId
+    const assistants = this.settings.assistants || []
+    const currentAssistant = currentAssistantId
+      ? assistants.find((a) => a.id === currentAssistantId)
+      : null
+    const projectContextSection = await getProjectContext(
+      this.app,
+      currentAssistant?.enableClaudeMd !== false,
     )
+
+    const sections = [
+      customInstructionsSection,
+      baseBehaviorSection,
+      projectContextSection,
+    ].filter(Boolean)
 
     return {
       role: 'system',


### PR DESCRIPTION
## Summary

实现 CLAUDE.md 项目上下文兼容层，使 YOLO Agent 能够自动加载并遵循 vault 中已有的 `CLAUDE.md` 和 `.claude/rules/*.md` 规则文件，与 Claude Code / Claude Desktop 的项目指令格式完全兼容，无需任何迁移或配置。

### 核心能力

- **文件发现**：自动扫描 vault 根目录的 `CLAUDE.md` 和 `.claude/rules/*.md`（含 `.cursor/rules` 兼容）
- **完整解析**：支持 YAML frontmatter `paths` 条件匹配、`@include` 引用展开、HTML 注释剥离
- **静态注入**：无条件规则在 system prompt 构建时一次性注入，所有对话均可获取
- **动态注入**：带 `paths` 前缀的条件规则在 Agent 使用文件工具时按需注入，避免无关上下文占用 token
- **mtime 缓存**：基于文件修改时间的 FIFO 缓存（上限 100 条），避免重复解析
- **Agent 级开关**：每个 Agent 可独立控制是否启用 CLAUDE.md 兼容，默认开启

### 为什么做这个

**与 Claude 生态无缝兼容**是最大的收益。

Claude Code、Claude Desktop 以及社区中大量工具（如 Claudian、Cursor 等）都使用 `CLAUDE.md` + `.claude/rules/*.md` 作为项目指令的标准格式。用户已经在这些工具中精心维护了项目规范、编码风格、上下文指令等信息。

YOLO 现在直接读取并遵循这些文件，意味着：

- **一份指令，多处生效** — 用户维护的 `CLAUDE.md` 在 Claude Code、Claude Desktop、YOLO 之间共享，无需重复配置
- **平滑迁移** — 从 Claude Code 切换到 YOLO 的用户，所有项目上下文指令自动生效，零迁移成本
- **生态互操作** — 使用 Claudian 等插件在 Obsidian 中管理知识库的用户，YOLO Agent 直接理解同一套规则
- **移动端延续** — 在移动端 Claude Code 不可用时，YOLO 作为补充方案仍能获取完整的项目上下文

### 收益

| 维度 | 收益 |
|------|------|
| **Claude 生态兼容** | 与 Claude Code / Claude Desktop 共享同一套 CLAUDE.md 规则，无需重复维护 |
| **零配置** | 自动发现 vault 中已有的 CLAUDE.md 文件，开箱即用 |
| **按需注入** | `paths` 条件规则仅在匹配时注入，减少无关 token 消耗 |
| **向后兼容** | 默认开启，可选关闭；不影响未使用 CLAUDE.md 的用户 |
| **缓存优化** | mtime 感知缓存 + FIFO 驱逐，避免重复文件 I/O 和解析开销 |

## Changed files

- **新增 `src/core/claude-md/`** — 完整的 CLAUDE.md 兼容模块（发现、解析、缓存、注入）
- **`src/components/chat-view/useChatStreamManager.ts`** — 静态注入传递 enableClaudeMd
- **`src/components/panels/quick-ask/QuickAskPanel.tsx`** — Quick Ask 模式传递 enableClaudeMd
- **`src/components/settings/sections/AgentsSectionContent.tsx`** — Agent 设置页新增"兼容 CLAUDE.md 项目上下文"开关
- **`src/core/agent/tool-gateway.ts`** — 动态条件规则注入（按需匹配 paths）
- **`src/core/agent/native-runtime.ts`** — 传递 enableClaudeMd 到 tool-gateway
- **`src/core/agent/types.ts`** — AgentRuntimeRunInput 新增 enableClaudeMd
- **`src/types/assistant.types.ts`** — assistant schema 新增 enableClaudeMd
- **`src/utils/chat/requestContextBuilder.ts`** — 静态规则注入 system prompt
- **`src/main.ts`** — vault rename 时清除缓存

## Test plan

- [ ] 在 vault 根目录放置 `CLAUDE.md`，验证 Agent 对话中是否遵循其中指令
- [ ] 在 `.claude/rules/` 下创建带 `paths` frontmatter 的条件规则文件，验证仅在匹配的文件操作时注入
- [ ] 在 Agent 设置中关闭"兼容 CLAUDE.md 项目上下文"，验证不再注入任何 CLAUDE.md 内容
- [ ] 验证 `@include` 引用展开和 HTML 注释剥离正常工作
- [ ] 验证缓存命中（同一文件不重复读取）和 FIFO 驱逐（超过 100 条时淘汰最早条目）
- [ ] 运行 `npm test` 确认新增单元测试全部通过