### PR TITLE
feat: add settings import/export functionality

### DIFF
--- a/src/components/settings/sections/EtcSection.tsx
+++ b/src/components/settings/sections/EtcSection.tsx
@@ -22,6 +22,8 @@ import { clearPdfTextCache } from '../../../database/json/chat/pdfTextCacheStore
 import { clearAllPromptSnapshotStores } from '../../../database/json/chat/promptSnapshotStore'
 import { clearAllTimelineHeightCacheStores } from '../../../database/json/chat/timelineHeightCacheStore'
 import { CHAT_DIR } from '../../../database/json/constants'
+import { ExportConfigModal } from '../../../features/config-transfer/components/ExportConfigModal'
+import { ImportConfigModal } from '../../../features/config-transfer/components/ImportConfigModal'
 import YoloPlugin from '../../../main'
 import { yoloSettingsSchema } from '../../../settings/schema/setting.types'
 import { ObsidianButton } from '../../common/ObsidianButton'
@@ -142,7 +144,7 @@ const StorageBadge = ({ value }: { value: number | null }) => {
   )
 }
 
-export function EtcSection({ app, className }: EtcSectionProps) {
+export function EtcSection({ app, plugin, className }: EtcSectionProps) {
   const { settings, setSettings } = useSettings()
   const { t } = useLanguage()
   const yoloBaseDir = settings.yolo?.baseDir ?? 'YOLO'
@@ -333,6 +335,34 @@ export function EtcSection({ app, className }: EtcSectionProps) {
         </div>
 
         <div className="yolo-settings-block-content">
+          <ObsidianSetting
+            name={t('settings.etc.exportConfig', '导出配置')}
+            desc={t(
+              'settings.etc.exportConfigDesc',
+              '将当前插件配置导出为 JSON 文件，方便在其他笔记库中导入使用。',
+            )}
+            className="yolo-settings-card"
+          >
+            <ObsidianButton
+              text={t('settings.etc.export', '导出')}
+              onClick={() => new ExportConfigModal(app, plugin).open()}
+            />
+          </ObsidianSetting>
+
+          <ObsidianSetting
+            name={t('settings.etc.importConfig', '导入配置')}
+            desc={t(
+              'settings.etc.importConfigDesc',
+              '从导出文件或其他笔记库导入插件配置。',
+            )}
+            className="yolo-settings-card"
+          >
+            <ObsidianButton
+              text={t('settings.etc.import', '导入')}
+              onClick={() => new ImportConfigModal(app, plugin).open()}
+            />
+          </ObsidianSetting>
+
           <ObsidianSetting
             name={t('settings.etc.yoloBaseDir', 'YOLO 根目录')}
             desc={t(

--- a/src/core/agent/todos-from-messages.test.ts
+++ b/src/core/agent/todos-from-messages.test.ts
@@ -59,10 +59,7 @@ describe('deriveTodosFromMessages', () => {
   it('returns todos from the latest todo_write tool call', () => {
     const messages: ChatMessage[] = [
       userMessage('start'),
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
       todoWriteToolMessage(
         [
           { content: 'A', status: 'completed' },
@@ -79,10 +76,7 @@ describe('deriveTodosFromMessages', () => {
 
   it('returns empty when the latest todo_write was an empty list (explicit clear)', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
       todoWriteToolMessage([], 'm2'),
     ]
     expect(deriveTodosFromMessages(messages)).toEqual([])
@@ -138,10 +132,7 @@ describe('deriveTodosFromMessages', () => {
 
   it('skips a failed todo_write and falls back to the previous successful state', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
       todoWriteToolMessage('not-an-array', 'm2', {
         status: ToolCallResponseStatus.Error,
         error: 'todos must be an array.',
@@ -154,15 +145,10 @@ describe('deriveTodosFromMessages', () => {
 
   it('skips a rejected todo_write and falls back to the previous successful state', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
-      todoWriteToolMessage(
-        [{ content: 'B', status: 'pending' }],
-        'm2',
-        { status: ToolCallResponseStatus.Rejected },
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
+      todoWriteToolMessage([{ content: 'B', status: 'pending' }], 'm2', {
+        status: ToolCallResponseStatus.Rejected,
+      }),
     ]
     expect(deriveTodosFromMessages(messages)).toEqual([
       { content: 'A', status: 'pending' },
@@ -171,15 +157,10 @@ describe('deriveTodosFromMessages', () => {
 
   it('skips a still-running todo_write so UI never shows un-committed args', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
-      todoWriteToolMessage(
-        [{ content: 'B', status: 'in_progress' }],
-        'm2',
-        { status: ToolCallResponseStatus.Running },
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
+      todoWriteToolMessage([{ content: 'B', status: 'in_progress' }], 'm2', {
+        status: ToolCallResponseStatus.Running,
+      }),
     ]
     expect(deriveTodosFromMessages(messages)).toEqual([
       { content: 'A', status: 'pending' },
@@ -188,15 +169,10 @@ describe('deriveTodosFromMessages', () => {
 
   it('skips an aborted todo_write and falls back to the previous successful state', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
-      todoWriteToolMessage(
-        [{ content: 'B', status: 'pending' }],
-        'm2',
-        { status: ToolCallResponseStatus.Aborted },
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
+      todoWriteToolMessage([{ content: 'B', status: 'pending' }], 'm2', {
+        status: ToolCallResponseStatus.Aborted,
+      }),
     ]
     expect(deriveTodosFromMessages(messages)).toEqual([
       { content: 'A', status: 'pending' },
@@ -205,15 +181,10 @@ describe('deriveTodosFromMessages', () => {
 
   it('skips a pending-approval todo_write', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
-      todoWriteToolMessage(
-        [{ content: 'B', status: 'pending' }],
-        'm2',
-        { status: ToolCallResponseStatus.PendingApproval },
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
+      todoWriteToolMessage([{ content: 'B', status: 'pending' }], 'm2', {
+        status: ToolCallResponseStatus.PendingApproval,
+      }),
     ]
     expect(deriveTodosFromMessages(messages)).toEqual([
       { content: 'A', status: 'pending' },
@@ -222,11 +193,9 @@ describe('deriveTodosFromMessages', () => {
 
   it('returns empty when the only todo_write call has not succeeded yet', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-        { status: ToolCallResponseStatus.Running },
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1', {
+        status: ToolCallResponseStatus.Running,
+      }),
     ]
     expect(deriveTodosFromMessages(messages)).toEqual([])
   })
@@ -251,10 +220,7 @@ describe('deriveTodosFromMessages', () => {
 
   it('returns frozen array (callers cannot mutate)', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
     ]
     const result = deriveTodosFromMessages(messages)
     expect(Object.isFrozen(result)).toBe(true)
@@ -269,10 +235,7 @@ describe('findTodoSeriesStartId', () => {
 
   it('returns the first call id as the series start', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
     ]
     expect(findTodoSeriesStartId(messages)).toBe('m1-call')
   })
@@ -307,48 +270,30 @@ describe('findTodoSeriesStartId', () => {
 
   it('starts a new series when the previous list was all completed', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'completed' }],
-        'm1',
-      ),
-      todoWriteToolMessage(
-        [{ content: 'B', status: 'pending' }],
-        'm2',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'completed' }], 'm1'),
+      todoWriteToolMessage([{ content: 'B', status: 'pending' }], 'm2'),
     ]
     expect(findTodoSeriesStartId(messages)).toBe('m2-call')
   })
 
   it('starts a new series when the previous list was empty (explicit clear)', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
       todoWriteToolMessage([], 'm2'),
-      todoWriteToolMessage(
-        [{ content: 'B', status: 'pending' }],
-        'm3',
-      ),
+      todoWriteToolMessage([{ content: 'B', status: 'pending' }], 'm3'),
     ]
     expect(findTodoSeriesStartId(messages)).toBe('m3-call')
   })
 
   it('ignores non-success todo_write calls when computing the series', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
       // Failed write does not affect series detection.
       todoWriteToolMessage('bad', 'm2', {
         status: ToolCallResponseStatus.Error,
         error: 'todos must be an array.',
       }),
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'completed' }],
-        'm3',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'completed' }], 'm3'),
     ]
     // m3 follows m1 (m2 ignored); m1 had an active item so m3 is a continuation.
     expect(findTodoSeriesStartId(messages)).toBe('m1-call')
@@ -356,22 +301,10 @@ describe('findTodoSeriesStartId', () => {
 
   it('handles multiple series in one message stream', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'pending' }],
-        'm1',
-      ),
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'completed' }],
-        'm2',
-      ),
-      todoWriteToolMessage(
-        [{ content: 'B', status: 'pending' }],
-        'm3',
-      ),
-      todoWriteToolMessage(
-        [{ content: 'B', status: 'in_progress' }],
-        'm4',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'pending' }], 'm1'),
+      todoWriteToolMessage([{ content: 'A', status: 'completed' }], 'm2'),
+      todoWriteToolMessage([{ content: 'B', status: 'pending' }], 'm3'),
+      todoWriteToolMessage([{ content: 'B', status: 'in_progress' }], 'm4'),
     ]
     expect(findTodoSeriesStartId(messages)).toBe('m3-call')
   })
@@ -398,10 +331,7 @@ describe('findLatestCompletedTodoWriteId', () => {
 
   it('returns null when latest list is an explicit empty (no completion to mark)', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'completed' }],
-        'm1',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'completed' }], 'm1'),
       todoWriteToolMessage([], 'm2'),
     ]
     expect(findLatestCompletedTodoWriteId(messages)).toBeNull()
@@ -422,10 +352,7 @@ describe('findLatestCompletedTodoWriteId', () => {
 
   it('returns the latest matching write, not an older one', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'completed' }],
-        'm1',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'completed' }], 'm1'),
       todoWriteToolMessage(
         [
           { content: 'A', status: 'completed' },
@@ -439,10 +366,7 @@ describe('findLatestCompletedTodoWriteId', () => {
 
   it('skips non-success todo_write calls', () => {
     const messages: ChatMessage[] = [
-      todoWriteToolMessage(
-        [{ content: 'A', status: 'completed' }],
-        'm1',
-      ),
+      todoWriteToolMessage([{ content: 'A', status: 'completed' }], 'm1'),
       // Failed write does not change the "completed write" identity.
       todoWriteToolMessage('bad', 'm2', {
         status: ToolCallResponseStatus.Error,

--- a/src/features/config-transfer/components/ExportConfigModal.tsx
+++ b/src/features/config-transfer/components/ExportConfigModal.tsx
@@ -1,11 +1,12 @@
 import { App, Notice } from 'obsidian'
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 
 import { ReactModal } from '../../../components/common/ReactModal'
 import { useLanguage } from '../../../contexts/language-context'
 import YoloPlugin from '../../../main'
 import { EXPORTABLE_CONFIG_KEYS } from '../config-keys'
 import { buildExportData } from '../export-config'
+import { hasNonEmptyCredentials } from '../redact'
 
 type ExportConfigModalComponentProps = {
   plugin: YoloPlugin
@@ -34,6 +35,18 @@ function ExportConfigModalComponent({
     new Set(EXPORTABLE_CONFIG_KEYS.map((k) => k.key)),
   )
   const [redacted, setRedacted] = useState(false)
+
+  // 基于当前实际配置探测每个顶层 key 是否含有非空凭证；
+  // 取自 plugin.settings 而非懒加载 loadData()，因为 settings 已在内存且
+  // 包含所有 schema 内字段，仅用于 UI 标记，不影响导出流程的真实数据来源。
+  const credentialsByKey = useMemo(() => {
+    const settings = plugin.settings as unknown as Record<string, unknown>
+    const map: Record<string, boolean> = {}
+    for (const item of EXPORTABLE_CONFIG_KEYS) {
+      map[item.key] = hasNonEmptyCredentials(settings?.[item.key])
+    }
+    return map
+  }, [plugin.settings])
 
   const toggleKey = (key: string) => {
     setSelectedKeys((prev) => {
@@ -143,7 +156,7 @@ function ExportConfigModalComponent({
               {t(`configTransfer.keyLabels.${item.key}`, item.fallbackLabel)}
               <span className="yolo-config-transfer-item-key">{item.key}</span>
             </span>
-            {item.sensitive && (
+            {credentialsByKey[item.key] && (
               <span className="yolo-config-transfer-sensitive">
                 {t('configTransfer.export.sensitive', '含凭证')}
               </span>

--- a/src/features/config-transfer/components/ExportConfigModal.tsx
+++ b/src/features/config-transfer/components/ExportConfigModal.tsx
@@ -1,0 +1,149 @@
+import { App, Notice } from 'obsidian'
+import React, { useState } from 'react'
+
+import { ReactModal } from '../../../components/common/ReactModal'
+import YoloPlugin from '../../../main'
+import { EXPORTABLE_CONFIG_KEYS } from '../config-keys'
+import { buildExportData } from '../export-config'
+
+type ExportConfigModalComponentProps = {
+  plugin: YoloPlugin
+}
+
+export class ExportConfigModal extends ReactModal<ExportConfigModalComponentProps> {
+  constructor(app: App, plugin: YoloPlugin) {
+    super({
+      app,
+      Component: ExportConfigModalComponent,
+      props: { plugin },
+      options: { title: '导出配置' },
+      plugin,
+    })
+  }
+}
+
+function ExportConfigModalComponent({
+  plugin,
+  onClose,
+}: ExportConfigModalComponentProps & { onClose: () => void }) {
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(
+    new Set(EXPORTABLE_CONFIG_KEYS.map((k) => k.key)),
+  )
+  const [redacted, setRedacted] = useState(false)
+
+  const toggleKey = (key: string) => {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
+
+  const selectAll = () => {
+    setSelectedKeys(new Set(EXPORTABLE_CONFIG_KEYS.map((k) => k.key)))
+  }
+
+  const selectNone = () => {
+    setSelectedKeys(new Set())
+  }
+
+  const handleExport = async () => {
+    if (selectedKeys.size === 0) {
+      new Notice('请至少选择一项配置')
+      return
+    }
+
+    try {
+      const settingsData = (await plugin.loadData()) as Record<
+        string,
+        unknown
+      > | null
+      if (!settingsData || typeof settingsData !== 'object') {
+        new Notice('无法读取当前配置数据')
+        return
+      }
+
+      const manifest = plugin.manifest
+
+      const exportData = await buildExportData({
+        keys: Array.from(selectedKeys),
+        settingsData,
+        pluginVersion: manifest.version,
+        redacted,
+      })
+
+      const json = JSON.stringify(exportData, null, 2)
+      const dateStr = new Date().toISOString().slice(0, 10)
+      const fileName = `yolo-config-${dateStr}.json`
+
+      const blob = new Blob([json], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = fileName
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+
+      new Notice(`配置已导出为 ${fileName}`)
+      onClose()
+    } catch (err) {
+      console.error('Failed to export config', err)
+      new Notice('配置导出失败，请检查控制台日志')
+    }
+  }
+
+  return (
+    <div className="yolo-config-transfer-modal">
+      <div className="yolo-config-transfer-toolbar">
+        <div className="yolo-config-transfer-desc">选择要导出的配置项</div>
+        <div className="yolo-config-transfer-toolbar-actions">
+          <button onClick={selectAll}>全选</button>
+          <button onClick={selectNone}>全不选</button>
+        </div>
+      </div>
+
+      <div className="yolo-config-transfer-list">
+        {EXPORTABLE_CONFIG_KEYS.map((item) => (
+          <label key={item.key} className="yolo-config-transfer-item">
+            <input
+              type="checkbox"
+              checked={selectedKeys.has(item.key)}
+              onChange={() => toggleKey(item.key)}
+            />
+            <span className="yolo-config-transfer-item-label">
+              {item.label}
+              <span className="yolo-config-transfer-item-key">{item.key}</span>
+            </span>
+            {item.sensitive && (
+              <span className="yolo-config-transfer-sensitive">含 API Key</span>
+            )}
+          </label>
+        ))}
+      </div>
+
+      <label className="yolo-config-transfer-option">
+        <input
+          type="checkbox"
+          checked={redacted}
+          onChange={(e) => setRedacted(e.target.checked)}
+        />
+        脱敏导出（将 API Key 替换为随机字符串）
+      </label>
+
+      <div className="modal-button-container">
+        <button className="mod-cta" onClick={() => void handleExport()}>
+          导出
+        </button>
+        <button className="mod-cancel" onClick={onClose}>
+          取消
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/config-transfer/components/ExportConfigModal.tsx
+++ b/src/features/config-transfer/components/ExportConfigModal.tsx
@@ -2,6 +2,7 @@ import { App, Notice } from 'obsidian'
 import React, { useState } from 'react'
 
 import { ReactModal } from '../../../components/common/ReactModal'
+import { useLanguage } from '../../../contexts/language-context'
 import YoloPlugin from '../../../main'
 import { EXPORTABLE_CONFIG_KEYS } from '../config-keys'
 import { buildExportData } from '../export-config'
@@ -16,7 +17,9 @@ export class ExportConfigModal extends ReactModal<ExportConfigModalComponentProp
       app,
       Component: ExportConfigModalComponent,
       props: { plugin },
-      options: { title: '导出配置' },
+      options: {
+        title: plugin.t('configTransfer.export.title', '导出配置'),
+      },
       plugin,
     })
   }
@@ -26,6 +29,7 @@ function ExportConfigModalComponent({
   plugin,
   onClose,
 }: ExportConfigModalComponentProps & { onClose: () => void }) {
+  const { t } = useLanguage()
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(
     new Set(EXPORTABLE_CONFIG_KEYS.map((k) => k.key)),
   )
@@ -53,7 +57,9 @@ function ExportConfigModalComponent({
 
   const handleExport = async () => {
     if (selectedKeys.size === 0) {
-      new Notice('请至少选择一项配置')
+      new Notice(
+        t('configTransfer.export.noticeAtLeastOne', '请至少选择一项配置'),
+      )
       return
     }
 
@@ -63,7 +69,9 @@ function ExportConfigModalComponent({
         unknown
       > | null
       if (!settingsData || typeof settingsData !== 'object') {
-        new Notice('无法读取当前配置数据')
+        new Notice(
+          t('configTransfer.export.noticeReadFailed', '无法读取当前配置数据'),
+        )
         return
       }
 
@@ -90,21 +98,36 @@ function ExportConfigModalComponent({
       document.body.removeChild(a)
       URL.revokeObjectURL(url)
 
-      new Notice(`配置已导出为 ${fileName}`)
+      const successTemplate = t(
+        'configTransfer.export.noticeSuccess',
+        '配置已导出为 {fileName}',
+      )
+      new Notice(successTemplate.replace('{fileName}', fileName))
       onClose()
     } catch (err) {
       console.error('Failed to export config', err)
-      new Notice('配置导出失败，请检查控制台日志')
+      new Notice(
+        t(
+          'configTransfer.export.noticeFailed',
+          '配置导出失败，请检查控制台日志',
+        ),
+      )
     }
   }
 
   return (
     <div className="yolo-config-transfer-modal">
       <div className="yolo-config-transfer-toolbar">
-        <div className="yolo-config-transfer-desc">选择要导出的配置项</div>
+        <div className="yolo-config-transfer-desc">
+          {t('configTransfer.export.description', '选择要导出的配置项')}
+        </div>
         <div className="yolo-config-transfer-toolbar-actions">
-          <button onClick={selectAll}>全选</button>
-          <button onClick={selectNone}>全不选</button>
+          <button onClick={selectAll}>
+            {t('configTransfer.export.selectAll', '全选')}
+          </button>
+          <button onClick={selectNone}>
+            {t('configTransfer.export.selectNone', '全不选')}
+          </button>
         </div>
       </div>
 
@@ -117,11 +140,13 @@ function ExportConfigModalComponent({
               onChange={() => toggleKey(item.key)}
             />
             <span className="yolo-config-transfer-item-label">
-              {item.label}
+              {t(`configTransfer.keyLabels.${item.key}`, item.fallbackLabel)}
               <span className="yolo-config-transfer-item-key">{item.key}</span>
             </span>
             {item.sensitive && (
-              <span className="yolo-config-transfer-sensitive">含 API Key</span>
+              <span className="yolo-config-transfer-sensitive">
+                {t('configTransfer.export.sensitive', '含凭证')}
+              </span>
             )}
           </label>
         ))}
@@ -133,15 +158,18 @@ function ExportConfigModalComponent({
           checked={redacted}
           onChange={(e) => setRedacted(e.target.checked)}
         />
-        脱敏导出（将 API Key 替换为随机字符串）
+        {t(
+          'configTransfer.export.redactedOption',
+          '脱敏导出（替换 API Key / 密码 / Header / 环境变量等凭证为随机字符串）',
+        )}
       </label>
 
       <div className="modal-button-container">
         <button className="mod-cta" onClick={() => void handleExport()}>
-          导出
+          {t('configTransfer.export.submit', '导出')}
         </button>
         <button className="mod-cancel" onClick={onClose}>
-          取消
+          {t('configTransfer.export.cancel', '取消')}
         </button>
       </div>
     </div>

--- a/src/features/config-transfer/components/ImportConfigModal.tsx
+++ b/src/features/config-transfer/components/ImportConfigModal.tsx
@@ -1,0 +1,320 @@
+import { App, Notice, Platform } from 'obsidian'
+import React, { useCallback, useState } from 'react'
+
+import { ReactModal } from '../../../components/common/ReactModal'
+import YoloPlugin from '../../../main'
+import { EXCLUDED_KEYS, EXPORTABLE_CONFIG_KEYS } from '../config-keys'
+import {
+  applyImport,
+  parseVaultData,
+  validateExportFile,
+} from '../import-config'
+import { ConfigExportFile, MergeStrategy } from '../types'
+
+type ImportConfigModalComponentProps = {
+  plugin: YoloPlugin
+}
+
+export class ImportConfigModal extends ReactModal<ImportConfigModalComponentProps> {
+  constructor(app: App, plugin: YoloPlugin) {
+    super({
+      app,
+      Component: ImportConfigModalComponent,
+      props: { plugin },
+      options: { title: '导入配置' },
+      plugin,
+    })
+  }
+}
+
+type ImportStep = 'source' | 'select'
+
+function ImportConfigModalComponent({
+  plugin,
+  onClose,
+}: ImportConfigModalComponentProps & { onClose: () => void }) {
+  const [step, setStep] = useState<ImportStep>('source')
+  const [importData, setImportData] = useState<ConfigExportFile | null>(null)
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
+  const [mergeStrategy, setMergeStrategy] = useState<MergeStrategy>('overwrite')
+
+  const handleFileImport = useCallback(() => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.json'
+    input.onchange = async (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0]
+      if (!file) return
+
+      try {
+        const text = await file.text()
+        let raw: unknown
+        try {
+          raw = JSON.parse(text)
+        } catch {
+          new Notice(
+            '文件不是有效的 JSON 格式，请确认选择了正确的配置文件。',
+            5000,
+          )
+          return
+        }
+        const result = await validateExportFile(raw)
+        if (!result.valid) {
+          new Notice(result.error, 5000)
+          return
+        }
+        setImportData(result.data)
+        setSelectedKeys(new Set(result.data.keys))
+        setStep('select')
+        if (result.data.redacted) {
+          new Notice('注意：该配置为脱敏导出，API Key 需导入后手动补填', 5000)
+        }
+      } catch {
+        new Notice('文件读取失败，请重试。', 5000)
+      }
+    }
+    input.click()
+  }, [])
+
+  const handleVaultImport = useCallback(() => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.setAttribute('webkitdirectory', '')
+    input.setAttribute('directory', '')
+    input.onchange = async (e) => {
+      const files = (e.target as HTMLInputElement).files
+      if (!files || files.length === 0) return
+
+      let dataJsonFile: File | null = null
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i]
+        const relativePath = file.webkitRelativePath
+        // 在外部笔记库中查找 YOLO 配置文件，需要匹配常见的配置目录名
+        /* eslint-disable obsidianmd/hardcoded-config-path */
+        const configDirPatterns = [
+          '.obsidian/plugins/yolo/data.json',
+          '.obsidian/plugins/obsidian-yolo/data.json',
+        ]
+        /* eslint-enable obsidianmd/hardcoded-config-path */
+        if (
+          configDirPatterns.some((pattern) => relativePath.includes(pattern))
+        ) {
+          dataJsonFile = file
+          break
+        }
+      }
+
+      if (!dataJsonFile) {
+        new Notice('未在该目录找到 YOLO 插件配置', 5000)
+        return
+      }
+
+      try {
+        const text = await dataJsonFile.text()
+        let raw: unknown
+        try {
+          raw = JSON.parse(text)
+        } catch {
+          new Notice('配置文件不是有效的 JSON 格式', 5000)
+          return
+        }
+        const result = parseVaultData(raw, plugin.manifest.version)
+        if (!result.valid) {
+          new Notice(result.error, 5000)
+          return
+        }
+        setImportData(result.data)
+        setSelectedKeys(
+          new Set(result.data.keys.filter((k) => !EXCLUDED_KEYS.has(k))),
+        )
+        setStep('select')
+      } catch {
+        new Notice('配置文件读取失败', 5000)
+      }
+    }
+    input.click()
+  }, [plugin])
+
+  const toggleKey = (key: string) => {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
+
+  const selectAll = () => {
+    if (importData) {
+      setSelectedKeys(
+        new Set(importData.keys.filter((k) => !EXCLUDED_KEYS.has(k))),
+      )
+    }
+  }
+
+  const selectNone = () => {
+    setSelectedKeys(new Set())
+  }
+
+  const handleImport = async () => {
+    if (!importData) return
+    if (selectedKeys.size === 0) {
+      new Notice('请至少选择一项配置')
+      return
+    }
+
+    try {
+      const currentSettings = plugin.settings
+      const result = applyImport({
+        importData,
+        selectedKeys: Array.from(selectedKeys),
+        currentSettings,
+        mergeStrategy,
+      })
+
+      await plugin.setSettings(result)
+      new Notice('配置导入成功')
+
+      if (importData.redacted) {
+        new Notice('注意：该配置为脱敏导出，API Key 需手动补填', 5000)
+      }
+
+      onClose()
+    } catch (err) {
+      console.error('Failed to import config', err)
+      new Notice('配置导入失败，请检查控制台日志')
+    }
+  }
+
+  const availableKeys = importData
+    ? EXPORTABLE_CONFIG_KEYS.filter((k) => importData.keys.includes(k.key))
+    : []
+
+  const extraKeys = importData
+    ? importData.keys.filter(
+        (k) =>
+          !EXCLUDED_KEYS.has(k) &&
+          !EXPORTABLE_CONFIG_KEYS.some((ek) => ek.key === k),
+      )
+    : []
+
+  if (step === 'source') {
+    return (
+      <div className="yolo-config-transfer-modal">
+        <div className="yolo-config-transfer-source-buttons">
+          <button
+            className="yolo-config-transfer-source-btn"
+            onClick={handleFileImport}
+          >
+            <strong>从配置文件导入</strong>
+            <span>选择之前导出的 .json 文件</span>
+          </button>
+
+          {Platform.isDesktop && (
+            <button
+              className="yolo-config-transfer-source-btn"
+              onClick={handleVaultImport}
+            >
+              <strong>从其他笔记库导入</strong>
+              <span>选择已安装 YOLO 的笔记库目录</span>
+            </button>
+          )}
+        </div>
+
+        <div className="modal-button-container">
+          <button className="mod-cancel" onClick={onClose}>
+            取消
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="yolo-config-transfer-modal">
+      <div className="yolo-config-transfer-toolbar">
+        <div className="yolo-config-transfer-desc">选择要导入的配置项</div>
+        <div className="yolo-config-transfer-toolbar-actions">
+          <button onClick={selectAll}>全选</button>
+          <button onClick={selectNone}>全不选</button>
+        </div>
+      </div>
+
+      <div className="yolo-config-transfer-list">
+        {availableKeys.map((item) => (
+          <label key={item.key} className="yolo-config-transfer-item">
+            <input
+              type="checkbox"
+              checked={selectedKeys.has(item.key)}
+              onChange={() => toggleKey(item.key)}
+            />
+            <span className="yolo-config-transfer-item-label">
+              {item.label}
+              <span className="yolo-config-transfer-item-key">{item.key}</span>
+            </span>
+            {item.sensitive && (
+              <span className="yolo-config-transfer-sensitive">含 API Key</span>
+            )}
+          </label>
+        ))}
+        {extraKeys.map((key) => (
+          <label key={key} className="yolo-config-transfer-item">
+            <input
+              type="checkbox"
+              checked={selectedKeys.has(key)}
+              onChange={() => toggleKey(key)}
+            />
+            <span className="yolo-config-transfer-item-label">
+              {key}
+              <span className="yolo-config-transfer-item-key">{key}</span>
+            </span>
+          </label>
+        ))}
+      </div>
+
+      <div className="yolo-config-transfer-strategy">
+        <label
+          className={`yolo-config-transfer-strategy-option${mergeStrategy === 'overwrite' ? ' is-selected' : ''}`}
+          onClick={() => setMergeStrategy('overwrite')}
+        >
+          <span className="yolo-config-transfer-radio">
+            {mergeStrategy === 'overwrite' && (
+              <span className="yolo-config-transfer-radio-dot" />
+            )}
+          </span>
+          <span>
+            <strong>全量覆盖</strong> — 用导入的配置替换选中项
+          </span>
+        </label>
+        <label
+          className={`yolo-config-transfer-strategy-option${mergeStrategy === 'merge' ? ' is-selected' : ''}`}
+          onClick={() => setMergeStrategy('merge')}
+        >
+          <span className="yolo-config-transfer-radio">
+            {mergeStrategy === 'merge' && (
+              <span className="yolo-config-transfer-radio-dot" />
+            )}
+          </span>
+          <span>
+            <strong>JSON 合并</strong> — 深度合并，保留未冲突的现有值
+          </span>
+        </label>
+      </div>
+
+      <div className="modal-button-container">
+        <button className="mod-cta" onClick={() => void handleImport()}>
+          确认导入
+        </button>
+        <button className="mod-cancel" onClick={() => setStep('source')}>
+          返回
+        </button>
+        <button className="mod-cancel" onClick={onClose}>
+          取消
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/config-transfer/components/ImportConfigModal.tsx
+++ b/src/features/config-transfer/components/ImportConfigModal.tsx
@@ -2,12 +2,14 @@ import { App, Notice, Platform } from 'obsidian'
 import React, { useCallback, useState } from 'react'
 
 import { ReactModal } from '../../../components/common/ReactModal'
+import { useLanguage } from '../../../contexts/language-context'
 import YoloPlugin from '../../../main'
 import { EXCLUDED_KEYS, EXPORTABLE_CONFIG_KEYS } from '../config-keys'
 import {
-  applyImport,
   ImportValidationError,
+  applyImport,
   parseVaultData,
+  renderImportError,
   validateExportFile,
 } from '../import-config'
 import { ConfigExportFile, MergeStrategy } from '../types'
@@ -22,7 +24,9 @@ export class ImportConfigModal extends ReactModal<ImportConfigModalComponentProp
       app,
       Component: ImportConfigModalComponent,
       props: { plugin },
-      options: { title: '导入配置' },
+      options: {
+        title: plugin.t('configTransfer.import.title', '导入配置'),
+      },
       plugin,
     })
   }
@@ -34,6 +38,7 @@ function ImportConfigModalComponent({
   plugin,
   onClose,
 }: ImportConfigModalComponentProps & { onClose: () => void }) {
+  const { t } = useLanguage()
   const [step, setStep] = useState<ImportStep>('source')
   const [importData, setImportData] = useState<ConfigExportFile | null>(null)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
@@ -54,28 +59,43 @@ function ImportConfigModalComponent({
           raw = JSON.parse(text)
         } catch {
           new Notice(
-            '文件不是有效的 JSON 格式，请确认选择了正确的配置文件。',
+            t(
+              'configTransfer.import.noticeInvalidJson',
+              '文件不是有效的 JSON 格式，请确认选择了正确的配置文件。',
+            ),
             5000,
           )
           return
         }
         const result = await validateExportFile(raw)
         if (!result.valid) {
-          new Notice(result.error, 5000)
+          new Notice(renderImportError(result, t), 5000)
           return
         }
         setImportData(result.data)
         setSelectedKeys(new Set(result.data.keys))
         setStep('select')
         if (result.data.redacted) {
-          new Notice('注意：该配置为脱敏导出，API Key 需导入后手动补填', 5000)
+          new Notice(
+            t(
+              'configTransfer.import.noticeRedactedHint',
+              '注意：该配置为脱敏导出，所有 API Key / 密码 / Header / 环境变量已被清空，需导入后手动补填。',
+            ),
+            5000,
+          )
         }
       } catch {
-        new Notice('文件读取失败，请重试。', 5000)
+        new Notice(
+          t(
+            'configTransfer.import.noticeFileReadFailed',
+            '文件读取失败，请重试。',
+          ),
+          5000,
+        )
       }
     }
     input.click()
-  }, [])
+  }, [t])
 
   const handleVaultImport = useCallback(() => {
     const input = document.createElement('input')
@@ -106,7 +126,13 @@ function ImportConfigModalComponent({
       }
 
       if (!dataJsonFile) {
-        new Notice('未在该目录找到 YOLO 插件配置', 5000)
+        new Notice(
+          t(
+            'configTransfer.import.noticePluginNotFound',
+            '未在该目录找到 YOLO 插件配置',
+          ),
+          5000,
+        )
         return
       }
 
@@ -116,12 +142,18 @@ function ImportConfigModalComponent({
         try {
           raw = JSON.parse(text)
         } catch {
-          new Notice('配置文件不是有效的 JSON 格式', 5000)
+          new Notice(
+            t(
+              'configTransfer.import.noticeInvalidJson',
+              '配置文件不是有效的 JSON 格式',
+            ),
+            5000,
+          )
           return
         }
         const result = parseVaultData(raw, plugin.manifest.version)
         if (!result.valid) {
-          new Notice(result.error, 5000)
+          new Notice(renderImportError(result, t), 5000)
           return
         }
         setImportData(result.data)
@@ -130,11 +162,14 @@ function ImportConfigModalComponent({
         )
         setStep('select')
       } catch {
-        new Notice('配置文件读取失败', 5000)
+        new Notice(
+          t('configTransfer.import.noticeFileReadFailed', '配置文件读取失败'),
+          5000,
+        )
       }
     }
     input.click()
-  }, [plugin])
+  }, [plugin, t])
 
   const toggleKey = (key: string) => {
     setSelectedKeys((prev) => {
@@ -163,7 +198,9 @@ function ImportConfigModalComponent({
   const handleImport = async () => {
     if (!importData) return
     if (selectedKeys.size === 0) {
-      new Notice('请至少选择一项配置')
+      new Notice(
+        t('configTransfer.import.noticeAtLeastOne', '请至少选择一项配置'),
+      )
       return
     }
 
@@ -177,22 +214,33 @@ function ImportConfigModalComponent({
       })
 
       await plugin.setSettings(result)
-      new Notice('配置导入成功')
+      new Notice(t('configTransfer.import.noticeSuccess', '配置导入成功'))
 
       if (importData.redacted) {
-        new Notice('注意：该配置为脱敏导出，API Key 需手动补填', 5000)
+        new Notice(
+          t(
+            'configTransfer.import.noticeRedactedReminder',
+            '注意：该配置为脱敏导出，所有 API Key / 密码 / Header / 环境变量已被清空，请前往设置补填。',
+          ),
+          5000,
+        )
       }
 
       onClose()
     } catch (err) {
       console.error('Failed to import config', err)
+      const failedPrefix = t(
+        'configTransfer.import.noticeFailed',
+        '配置导入失败',
+      )
       if (err instanceof ImportValidationError) {
+        const reason = renderImportError(err, t)
         const detail =
           err.issues.length > 0 ? `\n${err.issues.slice(0, 5).join('\n')}` : ''
-        new Notice(`配置导入失败：${err.message}${detail}`, 8000)
+        new Notice(`${failedPrefix}：${reason}${detail}`, 8000)
       } else {
         const message = err instanceof Error ? err.message : String(err)
-        new Notice(`配置导入失败：${message}`, 8000)
+        new Notice(`${failedPrefix}：${message}`, 8000)
       }
     }
   }
@@ -209,8 +257,15 @@ function ImportConfigModalComponent({
             className="yolo-config-transfer-source-btn"
             onClick={handleFileImport}
           >
-            <strong>从配置文件导入</strong>
-            <span>选择之前导出的 .json 文件</span>
+            <strong>
+              {t('configTransfer.import.sourceFile', '从配置文件导入')}
+            </strong>
+            <span>
+              {t(
+                'configTransfer.import.sourceFileDesc',
+                '选择之前导出的 .json 文件',
+              )}
+            </span>
           </button>
 
           {Platform.isDesktop && (
@@ -218,15 +273,22 @@ function ImportConfigModalComponent({
               className="yolo-config-transfer-source-btn"
               onClick={handleVaultImport}
             >
-              <strong>从其他笔记库导入</strong>
-              <span>选择已安装 YOLO 的笔记库目录</span>
+              <strong>
+                {t('configTransfer.import.sourceVault', '从其他笔记库导入')}
+              </strong>
+              <span>
+                {t(
+                  'configTransfer.import.sourceVaultDesc',
+                  '选择已安装 YOLO 的笔记库目录',
+                )}
+              </span>
             </button>
           )}
         </div>
 
         <div className="modal-button-container">
           <button className="mod-cancel" onClick={onClose}>
-            取消
+            {t('configTransfer.import.cancel', '取消')}
           </button>
         </div>
       </div>
@@ -236,10 +298,16 @@ function ImportConfigModalComponent({
   return (
     <div className="yolo-config-transfer-modal">
       <div className="yolo-config-transfer-toolbar">
-        <div className="yolo-config-transfer-desc">选择要导入的配置项</div>
+        <div className="yolo-config-transfer-desc">
+          {t('configTransfer.import.description', '选择要导入的配置项')}
+        </div>
         <div className="yolo-config-transfer-toolbar-actions">
-          <button onClick={selectAll}>全选</button>
-          <button onClick={selectNone}>全不选</button>
+          <button onClick={selectAll}>
+            {t('configTransfer.import.selectAll', '全选')}
+          </button>
+          <button onClick={selectNone}>
+            {t('configTransfer.import.selectNone', '全不选')}
+          </button>
         </div>
       </div>
 
@@ -252,11 +320,13 @@ function ImportConfigModalComponent({
               onChange={() => toggleKey(item.key)}
             />
             <span className="yolo-config-transfer-item-label">
-              {item.label}
+              {t(`configTransfer.keyLabels.${item.key}`, item.fallbackLabel)}
               <span className="yolo-config-transfer-item-key">{item.key}</span>
             </span>
             {item.sensitive && (
-              <span className="yolo-config-transfer-sensitive">含 API Key</span>
+              <span className="yolo-config-transfer-sensitive">
+                {t('configTransfer.import.sensitive', '含凭证')}
+              </span>
             )}
           </label>
         ))}
@@ -273,7 +343,14 @@ function ImportConfigModalComponent({
             )}
           </span>
           <span>
-            <strong>全量覆盖</strong> — 用导入的配置替换选中项
+            <strong>
+              {t('configTransfer.import.strategyOverwriteTitle', '全量覆盖')}
+            </strong>
+            {' — '}
+            {t(
+              'configTransfer.import.strategyOverwriteDesc',
+              '用导入的配置替换选中项',
+            )}
           </span>
         </label>
         <label
@@ -286,20 +363,27 @@ function ImportConfigModalComponent({
             )}
           </span>
           <span>
-            <strong>JSON 合并</strong> — 深度合并，保留未冲突的现有值
+            <strong>
+              {t('configTransfer.import.strategyMergeTitle', 'JSON 合并')}
+            </strong>
+            {' — '}
+            {t(
+              'configTransfer.import.strategyMergeDesc',
+              '深度合并，保留未冲突的现有值',
+            )}
           </span>
         </label>
       </div>
 
       <div className="modal-button-container">
         <button className="mod-cta" onClick={() => void handleImport()}>
-          确认导入
+          {t('configTransfer.import.submit', '确认导入')}
         </button>
         <button className="mod-cancel" onClick={() => setStep('source')}>
-          返回
+          {t('configTransfer.import.back', '返回')}
         </button>
         <button className="mod-cancel" onClick={onClose}>
-          取消
+          {t('configTransfer.import.cancel', '取消')}
         </button>
       </div>
     </div>

--- a/src/features/config-transfer/components/ImportConfigModal.tsx
+++ b/src/features/config-transfer/components/ImportConfigModal.tsx
@@ -1,5 +1,5 @@
 import { App, Notice, Platform } from 'obsidian'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
 import { ReactModal } from '../../../components/common/ReactModal'
 import { useLanguage } from '../../../contexts/language-context'
@@ -12,6 +12,7 @@ import {
   renderImportError,
   validateExportFile,
 } from '../import-config'
+import { hasNonEmptyCredentials } from '../redact'
 import { ConfigExportFile, MergeStrategy } from '../types'
 
 type ImportConfigModalComponentProps = {
@@ -249,6 +250,18 @@ function ImportConfigModalComponent({
     ? EXPORTABLE_CONFIG_KEYS.filter((k) => importData.keys.includes(k.key))
     : []
 
+  // 基于待导入数据的实际内容判定哪些 key 含凭证。脱敏导出（redacted=true）
+  // 时所有敏感字段都是随机字符串，仍判定为"含凭证"——因为提示用户"这部分
+  // 涉及凭证、会被清空"是正确的语义。
+  const credentialsByKey = useMemo(() => {
+    const map: Record<string, boolean> = {}
+    if (!importData) return map
+    for (const item of availableKeys) {
+      map[item.key] = hasNonEmptyCredentials(importData.data[item.key])
+    }
+    return map
+  }, [importData, availableKeys])
+
   if (step === 'source') {
     return (
       <div className="yolo-config-transfer-modal">
@@ -323,7 +336,7 @@ function ImportConfigModalComponent({
               {t(`configTransfer.keyLabels.${item.key}`, item.fallbackLabel)}
               <span className="yolo-config-transfer-item-key">{item.key}</span>
             </span>
-            {item.sensitive && (
+            {credentialsByKey[item.key] && (
               <span className="yolo-config-transfer-sensitive">
                 {t('configTransfer.import.sensitive', '含凭证')}
               </span>

--- a/src/features/config-transfer/components/ImportConfigModal.tsx
+++ b/src/features/config-transfer/components/ImportConfigModal.tsx
@@ -6,6 +6,7 @@ import YoloPlugin from '../../../main'
 import { EXCLUDED_KEYS, EXPORTABLE_CONFIG_KEYS } from '../config-keys'
 import {
   applyImport,
+  ImportValidationError,
   parseVaultData,
   validateExportFile,
 } from '../import-config'
@@ -185,20 +186,19 @@ function ImportConfigModalComponent({
       onClose()
     } catch (err) {
       console.error('Failed to import config', err)
-      new Notice('配置导入失败，请检查控制台日志')
+      if (err instanceof ImportValidationError) {
+        const detail =
+          err.issues.length > 0 ? `\n${err.issues.slice(0, 5).join('\n')}` : ''
+        new Notice(`配置导入失败：${err.message}${detail}`, 8000)
+      } else {
+        const message = err instanceof Error ? err.message : String(err)
+        new Notice(`配置导入失败：${message}`, 8000)
+      }
     }
   }
 
   const availableKeys = importData
     ? EXPORTABLE_CONFIG_KEYS.filter((k) => importData.keys.includes(k.key))
-    : []
-
-  const extraKeys = importData
-    ? importData.keys.filter(
-        (k) =>
-          !EXCLUDED_KEYS.has(k) &&
-          !EXPORTABLE_CONFIG_KEYS.some((ek) => ek.key === k),
-      )
     : []
 
   if (step === 'source') {
@@ -258,19 +258,6 @@ function ImportConfigModalComponent({
             {item.sensitive && (
               <span className="yolo-config-transfer-sensitive">含 API Key</span>
             )}
-          </label>
-        ))}
-        {extraKeys.map((key) => (
-          <label key={key} className="yolo-config-transfer-item">
-            <input
-              type="checkbox"
-              checked={selectedKeys.has(key)}
-              onChange={() => toggleKey(key)}
-            />
-            <span className="yolo-config-transfer-item-label">
-              {key}
-              <span className="yolo-config-transfer-item-key">{key}</span>
-            </span>
           </label>
         ))}
       </div>

--- a/src/features/config-transfer/config-keys.ts
+++ b/src/features/config-transfer/config-keys.ts
@@ -1,0 +1,32 @@
+import { ConfigKeyMeta } from './types'
+
+/**
+ * 可导入/导出的配置 key 列表及其元信息。
+ * 按 data.json 第一层级 key 划分。
+ */
+export const EXPORTABLE_CONFIG_KEYS: ConfigKeyMeta[] = [
+  { key: 'providers', label: 'AI 服务商', sensitive: true },
+  { key: 'chatModels', label: '对话模型' },
+  { key: 'embeddingModels', label: '嵌入模型' },
+  { key: 'chatModelId', label: '默认对话模型' },
+  { key: 'chatTitleModelId', label: '标题生成模型' },
+  { key: 'embeddingModelId', label: '默认嵌入模型' },
+  { key: 'systemPrompt', label: '系统提示词' },
+  { key: 'ragOptions', label: '知识库设置' },
+  { key: 'mcp', label: 'MCP 工具' },
+  { key: 'webSearch', label: '联网搜索', sensitive: true },
+  { key: 'skills', label: '技能设置' },
+  { key: 'yolo', label: '基础设置' },
+  { key: 'debug', label: '调试设置' },
+  { key: 'chatOptions', label: '对话偏好' },
+  { key: 'notificationOptions', label: '通知设置' },
+  { key: 'continuationOptions', label: '续写与补全' },
+  { key: 'assistants', label: 'Agent 配置' },
+  { key: 'currentAssistantId', label: '当前 Agent' },
+  { key: 'quickAskAssistantId', label: 'Quick Ask Agent' },
+]
+
+/**
+ * 不参与导入导出的内部字段
+ */
+export const EXCLUDED_KEYS = new Set(['version', '__meta'])

--- a/src/features/config-transfer/config-keys.ts
+++ b/src/features/config-transfer/config-keys.ts
@@ -3,14 +3,16 @@ import { ConfigKeyMeta } from './types'
 /**
  * 可导入/导出的配置 key 列表及其元信息。
  * 按 data.json 第一层级 key 划分。
+ *
  * 显示用文案优先通过 i18n key `configTransfer.keyLabels.<key>` 查找，
  * 缺失时回退到 `fallbackLabel`（避免 Italian 等未翻译语种直接显示 raw key）。
  *
- * `sensitive` 表示该 key 包含凭证（apiKey / password / headers / env / customHeaders.value），
- * UI 会提示用户，脱敏导出/导入清空也按此覆盖。
+ * "是否含凭证"由 `hasNonEmptyCredentials()` 对实际数据动态探测，
+ * 不在此处用静态标记 —— 同一个类目（如 mcp / providers）在不同用户的
+ * 配置里可能有或没有真凭证，类目级别打标会误导。
  */
 export const EXPORTABLE_CONFIG_KEYS: ConfigKeyMeta[] = [
-  { key: 'providers', fallbackLabel: 'AI 服务商', sensitive: true },
+  { key: 'providers', fallbackLabel: 'AI 服务商' },
   { key: 'chatModels', fallbackLabel: '对话模型' },
   { key: 'embeddingModels', fallbackLabel: '嵌入模型' },
   { key: 'chatModelId', fallbackLabel: '默认对话模型' },
@@ -18,8 +20,8 @@ export const EXPORTABLE_CONFIG_KEYS: ConfigKeyMeta[] = [
   { key: 'embeddingModelId', fallbackLabel: '默认嵌入模型' },
   { key: 'systemPrompt', fallbackLabel: '系统提示词' },
   { key: 'ragOptions', fallbackLabel: '知识库设置' },
-  { key: 'mcp', fallbackLabel: 'MCP 工具', sensitive: true },
-  { key: 'webSearch', fallbackLabel: '联网搜索', sensitive: true },
+  { key: 'mcp', fallbackLabel: 'MCP 工具' },
+  { key: 'webSearch', fallbackLabel: '联网搜索' },
   { key: 'skills', fallbackLabel: '技能设置' },
   { key: 'yolo', fallbackLabel: '基础设置' },
   { key: 'debug', fallbackLabel: '调试设置' },

--- a/src/features/config-transfer/config-keys.ts
+++ b/src/features/config-transfer/config-keys.ts
@@ -3,27 +3,32 @@ import { ConfigKeyMeta } from './types'
 /**
  * 可导入/导出的配置 key 列表及其元信息。
  * 按 data.json 第一层级 key 划分。
+ * 显示用文案优先通过 i18n key `configTransfer.keyLabels.<key>` 查找，
+ * 缺失时回退到 `fallbackLabel`（避免 Italian 等未翻译语种直接显示 raw key）。
+ *
+ * `sensitive` 表示该 key 包含凭证（apiKey / password / headers / env / customHeaders.value），
+ * UI 会提示用户，脱敏导出/导入清空也按此覆盖。
  */
 export const EXPORTABLE_CONFIG_KEYS: ConfigKeyMeta[] = [
-  { key: 'providers', label: 'AI 服务商', sensitive: true },
-  { key: 'chatModels', label: '对话模型' },
-  { key: 'embeddingModels', label: '嵌入模型' },
-  { key: 'chatModelId', label: '默认对话模型' },
-  { key: 'chatTitleModelId', label: '标题生成模型' },
-  { key: 'embeddingModelId', label: '默认嵌入模型' },
-  { key: 'systemPrompt', label: '系统提示词' },
-  { key: 'ragOptions', label: '知识库设置' },
-  { key: 'mcp', label: 'MCP 工具' },
-  { key: 'webSearch', label: '联网搜索', sensitive: true },
-  { key: 'skills', label: '技能设置' },
-  { key: 'yolo', label: '基础设置' },
-  { key: 'debug', label: '调试设置' },
-  { key: 'chatOptions', label: '对话偏好' },
-  { key: 'notificationOptions', label: '通知设置' },
-  { key: 'continuationOptions', label: '续写与补全' },
-  { key: 'assistants', label: 'Agent 配置' },
-  { key: 'currentAssistantId', label: '当前 Agent' },
-  { key: 'quickAskAssistantId', label: 'Quick Ask Agent' },
+  { key: 'providers', fallbackLabel: 'AI 服务商', sensitive: true },
+  { key: 'chatModels', fallbackLabel: '对话模型' },
+  { key: 'embeddingModels', fallbackLabel: '嵌入模型' },
+  { key: 'chatModelId', fallbackLabel: '默认对话模型' },
+  { key: 'chatTitleModelId', fallbackLabel: '标题生成模型' },
+  { key: 'embeddingModelId', fallbackLabel: '默认嵌入模型' },
+  { key: 'systemPrompt', fallbackLabel: '系统提示词' },
+  { key: 'ragOptions', fallbackLabel: '知识库设置' },
+  { key: 'mcp', fallbackLabel: 'MCP 工具', sensitive: true },
+  { key: 'webSearch', fallbackLabel: '联网搜索', sensitive: true },
+  { key: 'skills', fallbackLabel: '技能设置' },
+  { key: 'yolo', fallbackLabel: '基础设置' },
+  { key: 'debug', fallbackLabel: '调试设置' },
+  { key: 'chatOptions', fallbackLabel: '对话偏好' },
+  { key: 'notificationOptions', fallbackLabel: '通知设置' },
+  { key: 'continuationOptions', fallbackLabel: '续写与补全' },
+  { key: 'assistants', fallbackLabel: 'Agent 配置' },
+  { key: 'currentAssistantId', fallbackLabel: '当前 Agent' },
+  { key: 'quickAskAssistantId', fallbackLabel: 'Quick Ask Agent' },
 ]
 
 /**

--- a/src/features/config-transfer/export-config.test.ts
+++ b/src/features/config-transfer/export-config.test.ts
@@ -1,0 +1,210 @@
+import { SETTINGS_SCHEMA_VERSION } from '../../settings/schema/migrations'
+
+import {
+  buildExportData,
+  computeChecksum,
+  redactApiKeys,
+} from './export-config'
+import { CONFIG_EXPORT_FORMAT_VERSION } from './types'
+
+describe('redactApiKeys', () => {
+  it('should replace apiKey string values with random strings of same length', () => {
+    const data = {
+      id: 'provider-1',
+      apiKey: 'sk-1234567890abcdef',
+      baseUrl: 'https://api.example.com',
+    }
+    const result = redactApiKeys(data) as Record<string, unknown>
+    expect(result.id).toBe('provider-1')
+    expect(result.baseUrl).toBe('https://api.example.com')
+    expect(result.apiKey).not.toBe('sk-1234567890abcdef')
+    expect((result.apiKey as string).length).toBe('sk-1234567890abcdef'.length)
+  })
+
+  it('should handle empty apiKey', () => {
+    const data = { apiKey: '' }
+    const result = redactApiKeys(data) as Record<string, unknown>
+    expect(result.apiKey).toBe('')
+  })
+
+  it('should recursively redact apiKey in nested objects', () => {
+    const data = {
+      providers: [
+        { id: 'a', apiKey: 'key-aaa' },
+        { id: 'b', apiKey: 'key-bbb' },
+      ],
+      webSearch: {
+        providers: [{ id: 'c', apiKey: 'key-ccc' }],
+      },
+    }
+    const result = redactApiKeys(data) as Record<string, unknown>
+    const providers = result.providers as Array<Record<string, unknown>>
+    expect(providers[0].apiKey).not.toBe('key-aaa')
+    expect((providers[0].apiKey as string).length).toBe('key-aaa'.length)
+    expect(providers[1].apiKey).not.toBe('key-bbb')
+
+    const webSearch = result.webSearch as Record<string, unknown>
+    const wsProviders = webSearch.providers as Array<Record<string, unknown>>
+    expect(wsProviders[0].apiKey).not.toBe('key-ccc')
+    expect((wsProviders[0].apiKey as string).length).toBe('key-ccc'.length)
+  })
+
+  it('should not modify non-apiKey fields', () => {
+    const data = {
+      name: 'test',
+      key: 'not-an-api-key',
+      nested: { value: 123 },
+    }
+    const result = redactApiKeys(data)
+    expect(result).toEqual(data)
+  })
+
+  it('should handle null and primitive values', () => {
+    expect(redactApiKeys(null)).toBeNull()
+    expect(redactApiKeys(42)).toBe(42)
+    expect(redactApiKeys('hello')).toBe('hello')
+    expect(redactApiKeys(undefined)).toBeUndefined()
+  })
+})
+
+describe('computeChecksum', () => {
+  it('should produce a hex string of 64 characters (SHA-256)', async () => {
+    const hash = await computeChecksum('hello world')
+    expect(hash).toHaveLength(64)
+    expect(hash).toMatch(/^[0-9a-f]+$/)
+  })
+
+  it('should produce different hashes for different inputs', async () => {
+    const hash1 = await computeChecksum('hello')
+    const hash2 = await computeChecksum('world')
+    expect(hash1).not.toBe(hash2)
+  })
+
+  it('should produce the same hash for the same input', async () => {
+    const hash1 = await computeChecksum('test content')
+    const hash2 = await computeChecksum('test content')
+    expect(hash1).toBe(hash2)
+  })
+})
+
+describe('buildExportData', () => {
+  const mockSettings: Record<string, unknown> = {
+    version: 51,
+    __meta: { deviceId: 'test-device', updatedAt: 123456 },
+    providers: [
+      { id: 'ds', apiKey: 'sk-secret', baseUrl: 'https://api.deepseek.com' },
+    ],
+    chatModels: [{ id: 'ds/model', model: 'model', providerId: 'ds' }],
+    chatModelId: 'ds/model',
+    ragOptions: { enabled: true, chunkSize: 1000 },
+    systemPrompt: 'hello',
+  }
+
+  it('should export only selected keys', async () => {
+    const result = await buildExportData({
+      keys: ['providers', 'chatModelId'],
+      settingsData: mockSettings,
+      pluginVersion: '1.5.7.5',
+    })
+
+    expect(result.$schema).toBe('yolo-config-export')
+    expect(result.formatVersion).toBe(CONFIG_EXPORT_FORMAT_VERSION)
+    expect(result.settingsVersion).toBe(SETTINGS_SCHEMA_VERSION)
+    expect(result.pluginVersion).toBe('1.5.7.5')
+    expect(result.redacted).toBe(false)
+    expect(result.keys).toEqual(['providers', 'chatModelId'])
+    expect(result.data).toHaveProperty('providers')
+    expect(result.data).toHaveProperty('chatModelId')
+    expect(result.data).not.toHaveProperty('ragOptions')
+    expect(result.data).not.toHaveProperty('chatModels')
+  })
+
+  it('should exclude internal keys (version, __meta) even if selected', async () => {
+    const result = await buildExportData({
+      keys: ['version', '__meta', 'providers'],
+      settingsData: mockSettings,
+      pluginVersion: '1.5.7.5',
+    })
+
+    expect(result.data).not.toHaveProperty('version')
+    expect(result.data).not.toHaveProperty('__meta')
+    expect(result.data).toHaveProperty('providers')
+  })
+
+  it('should redact API keys when redacted option is true', async () => {
+    const result = await buildExportData({
+      keys: ['providers'],
+      settingsData: mockSettings,
+      pluginVersion: '1.5.7.5',
+      redacted: true,
+    })
+
+    expect(result.redacted).toBe(true)
+    const providers = result.data.providers as Array<Record<string, unknown>>
+    expect(providers[0].apiKey).not.toBe('sk-secret')
+    expect((providers[0].apiKey as string).length).toBe('sk-secret'.length)
+    expect(providers[0].baseUrl).toBe('https://api.deepseek.com')
+  })
+
+  it('should not redact API keys when redacted option is false', async () => {
+    const result = await buildExportData({
+      keys: ['providers'],
+      settingsData: mockSettings,
+      pluginVersion: '1.5.7.5',
+      redacted: false,
+    })
+
+    expect(result.redacted).toBe(false)
+    const providers = result.data.providers as Array<Record<string, unknown>>
+    expect(providers[0].apiKey).toBe('sk-secret')
+  })
+
+  it('should include a valid checksum', async () => {
+    const result = await buildExportData({
+      keys: ['chatModelId'],
+      settingsData: mockSettings,
+      pluginVersion: '1.5.7.5',
+    })
+
+    expect(result.checksum).toHaveLength(64)
+    expect(result.checksum).toMatch(/^[0-9a-f]+$/)
+
+    // Verify checksum matches payload without checksum field
+    const { checksum, ...payload } = result
+    const expectedChecksum = await computeChecksum(JSON.stringify(payload))
+    expect(checksum).toBe(expectedChecksum)
+  })
+
+  it('should handle keys that do not exist in settings', async () => {
+    const result = await buildExportData({
+      keys: ['nonExistentKey', 'chatModelId'],
+      settingsData: mockSettings,
+      pluginVersion: '1.5.7.5',
+    })
+
+    expect(result.data).not.toHaveProperty('nonExistentKey')
+    expect(result.data).toHaveProperty('chatModelId')
+  })
+
+  it('should produce empty data when all selected keys are missing from settings', async () => {
+    const result = await buildExportData({
+      keys: ['nonExistent1', 'nonExistent2'],
+      settingsData: mockSettings,
+      pluginVersion: '1.5.7.5',
+    })
+
+    expect(result.keys).toEqual(['nonExistent1', 'nonExistent2'])
+    expect(Object.keys(result.data)).toHaveLength(0)
+  })
+
+  it('should handle empty keys array', async () => {
+    const result = await buildExportData({
+      keys: [],
+      settingsData: mockSettings,
+      pluginVersion: '1.5.7.5',
+    })
+
+    expect(result.keys).toEqual([])
+    expect(Object.keys(result.data)).toHaveLength(0)
+  })
+})

--- a/src/features/config-transfer/export-config.test.ts
+++ b/src/features/config-transfer/export-config.test.ts
@@ -1,7 +1,11 @@
 import { SETTINGS_SCHEMA_VERSION } from '../../settings/schema/migrations'
 
 import { buildExportData, computeChecksum } from './export-config'
-import { clearSensitive, redactSensitive } from './redact'
+import {
+  clearSensitive,
+  hasNonEmptyCredentials,
+  redactSensitive,
+} from './redact'
 import { CONFIG_EXPORT_FORMAT_VERSION } from './types'
 
 describe('redactSensitive', () => {
@@ -165,6 +169,138 @@ describe('clearSensitive', () => {
     const params = mcpServers[0].parameters as Record<string, unknown>
     expect((params.headers as Record<string, string>).Authorization).toBe('')
     expect((params.env as Record<string, string>).TOKEN).toBe('')
+  })
+})
+
+describe('hasNonEmptyCredentials', () => {
+  it('returns false for empty / missing data', () => {
+    expect(hasNonEmptyCredentials(undefined)).toBe(false)
+    expect(hasNonEmptyCredentials(null)).toBe(false)
+    expect(hasNonEmptyCredentials({})).toBe(false)
+    expect(hasNonEmptyCredentials([])).toBe(false)
+  })
+
+  it('returns false when sensitive fields exist but are empty strings', () => {
+    expect(
+      hasNonEmptyCredentials({
+        providers: [{ id: 'a', apiKey: '' }],
+      }),
+    ).toBe(false)
+    expect(
+      hasNonEmptyCredentials({
+        mcp: {
+          servers: [
+            { parameters: { headers: { Authorization: '' }, env: {} } },
+          ],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('returns true when apiKey contains a value', () => {
+    expect(
+      hasNonEmptyCredentials({
+        providers: [{ id: 'a', apiKey: 'sk-real' }],
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when password contains a value', () => {
+    expect(
+      hasNonEmptyCredentials({
+        providers: [{ type: 'searxng', password: 'pw' }],
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when any header value is non-empty', () => {
+    expect(
+      hasNonEmptyCredentials({
+        mcp: {
+          servers: [
+            {
+              parameters: {
+                headers: { Authorization: 'Bearer x' },
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when any env value is non-empty', () => {
+    expect(
+      hasNonEmptyCredentials({
+        mcp: {
+          servers: [{ parameters: { env: { OPENAI_API_KEY: 'sk-env' } } }],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when customHeaders has a non-empty value', () => {
+    expect(
+      hasNonEmptyCredentials({
+        providers: [
+          {
+            customHeaders: [{ key: 'Authorization', value: 'Bearer xyz' }],
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  it('returns false for typical category without configured credentials (Ollama-only providers)', () => {
+    // 真实场景：用户只用本地 Ollama，没填 apiKey
+    expect(
+      hasNonEmptyCredentials({
+        providers: [
+          {
+            id: 'ollama',
+            presetType: 'ollama',
+            baseUrl: 'http://localhost:11434',
+            apiKey: '',
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false for stdio MCP server without env', () => {
+    expect(
+      hasNonEmptyCredentials({
+        servers: [
+          {
+            parameters: {
+              transport: 'stdio',
+              command: 'npx',
+              args: ['some-mcp'],
+            },
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  it('returns true if any element in an array has credentials', () => {
+    expect(
+      hasNonEmptyCredentials({
+        providers: [
+          { id: 'a', apiKey: '' },
+          { id: 'b', apiKey: 'sk-only-on-b' },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  it('ignores unrelated string fields with credential-like names', () => {
+    // 字段名不在白名单（如 key/secret/token）一律不算
+    expect(
+      hasNonEmptyCredentials({
+        providers: [{ id: 'a', key: 'not-an-apikey', token: 'still-no' }],
+      }),
+    ).toBe(false)
   })
 })
 

--- a/src/features/config-transfer/export-config.test.ts
+++ b/src/features/config-transfer/export-config.test.ts
@@ -1,33 +1,35 @@
 import { SETTINGS_SCHEMA_VERSION } from '../../settings/schema/migrations'
 
-import {
-  buildExportData,
-  computeChecksum,
-  redactApiKeys,
-} from './export-config'
+import { buildExportData, computeChecksum } from './export-config'
+import { clearSensitive, redactSensitive } from './redact'
 import { CONFIG_EXPORT_FORMAT_VERSION } from './types'
 
-describe('redactApiKeys', () => {
-  it('should replace apiKey string values with random strings of same length', () => {
+describe('redactSensitive', () => {
+  it('replaces apiKey/password with equal-length random strings', () => {
     const data = {
       id: 'provider-1',
       apiKey: 'sk-1234567890abcdef',
       baseUrl: 'https://api.example.com',
+      webSearch: { type: 'searxng', password: 'p@ss123' },
     }
-    const result = redactApiKeys(data) as Record<string, unknown>
+    const result = redactSensitive(data) as Record<string, unknown>
     expect(result.id).toBe('provider-1')
     expect(result.baseUrl).toBe('https://api.example.com')
     expect(result.apiKey).not.toBe('sk-1234567890abcdef')
     expect((result.apiKey as string).length).toBe('sk-1234567890abcdef'.length)
+    const ws = result.webSearch as Record<string, unknown>
+    expect(ws.password).not.toBe('p@ss123')
+    expect((ws.password as string).length).toBe('p@ss123'.length)
   })
 
-  it('should handle empty apiKey', () => {
-    const data = { apiKey: '' }
-    const result = redactApiKeys(data) as Record<string, unknown>
+  it('handles empty sensitive values', () => {
+    const data = { apiKey: '', password: '' }
+    const result = redactSensitive(data) as Record<string, unknown>
     expect(result.apiKey).toBe('')
+    expect(result.password).toBe('')
   })
 
-  it('should recursively redact apiKey in nested objects', () => {
+  it('recursively redacts apiKey in nested objects/arrays', () => {
     const data = {
       providers: [
         { id: 'a', apiKey: 'key-aaa' },
@@ -37,33 +39,132 @@ describe('redactApiKeys', () => {
         providers: [{ id: 'c', apiKey: 'key-ccc' }],
       },
     }
-    const result = redactApiKeys(data) as Record<string, unknown>
+    const result = redactSensitive(data) as Record<string, unknown>
     const providers = result.providers as Array<Record<string, unknown>>
     expect(providers[0].apiKey).not.toBe('key-aaa')
     expect((providers[0].apiKey as string).length).toBe('key-aaa'.length)
-    expect(providers[1].apiKey).not.toBe('key-bbb')
 
     const webSearch = result.webSearch as Record<string, unknown>
     const wsProviders = webSearch.providers as Array<Record<string, unknown>>
     expect(wsProviders[0].apiKey).not.toBe('key-ccc')
-    expect((wsProviders[0].apiKey as string).length).toBe('key-ccc'.length)
   })
 
-  it('should not modify non-apiKey fields', () => {
+  it('redacts every value inside headers / env objects', () => {
+    const data = {
+      mcp: {
+        servers: [
+          {
+            id: 's1',
+            parameters: {
+              transport: 'http',
+              url: 'https://example.com',
+              headers: {
+                Authorization: 'Bearer real-token',
+                'X-Org': 'org-id',
+              },
+            },
+          },
+          {
+            id: 's2',
+            parameters: {
+              transport: 'stdio',
+              command: 'node',
+              env: { OPENAI_API_KEY: 'sk-env', NODE_ENV: 'production' },
+            },
+          },
+        ],
+      },
+    }
+    const result = redactSensitive(data) as Record<string, unknown>
+    const mcp = result.mcp as Record<string, unknown>
+    const servers = mcp.servers as Array<Record<string, unknown>>
+
+    const headers = (servers[0].parameters as Record<string, unknown>)
+      .headers as Record<string, string>
+    expect(headers.Authorization).not.toBe('Bearer real-token')
+    expect(headers.Authorization.length).toBe('Bearer real-token'.length)
+    expect(headers['X-Org']).not.toBe('org-id')
+
+    const env = (servers[1].parameters as Record<string, unknown>)
+      .env as Record<string, string>
+    expect(env.OPENAI_API_KEY).not.toBe('sk-env')
+    expect(env.NODE_ENV).not.toBe('production')
+  })
+
+  it("redacts each customHeaders entry's value but preserves its key", () => {
+    const data = {
+      providers: [
+        {
+          id: 'p1',
+          customHeaders: [
+            { key: 'Authorization', value: 'Bearer xyz' },
+            { key: 'X-Trace', value: 'trace-1' },
+          ],
+        },
+      ],
+    }
+    const result = redactSensitive(data) as Record<string, unknown>
+    const providers = result.providers as Array<Record<string, unknown>>
+    const headers = providers[0].customHeaders as Array<Record<string, string>>
+    expect(headers[0].key).toBe('Authorization')
+    expect(headers[0].value).not.toBe('Bearer xyz')
+    expect(headers[0].value.length).toBe('Bearer xyz'.length)
+    expect(headers[1].key).toBe('X-Trace')
+    expect(headers[1].value).not.toBe('trace-1')
+  })
+
+  it('does not modify non-sensitive fields', () => {
     const data = {
       name: 'test',
       key: 'not-an-api-key',
       nested: { value: 123 },
     }
-    const result = redactApiKeys(data)
+    const result = redactSensitive(data)
     expect(result).toEqual(data)
   })
 
-  it('should handle null and primitive values', () => {
-    expect(redactApiKeys(null)).toBeNull()
-    expect(redactApiKeys(42)).toBe(42)
-    expect(redactApiKeys('hello')).toBe('hello')
-    expect(redactApiKeys(undefined)).toBeUndefined()
+  it('handles null and primitive values', () => {
+    expect(redactSensitive(null)).toBeNull()
+    expect(redactSensitive(42)).toBe(42)
+    expect(redactSensitive('hello')).toBe('hello')
+    expect(redactSensitive(undefined)).toBeUndefined()
+  })
+})
+
+describe('clearSensitive', () => {
+  it('clears every sensitive field covered by redactSensitive', () => {
+    const data = {
+      providers: [
+        {
+          apiKey: 'sk-real',
+          customHeaders: [{ key: 'Authorization', value: 'Bearer real' }],
+        },
+      ],
+      webSearch: { password: 'pw' },
+      mcp: {
+        servers: [
+          {
+            parameters: {
+              headers: { Authorization: 'Bearer' },
+              env: { TOKEN: 'tok' },
+            },
+          },
+        ],
+      },
+    }
+    const result = clearSensitive(data) as Record<string, unknown>
+    const providers = result.providers as Array<Record<string, unknown>>
+    expect(providers[0].apiKey).toBe('')
+    const ch = providers[0].customHeaders as Array<Record<string, string>>
+    expect(ch[0].value).toBe('')
+    expect(ch[0].key).toBe('Authorization')
+    expect((result.webSearch as Record<string, unknown>).password).toBe('')
+    const mcpServers = (result.mcp as Record<string, unknown>).servers as Array<
+      Record<string, unknown>
+    >
+    const params = mcpServers[0].parameters as Record<string, unknown>
+    expect((params.headers as Record<string, string>).Authorization).toBe('')
+    expect((params.env as Record<string, string>).TOKEN).toBe('')
   })
 })
 

--- a/src/features/config-transfer/export-config.ts
+++ b/src/features/config-transfer/export-config.ts
@@ -1,19 +1,8 @@
 import { SETTINGS_SCHEMA_VERSION } from '../../settings/schema/migrations'
 
 import { EXCLUDED_KEYS } from './config-keys'
+import { redactSensitive } from './redact'
 import { CONFIG_EXPORT_FORMAT_VERSION, ConfigExportFile } from './types'
-
-/**
- * 生成与原始 API Key 等长的随机字符串，用于脱敏导出。
- */
-function generateRandomString(length: number): string {
-  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-  let result = ''
-  for (let i = 0; i < length; i++) {
-    result += chars.charAt(Math.floor(Math.random() * chars.length))
-  }
-  return result
-}
 
 /**
  * 计算字符串的 SHA-256 哈希（hex 格式）。
@@ -24,31 +13,6 @@ export async function computeChecksum(content: string): Promise<string> {
   const hashBuffer = await crypto.subtle.digest('SHA-256', data)
   const hashArray = Array.from(new Uint8Array(hashBuffer))
   return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
-}
-
-/**
- * 递归遍历对象，将所有名为 apiKey 的字段替换为等长随机字符串。
- */
-export function redactApiKeys(data: unknown): unknown {
-  if (Array.isArray(data)) {
-    return data.map((item) => redactApiKeys(item))
-  }
-
-  if (typeof data === 'object' && data !== null) {
-    const result: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(
-      data as Record<string, unknown>,
-    )) {
-      if (key === 'apiKey' && typeof value === 'string') {
-        result[key] = value.length > 0 ? generateRandomString(value.length) : ''
-      } else {
-        result[key] = redactApiKeys(value)
-      }
-    }
-    return result
-  }
-
-  return data
 }
 
 export type ExportOptions = {
@@ -81,7 +45,7 @@ export async function buildExportData(
 
   // 脱敏处理
   const finalData = redacted
-    ? (redactApiKeys(data) as Record<string, unknown>)
+    ? (redactSensitive(data) as Record<string, unknown>)
     : data
 
   // 构建不含 checksum 的对象

--- a/src/features/config-transfer/export-config.ts
+++ b/src/features/config-transfer/export-config.ts
@@ -1,0 +1,106 @@
+import { SETTINGS_SCHEMA_VERSION } from '../../settings/schema/migrations'
+
+import { EXCLUDED_KEYS } from './config-keys'
+import { CONFIG_EXPORT_FORMAT_VERSION, ConfigExportFile } from './types'
+
+/**
+ * 生成与原始 API Key 等长的随机字符串，用于脱敏导出。
+ */
+function generateRandomString(length: number): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+  let result = ''
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length))
+  }
+  return result
+}
+
+/**
+ * 计算字符串的 SHA-256 哈希（hex 格式）。
+ */
+export async function computeChecksum(content: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(content)
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/**
+ * 递归遍历对象，将所有名为 apiKey 的字段替换为等长随机字符串。
+ */
+export function redactApiKeys(data: unknown): unknown {
+  if (Array.isArray(data)) {
+    return data.map((item) => redactApiKeys(item))
+  }
+
+  if (typeof data === 'object' && data !== null) {
+    const result: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(
+      data as Record<string, unknown>,
+    )) {
+      if (key === 'apiKey' && typeof value === 'string') {
+        result[key] = value.length > 0 ? generateRandomString(value.length) : ''
+      } else {
+        result[key] = redactApiKeys(value)
+      }
+    }
+    return result
+  }
+
+  return data
+}
+
+export type ExportOptions = {
+  /** 要导出的 key 列表 */
+  keys: string[]
+  /** 当前完整的 settings 数据（原始 data.json 内容） */
+  settingsData: Record<string, unknown>
+  /** 插件版本号 */
+  pluginVersion: string
+  /** 是否脱敏导出 */
+  redacted?: boolean
+}
+
+/**
+ * 根据用户选择的 key 列表，从 settings 中提取数据并生成导出文件内容。
+ */
+export async function buildExportData(
+  options: ExportOptions,
+): Promise<ConfigExportFile> {
+  const { keys, settingsData, pluginVersion, redacted = false } = options
+
+  // 提取选中的 key 对应的数据
+  const data: Record<string, unknown> = {}
+  for (const key of keys) {
+    if (EXCLUDED_KEYS.has(key)) continue
+    if (key in settingsData) {
+      data[key] = settingsData[key]
+    }
+  }
+
+  // 脱敏处理
+  const finalData = redacted
+    ? (redactApiKeys(data) as Record<string, unknown>)
+    : data
+
+  // 构建不含 checksum 的对象
+  const payload = {
+    $schema: 'yolo-config-export' as const,
+    formatVersion: CONFIG_EXPORT_FORMAT_VERSION,
+    settingsVersion: SETTINGS_SCHEMA_VERSION,
+    exportedAt: new Date().toISOString(),
+    pluginVersion,
+    redacted,
+    keys,
+    data: finalData,
+  }
+
+  // 对完整 payload 计算 SHA-256 作为 checksum
+  const checksum = await computeChecksum(JSON.stringify(payload))
+
+  return {
+    ...payload,
+    checksum,
+  }
+}

--- a/src/features/config-transfer/import-config.test.ts
+++ b/src/features/config-transfer/import-config.test.ts
@@ -1,0 +1,448 @@
+import { SETTINGS_SCHEMA_VERSION } from '../../settings/schema/migrations'
+import { parseYoloSettings } from '../../settings/schema/settings'
+
+import { buildExportData, computeChecksum } from './export-config'
+import {
+  applyImport,
+  parseVaultData,
+  validateExportFile,
+} from './import-config'
+import { CONFIG_EXPORT_FORMAT_VERSION, ConfigExportFile } from './types'
+
+describe('validateExportFile', () => {
+  // 不含 checksum 的基础文件（跳过 checksum 校验）
+  const validFile = {
+    $schema: 'yolo-config-export',
+    formatVersion: CONFIG_EXPORT_FORMAT_VERSION,
+    settingsVersion: SETTINGS_SCHEMA_VERSION,
+    exportedAt: '2026-05-11T10:00:00.000Z',
+    pluginVersion: '1.5.7.5',
+    redacted: false,
+    keys: ['providers', 'chatModelId'],
+    data: {
+      providers: [],
+      chatModelId: 'test/model',
+    },
+  }
+
+  it('should accept a valid export file without checksum', async () => {
+    const result = await validateExportFile(validFile)
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.data.$schema).toBe('yolo-config-export')
+    }
+  })
+
+  it('should accept a valid export file with correct checksum', async () => {
+    const { checksum, ...payload } = validFile as Record<string, unknown>
+    void checksum
+    const correctChecksum = await computeChecksum(JSON.stringify(payload))
+    const fileWithChecksum = { ...validFile, checksum: correctChecksum }
+    const result = await validateExportFile(fileWithChecksum)
+    expect(result.valid).toBe(true)
+  })
+
+  it('should reject a file with incorrect checksum (tampered content)', async () => {
+    const fileWithBadChecksum = {
+      ...validFile,
+      checksum:
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    }
+    const result = await validateExportFile(fileWithBadChecksum)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('完整性校验失败')
+    }
+  })
+
+  it('should reject null input', async () => {
+    const result = await validateExportFile(null)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('JSON 对象')
+    }
+  })
+
+  it('should reject non-object input', async () => {
+    const result = await validateExportFile('not an object')
+    expect(result.valid).toBe(false)
+  })
+
+  it('should reject missing $schema', async () => {
+    const result = await validateExportFile({
+      ...validFile,
+      $schema: undefined,
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('不是 YOLO 插件的配置导出文件')
+    }
+  })
+
+  it('should reject wrong $schema value', async () => {
+    const result = await validateExportFile({ ...validFile, $schema: 'wrong' })
+    expect(result.valid).toBe(false)
+  })
+
+  it('should reject invalid formatVersion', async () => {
+    const result = await validateExportFile({ ...validFile, formatVersion: 0 })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('格式版本')
+    }
+  })
+
+  it('should reject invalid settingsVersion', async () => {
+    const result = await validateExportFile({
+      ...validFile,
+      settingsVersion: -1,
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('设置版本号')
+    }
+  })
+
+  it('should reject empty keys array', async () => {
+    const result = await validateExportFile({ ...validFile, keys: [] })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('没有包含任何配置项')
+    }
+  })
+
+  it('should reject missing data field', async () => {
+    const result = await validateExportFile({ ...validFile, data: undefined })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('数据字段')
+    }
+  })
+
+  it('should reject when data contains keys not declared in keys array', async () => {
+    const tampered = {
+      ...validFile,
+      keys: ['providers'],
+      data: {
+        providers: [],
+        systemPrompt: 'injected',
+      },
+    }
+    const result = await validateExportFile(tampered)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('篡改')
+      expect(result.error).toContain('systemPrompt')
+    }
+  })
+
+  it('should accept when keys is a superset of data keys (some keys have no data)', async () => {
+    const sparse = {
+      ...validFile,
+      keys: ['providers', 'chatModelId', 'ragOptions'],
+      data: {
+        providers: [],
+        chatModelId: 'test/model',
+      },
+    }
+    const result = await validateExportFile(sparse)
+    expect(result.valid).toBe(true)
+  })
+
+  it('should accept a file with higher formatVersion (forward compatible)', async () => {
+    const futureFile = {
+      ...validFile,
+      formatVersion: 99,
+    }
+    const result = await validateExportFile(futureFile)
+    expect(result.valid).toBe(true)
+  })
+
+  it('should validate checksum end-to-end with buildExportData', async () => {
+    const exported = await buildExportData({
+      keys: ['providers', 'chatModelId'],
+      settingsData: {
+        providers: [{ id: 'test', apiKey: 'key' }],
+        chatModelId: 'test/model',
+      },
+      pluginVersion: '1.5.7.5',
+    })
+
+    // 正常导出的文件应该通过校验
+    const result = await validateExportFile(exported)
+    expect(result.valid).toBe(true)
+
+    // 篡改后应该失败
+    const tampered = { ...exported, redacted: true }
+    const tamperedResult = await validateExportFile(tampered)
+    expect(tamperedResult.valid).toBe(false)
+    if (!tamperedResult.valid) {
+      expect(tamperedResult.error).toContain('完整性校验失败')
+    }
+  })
+})
+
+describe('parseVaultData', () => {
+  it('should parse valid vault data.json content', () => {
+    const vaultData = {
+      version: 45,
+      __meta: { deviceId: 'other-device' },
+      providers: [{ id: 'openai', apiKey: 'sk-xxx' }],
+      chatModels: [
+        { id: 'openai/gpt-4', model: 'gpt-4', providerId: 'openai' },
+      ],
+      chatModelId: 'openai/gpt-4',
+    }
+
+    const result = parseVaultData(vaultData, '1.5.0')
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.data.settingsVersion).toBe(45)
+      expect(result.data.keys).toContain('providers')
+      expect(result.data.keys).toContain('chatModels')
+      expect(result.data.keys).toContain('chatModelId')
+      expect(result.data.keys).not.toContain('version')
+      expect(result.data.keys).not.toContain('__meta')
+      expect(result.data.data).not.toHaveProperty('version')
+      expect(result.data.data).not.toHaveProperty('__meta')
+    }
+  })
+
+  it('should reject null input', () => {
+    const result = parseVaultData(null)
+    expect(result.valid).toBe(false)
+  })
+
+  it('should reject empty object (no exportable keys)', () => {
+    const result = parseVaultData({ version: 51, __meta: {} })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('为空')
+    }
+  })
+
+  it('should default settingsVersion to 0 if version field is missing', () => {
+    const result = parseVaultData({ providers: [] })
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.data.settingsVersion).toBe(0)
+    }
+  })
+
+  it('should include unknown keys from vault data (future settings fields)', () => {
+    const vaultData = {
+      version: 51,
+      providers: [],
+      futureFeature: { enabled: true },
+    }
+    const result = parseVaultData(vaultData)
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.data.keys).toContain('futureFeature')
+      expect(result.data.data).toHaveProperty('futureFeature')
+    }
+  })
+})
+
+describe('applyImport', () => {
+  const currentSettings = parseYoloSettings({
+    version: SETTINGS_SCHEMA_VERSION,
+    providers: [
+      { id: 'existing', presetType: 'openai', apiKey: 'existing-key' },
+    ],
+    chatModels: [
+      {
+        providerId: 'existing',
+        id: 'existing/gpt-4',
+        model: 'gpt-4',
+        enable: true,
+      },
+    ],
+    chatModelId: 'existing/gpt-4',
+    ragOptions: {
+      enabled: true,
+      chunkSize: 1000,
+      limit: 10,
+      excludePatterns: ['*.tmp'],
+    },
+  })
+
+  const makeImportData = (
+    overrides: Partial<ConfigExportFile>,
+  ): ConfigExportFile => ({
+    $schema: 'yolo-config-export',
+    formatVersion: 1,
+    settingsVersion: SETTINGS_SCHEMA_VERSION,
+    exportedAt: '2026-05-11T10:00:00.000Z',
+    pluginVersion: '1.5.7.5',
+    redacted: false,
+    checksum: '',
+    keys: [],
+    data: {},
+    ...overrides,
+  })
+
+  it('should overwrite selected keys in overwrite mode', () => {
+    const importData = makeImportData({
+      keys: ['ragOptions'],
+      data: { ragOptions: { enabled: false, chunkSize: 500, limit: 5 } },
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['ragOptions'],
+      currentSettings,
+      mergeStrategy: 'overwrite',
+    })
+
+    expect(result.ragOptions.enabled).toBe(false)
+    expect(result.ragOptions.chunkSize).toBe(500)
+    expect(result.ragOptions.limit).toBe(5)
+    expect(result.providers).toEqual(currentSettings.providers)
+  })
+
+  it('should deep merge in merge mode, preserving current-only fields', () => {
+    const importData = makeImportData({
+      keys: ['ragOptions'],
+      data: { ragOptions: { chunkSize: 800, limit: 20 } },
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['ragOptions'],
+      currentSettings,
+      mergeStrategy: 'merge',
+    })
+
+    expect(result.ragOptions.chunkSize).toBe(800)
+    expect(result.ragOptions.limit).toBe(20)
+    expect(result.ragOptions.enabled).toBe(true)
+    expect(result.ragOptions.excludePatterns).toEqual(['*.tmp'])
+  })
+
+  it('should only import selected keys, ignoring unselected ones', () => {
+    const importData = makeImportData({
+      keys: ['ragOptions', 'systemPrompt'],
+      data: { ragOptions: { chunkSize: 500 }, systemPrompt: 'imported prompt' },
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['systemPrompt'],
+      currentSettings,
+      mergeStrategy: 'overwrite',
+    })
+
+    expect(result.systemPrompt).toBe('imported prompt')
+    expect(result.ragOptions.chunkSize).toBe(1000)
+  })
+
+  it('should run migration for older settings versions', () => {
+    const importData = makeImportData({
+      settingsVersion: 38,
+      pluginVersion: '1.4.0',
+      keys: ['chatModelId'],
+      data: { chatModelId: 'existing/gpt-4' },
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['chatModelId'],
+      currentSettings,
+      mergeStrategy: 'overwrite',
+    })
+
+    expect(result.version).toBe(SETTINGS_SCHEMA_VERSION)
+  })
+
+  it('should normalize references after import (orphan model references)', () => {
+    const importData = makeImportData({
+      keys: ['chatModelId'],
+      data: { chatModelId: 'nonexistent/model' },
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['chatModelId'],
+      currentSettings,
+      mergeStrategy: 'overwrite',
+    })
+
+    expect(result.chatModelId).not.toBe('nonexistent/model')
+  })
+
+  it('should handle primitive value import in merge mode (direct overwrite)', () => {
+    const importData = makeImportData({
+      keys: ['systemPrompt'],
+      data: { systemPrompt: 'new prompt' },
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['systemPrompt'],
+      currentSettings,
+      mergeStrategy: 'merge',
+    })
+
+    expect(result.systemPrompt).toBe('new prompt')
+  })
+
+  it('should ignore EXCLUDED_KEYS in selectedKeys', () => {
+    const importData = makeImportData({
+      keys: ['systemPrompt', 'version'],
+      data: { systemPrompt: 'imported', version: 999 },
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['systemPrompt', 'version', '__meta'],
+      currentSettings,
+      mergeStrategy: 'overwrite',
+    })
+
+    expect(result.systemPrompt).toBe('imported')
+    // version 应该是当前 SETTINGS_SCHEMA_VERSION，不被导入覆盖
+    expect(result.version).toBe(SETTINGS_SCHEMA_VERSION)
+  })
+
+  it('should replace arrays in merge mode (providers list)', () => {
+    const importData = makeImportData({
+      keys: ['providers'],
+      data: {
+        providers: [
+          { id: 'new-provider', presetType: 'openai', apiKey: 'new-key' },
+        ],
+      },
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['providers'],
+      currentSettings,
+      mergeStrategy: 'merge',
+    })
+
+    // 数组在 merge 模式下是直接覆盖，不是追加
+    expect(result.providers).toHaveLength(1)
+    expect(result.providers[0].id).toBe('new-provider')
+  })
+
+  it('should skip keys whose imported value is undefined', () => {
+    const importData = makeImportData({
+      keys: ['systemPrompt', 'chatModelId'],
+      data: { chatModelId: 'existing/gpt-4' },
+      // systemPrompt 在 keys 中声明但 data 中没有
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['systemPrompt', 'chatModelId'],
+      currentSettings,
+      mergeStrategy: 'overwrite',
+    })
+
+    // systemPrompt 不在 migratedData 中，应保持当前值
+    expect(result.systemPrompt).toBe(currentSettings.systemPrompt)
+    expect(result.chatModelId).toBe('existing/gpt-4')
+  })
+})

--- a/src/features/config-transfer/import-config.test.ts
+++ b/src/features/config-transfer/import-config.test.ts
@@ -3,9 +3,10 @@ import { parseYoloSettings } from '../../settings/schema/settings'
 
 import { buildExportData, computeChecksum } from './export-config'
 import {
-  applyImport,
   ImportValidationError,
+  applyImport,
   parseVaultData,
+  renderImportError,
   validateExportFile,
 } from './import-config'
 import { CONFIG_EXPORT_FORMAT_VERSION, ConfigExportFile } from './types'
@@ -52,7 +53,7 @@ describe('validateExportFile', () => {
     const result = await validateExportFile(fileWithBadChecksum)
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('完整性校验失败')
+      expect(result.errorKey).toBe('errorChecksumMismatch')
     }
   })
 
@@ -60,7 +61,7 @@ describe('validateExportFile', () => {
     const result = await validateExportFile(null)
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('JSON 对象')
+      expect(result.errorKey).toBe('errorNotJson')
     }
   })
 
@@ -76,7 +77,7 @@ describe('validateExportFile', () => {
     })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('不是 YOLO 插件的配置导出文件')
+      expect(result.errorKey).toBe('errorNotExportFile')
     }
   })
 
@@ -89,7 +90,7 @@ describe('validateExportFile', () => {
     const result = await validateExportFile({ ...validFile, formatVersion: 0 })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('格式版本')
+      expect(result.errorKey).toBe('errorInvalidFormatVersion')
     }
   })
 
@@ -100,7 +101,7 @@ describe('validateExportFile', () => {
     })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('设置版本号')
+      expect(result.errorKey).toBe('errorInvalidSettingsVersion')
     }
   })
 
@@ -111,7 +112,8 @@ describe('validateExportFile', () => {
     })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('旧版本')
+      expect(result.errorKey).toBe('errorFileFromOlderVersion')
+      expect(result.params?.fileVersion).toBe(SETTINGS_SCHEMA_VERSION - 1)
     }
   })
 
@@ -122,7 +124,8 @@ describe('validateExportFile', () => {
     })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('更高版本')
+      expect(result.errorKey).toBe('errorFileFromNewerVersion')
+      expect(result.params?.fileVersion).toBe(SETTINGS_SCHEMA_VERSION + 1)
     }
   })
 
@@ -130,7 +133,7 @@ describe('validateExportFile', () => {
     const result = await validateExportFile({ ...validFile, keys: [] })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('没有包含任何配置项')
+      expect(result.errorKey).toBe('errorEmptyKeys')
     }
   })
 
@@ -138,7 +141,7 @@ describe('validateExportFile', () => {
     const result = await validateExportFile({ ...validFile, data: undefined })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('数据字段')
+      expect(result.errorKey).toBe('errorMissingData')
     }
   })
 
@@ -154,8 +157,8 @@ describe('validateExportFile', () => {
     const result = await validateExportFile(tampered)
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('篡改')
-      expect(result.error).toContain('systemPrompt')
+      expect(result.errorKey).toBe('errorTampered')
+      expect(String(result.params?.fields)).toContain('systemPrompt')
     }
   })
 
@@ -200,7 +203,7 @@ describe('validateExportFile', () => {
     const tamperedResult = await validateExportFile(tampered)
     expect(tamperedResult.valid).toBe(false)
     if (!tamperedResult.valid) {
-      expect(tamperedResult.error).toContain('完整性校验失败')
+      expect(tamperedResult.errorKey).toBe('errorChecksumMismatch')
     }
   })
 })
@@ -243,7 +246,7 @@ describe('parseVaultData', () => {
     })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('为空')
+      expect(result.errorKey).toBe('errorVaultEmpty')
     }
   })
 
@@ -251,7 +254,7 @@ describe('parseVaultData', () => {
     const result = parseVaultData({ providers: [] })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('version')
+      expect(result.errorKey).toBe('errorVaultMissingVersion')
     }
   })
 
@@ -262,7 +265,7 @@ describe('parseVaultData', () => {
     })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('旧版本')
+      expect(result.errorKey).toBe('errorVaultFromOlderVersion')
     }
   })
 
@@ -273,7 +276,7 @@ describe('parseVaultData', () => {
     })
     expect(result.valid).toBe(false)
     if (!result.valid) {
-      expect(result.error).toContain('更高版本')
+      expect(result.errorKey).toBe('errorVaultFromNewerVersion')
     }
   })
 
@@ -406,6 +409,64 @@ describe('applyImport', () => {
     ).toThrow(ImportValidationError)
   })
 
+  it('should clear apiKey fields when importData.redacted is true', () => {
+    const importData = makeImportData({
+      redacted: true,
+      keys: ['providers'],
+      data: {
+        providers: [
+          {
+            id: 'redacted-provider',
+            presetType: 'openai',
+            // 脱敏导出的随机字符串绝不能当成真的 key 写入
+            apiKey: 'FAKE_RANDOM_KEY_abcdefghijklmnop',
+          },
+        ],
+      },
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['providers'],
+      currentSettings,
+      mergeStrategy: 'overwrite',
+    })
+
+    const importedProvider = result.providers.find(
+      (p) => p.id === 'redacted-provider',
+    )
+    expect(importedProvider).toBeDefined()
+    expect(importedProvider?.apiKey).toBe('')
+  })
+
+  it('should not touch apiKey when importData.redacted is false', () => {
+    const importData = makeImportData({
+      redacted: false,
+      keys: ['providers'],
+      data: {
+        providers: [
+          {
+            id: 'real-provider',
+            presetType: 'openai',
+            apiKey: 'sk-real-key',
+          },
+        ],
+      },
+    })
+
+    const result = applyImport({
+      importData,
+      selectedKeys: ['providers'],
+      currentSettings,
+      mergeStrategy: 'overwrite',
+    })
+
+    const importedProvider = result.providers.find(
+      (p) => p.id === 'real-provider',
+    )
+    expect(importedProvider?.apiKey).toBe('sk-real-key')
+  })
+
   it('should silently replace malformed field with schema default (known schema .catch behavior)', () => {
     // 已知限制：yoloSettingsSchema 每个字段都用 .catch(default)，
     // 所以同版本下"字段格式非法"不会抛错，会被默默替换成默认值。
@@ -413,7 +474,9 @@ describe('applyImport', () => {
     // 真正的字段级严格化需要在 schema 层单独 issue 解决。
     const importData = makeImportData({
       keys: ['ragOptions'],
-      data: { ragOptions: 'not-an-object' as unknown as Record<string, unknown> },
+      data: {
+        ragOptions: 'not-an-object' as unknown as Record<string, unknown>,
+      },
     })
 
     const result = applyImport({
@@ -541,5 +604,50 @@ describe('applyImport', () => {
     // systemPrompt 不在 migratedData 中，应保持当前值
     expect(result.systemPrompt).toBe(currentSettings.systemPrompt)
     expect(result.chatModelId).toBe('existing/gpt-4')
+  })
+})
+
+describe('renderImportError', () => {
+  it('interpolates params into the i18n template', () => {
+    const t = (keyPath: string, fallback?: string): string => {
+      if (keyPath === 'configTransfer.errors.errorFileFromOlderVersion') {
+        return 'File v{fileVersion} < current v{currentVersion}'
+      }
+      return fallback ?? keyPath
+    }
+    const out = renderImportError(
+      {
+        valid: false,
+        errorKey: 'errorFileFromOlderVersion',
+        fallback: 'old version',
+        params: { fileVersion: 50, currentVersion: 52 },
+      },
+      t,
+    )
+    expect(out).toBe('File v50 < current v52')
+  })
+
+  it('falls back to the fallback string when translation is missing', () => {
+    const t = (_key: string, fallback?: string): string => fallback ?? _key
+    const out = renderImportError(
+      {
+        valid: false,
+        errorKey: 'errorNotJson',
+        fallback: '文件不是 JSON',
+      },
+      t,
+    )
+    expect(out).toBe('文件不是 JSON')
+  })
+
+  it('renders ImportValidationError via the same path', () => {
+    const t = (_key: string, fallback?: string): string => fallback ?? _key
+    const err = new ImportValidationError(
+      'errorApplyVersionMismatch',
+      'fallback {importVersion}/{currentVersion}',
+      [],
+      { importVersion: 49, currentVersion: 52 },
+    )
+    expect(renderImportError(err, t)).toBe('fallback 49/52')
   })
 })

--- a/src/features/config-transfer/import-config.test.ts
+++ b/src/features/config-transfer/import-config.test.ts
@@ -4,6 +4,7 @@ import { parseYoloSettings } from '../../settings/schema/settings'
 import { buildExportData, computeChecksum } from './export-config'
 import {
   applyImport,
+  ImportValidationError,
   parseVaultData,
   validateExportFile,
 } from './import-config'
@@ -103,6 +104,28 @@ describe('validateExportFile', () => {
     }
   })
 
+  it('should reject settingsVersion lower than current schema version', async () => {
+    const result = await validateExportFile({
+      ...validFile,
+      settingsVersion: SETTINGS_SCHEMA_VERSION - 1,
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('旧版本')
+    }
+  })
+
+  it('should reject settingsVersion higher than current schema version', async () => {
+    const result = await validateExportFile({
+      ...validFile,
+      settingsVersion: SETTINGS_SCHEMA_VERSION + 1,
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('更高版本')
+    }
+  })
+
   it('should reject empty keys array', async () => {
     const result = await validateExportFile({ ...validFile, keys: [] })
     expect(result.valid).toBe(false)
@@ -183,9 +206,9 @@ describe('validateExportFile', () => {
 })
 
 describe('parseVaultData', () => {
-  it('should parse valid vault data.json content', () => {
+  it('should parse vault data.json with matching version', () => {
     const vaultData = {
-      version: 45,
+      version: SETTINGS_SCHEMA_VERSION,
       __meta: { deviceId: 'other-device' },
       providers: [{ id: 'openai', apiKey: 'sk-xxx' }],
       chatModels: [
@@ -197,7 +220,7 @@ describe('parseVaultData', () => {
     const result = parseVaultData(vaultData, '1.5.0')
     expect(result.valid).toBe(true)
     if (result.valid) {
-      expect(result.data.settingsVersion).toBe(45)
+      expect(result.data.settingsVersion).toBe(SETTINGS_SCHEMA_VERSION)
       expect(result.data.keys).toContain('providers')
       expect(result.data.keys).toContain('chatModels')
       expect(result.data.keys).toContain('chatModelId')
@@ -214,32 +237,60 @@ describe('parseVaultData', () => {
   })
 
   it('should reject empty object (no exportable keys)', () => {
-    const result = parseVaultData({ version: 51, __meta: {} })
+    const result = parseVaultData({
+      version: SETTINGS_SCHEMA_VERSION,
+      __meta: {},
+    })
     expect(result.valid).toBe(false)
     if (!result.valid) {
       expect(result.error).toContain('为空')
     }
   })
 
-  it('should default settingsVersion to 0 if version field is missing', () => {
+  it('should reject when version field is missing', () => {
     const result = parseVaultData({ providers: [] })
-    expect(result.valid).toBe(true)
-    if (result.valid) {
-      expect(result.data.settingsVersion).toBe(0)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('version')
     }
   })
 
-  it('should include unknown keys from vault data (future settings fields)', () => {
+  it('should reject older vault version', () => {
+    const result = parseVaultData({
+      version: SETTINGS_SCHEMA_VERSION - 1,
+      providers: [],
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('旧版本')
+    }
+  })
+
+  it('should reject newer vault version', () => {
+    const result = parseVaultData({
+      version: SETTINGS_SCHEMA_VERSION + 1,
+      providers: [],
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.error).toContain('更高版本')
+    }
+  })
+
+  it('should drop unknown top-level keys not in EXPORTABLE_CONFIG_KEYS', () => {
+    // 同版本策略下，未在白名单内的字段被 schema strip 后不会落盘，
+    // 不应让用户在 UI 里勾选它们造成"导入成功但无效"的错觉。
     const vaultData = {
-      version: 51,
+      version: SETTINGS_SCHEMA_VERSION,
       providers: [],
       futureFeature: { enabled: true },
     }
     const result = parseVaultData(vaultData)
     expect(result.valid).toBe(true)
     if (result.valid) {
-      expect(result.data.keys).toContain('futureFeature')
-      expect(result.data.data).toHaveProperty('futureFeature')
+      expect(result.data.keys).toContain('providers')
+      expect(result.data.keys).not.toContain('futureFeature')
+      expect(result.data.data).not.toHaveProperty('futureFeature')
     }
   })
 })
@@ -337,22 +388,68 @@ describe('applyImport', () => {
     expect(result.ragOptions.chunkSize).toBe(1000)
   })
 
-  it('should run migration for older settings versions', () => {
+  it('should throw ImportValidationError when settingsVersion does not match', () => {
     const importData = makeImportData({
-      settingsVersion: 38,
+      settingsVersion: SETTINGS_SCHEMA_VERSION - 1,
       pluginVersion: '1.4.0',
       keys: ['chatModelId'],
       data: { chatModelId: 'existing/gpt-4' },
     })
 
+    expect(() =>
+      applyImport({
+        importData,
+        selectedKeys: ['chatModelId'],
+        currentSettings,
+        mergeStrategy: 'overwrite',
+      }),
+    ).toThrow(ImportValidationError)
+  })
+
+  it('should silently replace malformed field with schema default (known schema .catch behavior)', () => {
+    // 已知限制：yoloSettingsSchema 每个字段都用 .catch(default)，
+    // 所以同版本下"字段格式非法"不会抛错，会被默默替换成默认值。
+    // 本测试用于固化当前行为，避免后续 review 误以为 applyImport 能拦截。
+    // 真正的字段级严格化需要在 schema 层单独 issue 解决。
+    const importData = makeImportData({
+      keys: ['ragOptions'],
+      data: { ragOptions: 'not-an-object' as unknown as Record<string, unknown> },
+    })
+
     const result = applyImport({
       importData,
-      selectedKeys: ['chatModelId'],
+      selectedKeys: ['ragOptions'],
       currentSettings,
       mergeStrategy: 'overwrite',
     })
 
-    expect(result.version).toBe(SETTINGS_SCHEMA_VERSION)
+    // 没有抛错；坏字段被默认值替换
+    expect(result.ragOptions).toBeDefined()
+    expect(typeof result.ragOptions).toBe('object')
+    expect(typeof result.ragOptions.chunkSize).toBe('number')
+  })
+
+  it('should not silently fall back to defaults when version mismatches', () => {
+    // 回归：旧实现走 parseYoloSettings 的兜底，跨版本会返回一个被默认值覆盖
+    // 的"成功"结果。新实现必须显式抛错，调用方据此保留原配置。
+    const importData = makeImportData({
+      settingsVersion: SETTINGS_SCHEMA_VERSION + 1,
+      keys: ['ragOptions'],
+      data: { ragOptions: { enabled: false, chunkSize: 999 } },
+    })
+
+    expect(() =>
+      applyImport({
+        importData,
+        selectedKeys: ['ragOptions'],
+        currentSettings,
+        mergeStrategy: 'overwrite',
+      }),
+    ).toThrow(ImportValidationError)
+
+    // currentSettings 未被改动
+    expect(currentSettings.ragOptions.chunkSize).toBe(1000)
+    expect(currentSettings.ragOptions.enabled).toBe(true)
   })
 
   it('should normalize references after import (orphan model references)', () => {

--- a/src/features/config-transfer/import-config.ts
+++ b/src/features/config-transfer/import-config.ts
@@ -1,0 +1,213 @@
+import {
+  SETTINGS_SCHEMA_VERSION,
+  SETTING_MIGRATIONS,
+} from '../../settings/schema/migrations'
+import { YoloSettings } from '../../settings/schema/setting.types'
+import { parseYoloSettings } from '../../settings/schema/settings'
+
+import { EXCLUDED_KEYS } from './config-keys'
+import { computeChecksum } from './export-config'
+import { deepMerge } from './merge-utils'
+import { ConfigExportFile, MergeStrategy } from './types'
+
+export type ValidationResult =
+  | { valid: true; data: ConfigExportFile }
+  | { valid: false; error: string }
+
+/**
+ * 校验导出文件格式是否合法。
+ */
+export async function validateExportFile(
+  raw: unknown,
+): Promise<ValidationResult> {
+  if (!raw || typeof raw !== 'object') {
+    return { valid: false, error: '文件内容不是有效的 JSON 对象' }
+  }
+
+  const obj = raw as Record<string, unknown>
+
+  if (obj.$schema !== 'yolo-config-export') {
+    return {
+      valid: false,
+      error:
+        '该文件不是 YOLO 插件的配置导出文件，请选择通过「导出配置」功能生成的 .json 文件。',
+    }
+  }
+
+  if (typeof obj.formatVersion !== 'number' || obj.formatVersion < 1) {
+    return { valid: false, error: '配置文件格式版本不合法，可能已损坏。' }
+  }
+
+  if (typeof obj.settingsVersion !== 'number' || obj.settingsVersion < 0) {
+    return { valid: false, error: '配置文件中的设置版本号不合法，可能已损坏。' }
+  }
+
+  if (!Array.isArray(obj.keys) || obj.keys.length === 0) {
+    return { valid: false, error: '配置文件中没有包含任何配置项。' }
+  }
+
+  if (!obj.data || typeof obj.data !== 'object') {
+    return { valid: false, error: '配置文件中的数据字段缺失或不合法。' }
+  }
+
+  // 校验 keys 与 data 的一致性
+  const dataKeys = Object.keys(obj.data as Record<string, unknown>)
+  const declaredKeys = new Set(obj.keys as string[])
+  const undeclaredKeys = dataKeys.filter((k) => !declaredKeys.has(k))
+  if (undeclaredKeys.length > 0) {
+    return {
+      valid: false,
+      error: `配置文件数据与声明不一致：data 中包含未在 keys 中声明的字段（${undeclaredKeys.join(', ')}），文件可能已被篡改。`,
+    }
+  }
+
+  // 校验 checksum 完整性
+  if (typeof obj.checksum === 'string' && obj.checksum.length > 0) {
+    const { checksum, ...payload } = obj
+    const expectedChecksum = await computeChecksum(JSON.stringify(payload))
+    if (checksum !== expectedChecksum) {
+      return {
+        valid: false,
+        error: '配置文件完整性校验失败，文件内容可能已被修改。',
+      }
+    }
+  }
+
+  return { valid: true, data: obj as unknown as ConfigExportFile }
+}
+
+/**
+ * 从另一个笔记库的 data.json 原始数据中提取可导入的配置。
+ * 返回一个类似 ConfigExportFile 的结构，方便后续统一处理。
+ */
+export function parseVaultData(
+  raw: unknown,
+  pluginVersion?: string,
+): ValidationResult {
+  if (!raw || typeof raw !== 'object') {
+    return { valid: false, error: '无法解析目标笔记库的配置数据' }
+  }
+
+  const obj = raw as Record<string, unknown>
+  const settingsVersion = (obj.version as number) ?? 0
+
+  // 提取所有非排除字段作为可导入数据
+  const data: Record<string, unknown> = {}
+  const keys: string[] = []
+  for (const [key, value] of Object.entries(obj)) {
+    if (!EXCLUDED_KEYS.has(key)) {
+      data[key] = value
+      keys.push(key)
+    }
+  }
+
+  if (keys.length === 0) {
+    return { valid: false, error: '目标笔记库的配置数据为空' }
+  }
+
+  const exportFile: ConfigExportFile = {
+    $schema: 'yolo-config-export',
+    formatVersion: 1,
+    settingsVersion,
+    exportedAt: new Date().toISOString(),
+    pluginVersion: pluginVersion ?? 'unknown',
+    redacted: false,
+    keys,
+    data,
+    checksum: '',
+  }
+
+  return { valid: true, data: exportFile }
+}
+
+export type ImportOptions = {
+  /** 导入的配置数据（已校验） */
+  importData: ConfigExportFile
+  /** 用户选择要导入的 key 列表 */
+  selectedKeys: string[]
+  /** 当前完整的 settings */
+  currentSettings: YoloSettings
+  /** 合并策略 */
+  mergeStrategy: MergeStrategy
+}
+
+/**
+ * 对导入数据执行迁移链（不做 schema parse 和默认值填充）。
+ * 仅升级数据结构到当前版本。
+ */
+function migrateImportData(
+  data: Record<string, unknown>,
+  fromVersion: number,
+): Record<string, unknown> {
+  let currentData: Record<string, unknown> = { ...data, version: fromVersion }
+  let currentVersion = fromVersion
+
+  for (const migration of SETTING_MIGRATIONS) {
+    if (
+      currentVersion >= migration.fromVersion &&
+      currentVersion < migration.toVersion &&
+      migration.toVersion <= SETTINGS_SCHEMA_VERSION
+    ) {
+      currentData = migration.migrate(currentData)
+      currentVersion = migration.toVersion
+    }
+  }
+
+  return currentData
+}
+
+/**
+ * 执行配置导入，返回合并后的完整 settings。
+ *
+ * 流程：
+ * 1. 将导入数据通过迁移链升级到当前版本（不填充默认值）
+ * 2. 根据合并策略将迁移后的数据合并到当前配置
+ * 3. 通过 parseYoloSettings 进行 schema 校验和引用规范化
+ */
+export function applyImport(options: ImportOptions): YoloSettings {
+  const { importData, selectedKeys, currentSettings, mergeStrategy } = options
+
+  // 1. 迁移导入数据到当前版本（仅结构升级，不填充默认值）
+  const migratedData = migrateImportData(
+    importData.data,
+    importData.settingsVersion,
+  )
+
+  // 2. 根据合并策略合并到当前配置
+  const currentRaw = currentSettings as unknown as Record<string, unknown>
+  const merged: Record<string, unknown> = { ...currentRaw }
+
+  for (const key of selectedKeys) {
+    if (EXCLUDED_KEYS.has(key)) continue
+
+    const importedValue = migratedData[key]
+    if (importedValue === undefined) continue
+
+    if (mergeStrategy === 'overwrite') {
+      merged[key] = importedValue
+    } else {
+      // JSON merge
+      const currentValue = merged[key]
+      if (
+        typeof currentValue === 'object' &&
+        currentValue !== null &&
+        !Array.isArray(currentValue) &&
+        typeof importedValue === 'object' &&
+        importedValue !== null &&
+        !Array.isArray(importedValue)
+      ) {
+        merged[key] = deepMerge(
+          currentValue as Record<string, unknown>,
+          importedValue as Record<string, unknown>,
+        )
+      } else {
+        // 非对象类型（数组、基本类型）直接覆盖
+        merged[key] = importedValue
+      }
+    }
+  }
+
+  // 3. 通过 parseYoloSettings 校验和规范化最终结果
+  merged.version = SETTINGS_SCHEMA_VERSION
+  return parseYoloSettings(merged)
+}

--- a/src/features/config-transfer/import-config.ts
+++ b/src/features/config-transfer/import-config.ts
@@ -1,11 +1,12 @@
+import { ensureDefaultAssistantInSettings } from '../../core/agent/default-assistant'
+import { SETTINGS_SCHEMA_VERSION } from '../../settings/schema/migrations'
 import {
-  SETTINGS_SCHEMA_VERSION,
-  SETTING_MIGRATIONS,
-} from '../../settings/schema/migrations'
-import { YoloSettings } from '../../settings/schema/setting.types'
-import { parseYoloSettings } from '../../settings/schema/settings'
+  YoloSettings,
+  yoloSettingsSchema,
+} from '../../settings/schema/setting.types'
+import { normalizeYoloSettingsReferences } from '../../settings/schema/settings'
 
-import { EXCLUDED_KEYS } from './config-keys'
+import { EXCLUDED_KEYS, EXPORTABLE_CONFIG_KEYS } from './config-keys'
 import { computeChecksum } from './export-config'
 import { deepMerge } from './merge-utils'
 import { ConfigExportFile, MergeStrategy } from './types'
@@ -40,6 +41,16 @@ export async function validateExportFile(
 
   if (typeof obj.settingsVersion !== 'number' || obj.settingsVersion < 0) {
     return { valid: false, error: '配置文件中的设置版本号不合法，可能已损坏。' }
+  }
+
+  if (obj.settingsVersion !== SETTINGS_SCHEMA_VERSION) {
+    return {
+      valid: false,
+      error:
+        obj.settingsVersion > SETTINGS_SCHEMA_VERSION
+          ? `配置文件来自更高版本的插件（版本 ${obj.settingsVersion}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}，请先升级当前插件后再导入。`
+          : `配置文件来自旧版本的插件（版本 ${obj.settingsVersion}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}。请在源端升级 YOLO 插件后重新导出。`,
+    }
   }
 
   if (!Array.isArray(obj.keys) || obj.keys.length === 0) {
@@ -89,16 +100,35 @@ export function parseVaultData(
   }
 
   const obj = raw as Record<string, unknown>
-  const settingsVersion = (obj.version as number) ?? 0
 
-  // 提取所有非排除字段作为可导入数据
+  if (typeof obj.version !== 'number') {
+    return {
+      valid: false,
+      error: '目标笔记库的配置数据缺少 version 字段，无法判断版本兼容性。',
+    }
+  }
+
+  if (obj.version !== SETTINGS_SCHEMA_VERSION) {
+    return {
+      valid: false,
+      error:
+        obj.version > SETTINGS_SCHEMA_VERSION
+          ? `目标笔记库使用更高版本的插件（版本 ${obj.version}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}，请先升级当前插件后再导入。`
+          : `目标笔记库使用旧版本的插件（版本 ${obj.version}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}。请先在目标笔记库升级 YOLO 插件后再导入。`,
+    }
+  }
+
+  // 严格同版本策略下，未在 EXPORTABLE_CONFIG_KEYS 中声明的顶层字段不应进入
+  // 候选列表 —— 否则用户能勾选这些字段，但 yoloSettingsSchema 会 strip 掉，
+  // 最终"导入成功"但实际未生效，造成误导。
+  const exportableKeySet = new Set(EXPORTABLE_CONFIG_KEYS.map((k) => k.key))
   const data: Record<string, unknown> = {}
   const keys: string[] = []
   for (const [key, value] of Object.entries(obj)) {
-    if (!EXCLUDED_KEYS.has(key)) {
-      data[key] = value
-      keys.push(key)
-    }
+    if (EXCLUDED_KEYS.has(key)) continue
+    if (!exportableKeySet.has(key)) continue
+    data[key] = value
+    keys.push(key)
   }
 
   if (keys.length === 0) {
@@ -108,7 +138,7 @@ export function parseVaultData(
   const exportFile: ConfigExportFile = {
     $schema: 'yolo-config-export',
     formatVersion: 1,
-    settingsVersion,
+    settingsVersion: obj.version,
     exportedAt: new Date().toISOString(),
     pluginVersion: pluginVersion ?? 'unknown',
     redacted: false,
@@ -121,7 +151,7 @@ export function parseVaultData(
 }
 
 export type ImportOptions = {
-  /** 导入的配置数据（已校验） */
+  /** 导入的配置数据（已校验，版本与当前一致） */
   importData: ConfigExportFile
   /** 用户选择要导入的 key 列表 */
   selectedKeys: string[]
@@ -131,62 +161,51 @@ export type ImportOptions = {
   mergeStrategy: MergeStrategy
 }
 
-/**
- * 对导入数据执行迁移链（不做 schema parse 和默认值填充）。
- * 仅升级数据结构到当前版本。
- */
-function migrateImportData(
-  data: Record<string, unknown>,
-  fromVersion: number,
-): Record<string, unknown> {
-  let currentData: Record<string, unknown> = { ...data, version: fromVersion }
-  let currentVersion = fromVersion
-
-  for (const migration of SETTING_MIGRATIONS) {
-    if (
-      currentVersion >= migration.fromVersion &&
-      currentVersion < migration.toVersion &&
-      migration.toVersion <= SETTINGS_SCHEMA_VERSION
-    ) {
-      currentData = migration.migrate(currentData)
-      currentVersion = migration.toVersion
-    }
+export class ImportValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly issues: string[],
+  ) {
+    super(message)
+    this.name = 'ImportValidationError'
   }
-
-  return currentData
 }
 
 /**
  * 执行配置导入，返回合并后的完整 settings。
  *
+ * 前置约束：importData.settingsVersion 必须等于 SETTINGS_SCHEMA_VERSION
+ * （由 validateExportFile / parseVaultData 保证）。本函数不再处理跨版本迁移。
+ *
  * 流程：
- * 1. 将导入数据通过迁移链升级到当前版本（不填充默认值）
- * 2. 根据合并策略将迁移后的数据合并到当前配置
- * 3. 通过 parseYoloSettings 进行 schema 校验和引用规范化
+ * 1. 按合并策略将 importData.data 合并到 currentSettings
+ * 2. 通过 yoloSettingsSchema 显式校验；失败时抛出 ImportValidationError，
+ *    调用方负责提示用户并保留原配置（不静默回退到默认值）
+ * 3. 在合法结果上做引用规范化与默认 assistant 兜底
  */
 export function applyImport(options: ImportOptions): YoloSettings {
   const { importData, selectedKeys, currentSettings, mergeStrategy } = options
 
-  // 1. 迁移导入数据到当前版本（仅结构升级，不填充默认值）
-  const migratedData = migrateImportData(
-    importData.data,
-    importData.settingsVersion,
-  )
+  if (importData.settingsVersion !== SETTINGS_SCHEMA_VERSION) {
+    throw new ImportValidationError(
+      `导入数据版本（${importData.settingsVersion}）与当前插件版本（${SETTINGS_SCHEMA_VERSION}）不一致，无法导入。`,
+      [],
+    )
+  }
 
-  // 2. 根据合并策略合并到当前配置
+  // 1. 按合并策略合并到当前配置
   const currentRaw = currentSettings as unknown as Record<string, unknown>
   const merged: Record<string, unknown> = { ...currentRaw }
 
   for (const key of selectedKeys) {
     if (EXCLUDED_KEYS.has(key)) continue
 
-    const importedValue = migratedData[key]
+    const importedValue = importData.data[key]
     if (importedValue === undefined) continue
 
     if (mergeStrategy === 'overwrite') {
       merged[key] = importedValue
     } else {
-      // JSON merge
       const currentValue = merged[key]
       if (
         typeof currentValue === 'object' &&
@@ -201,13 +220,30 @@ export function applyImport(options: ImportOptions): YoloSettings {
           importedValue as Record<string, unknown>,
         )
       } else {
-        // 非对象类型（数组、基本类型）直接覆盖
         merged[key] = importedValue
       }
     }
   }
 
-  // 3. 通过 parseYoloSettings 校验和规范化最终结果
   merged.version = SETTINGS_SCHEMA_VERSION
-  return parseYoloSettings(merged)
+
+  // 2. 显式 schema 校验，失败时抛错（不走 parseYoloSettings 的默认值兜底）
+  const parsed = yoloSettingsSchema.safeParse(merged)
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
+      return `${path}: ${issue.message}`
+    })
+    throw new ImportValidationError(
+      '导入的配置未通过校验，可能存在字段缺失或格式错误。',
+      issues,
+    )
+  }
+
+  // 3. 引用规范化 + 默认 assistant 兜底
+  const normalized = normalizeYoloSettingsReferences(parsed.data)
+  return ensureDefaultAssistantInSettings({
+    ...normalized,
+    version: SETTINGS_SCHEMA_VERSION,
+  })
 }

--- a/src/features/config-transfer/import-config.ts
+++ b/src/features/config-transfer/import-config.ts
@@ -9,11 +9,27 @@ import { normalizeYoloSettingsReferences } from '../../settings/schema/settings'
 import { EXCLUDED_KEYS, EXPORTABLE_CONFIG_KEYS } from './config-keys'
 import { computeChecksum } from './export-config'
 import { deepMerge } from './merge-utils'
-import { ConfigExportFile, MergeStrategy } from './types'
+import { clearSensitive } from './redact'
+import { ConfigExportFile, ImportErrorKey, MergeStrategy } from './types'
+
+export type ValidationFailure = {
+  valid: false
+  errorKey: ImportErrorKey
+  fallback: string
+  params?: Record<string, string | number>
+}
 
 export type ValidationResult =
   | { valid: true; data: ConfigExportFile }
-  | { valid: false; error: string }
+  | ValidationFailure
+
+function failure(
+  errorKey: ImportErrorKey,
+  fallback: string,
+  params?: Record<string, string | number>,
+): ValidationFailure {
+  return { valid: false, errorKey, fallback, params }
+}
 
 /**
  * 校验导出文件格式是否合法。
@@ -22,43 +38,59 @@ export async function validateExportFile(
   raw: unknown,
 ): Promise<ValidationResult> {
   if (!raw || typeof raw !== 'object') {
-    return { valid: false, error: '文件内容不是有效的 JSON 对象' }
+    return failure('errorNotJson', '文件内容不是有效的 JSON 对象')
   }
 
   const obj = raw as Record<string, unknown>
 
   if (obj.$schema !== 'yolo-config-export') {
-    return {
-      valid: false,
-      error:
-        '该文件不是 YOLO 插件的配置导出文件，请选择通过「导出配置」功能生成的 .json 文件。',
-    }
+    return failure(
+      'errorNotExportFile',
+      '该文件不是 YOLO 插件的配置导出文件，请选择通过「导出配置」功能生成的 .json 文件。',
+    )
   }
 
   if (typeof obj.formatVersion !== 'number' || obj.formatVersion < 1) {
-    return { valid: false, error: '配置文件格式版本不合法，可能已损坏。' }
+    return failure(
+      'errorInvalidFormatVersion',
+      '配置文件格式版本不合法，可能已损坏。',
+    )
   }
 
   if (typeof obj.settingsVersion !== 'number' || obj.settingsVersion < 0) {
-    return { valid: false, error: '配置文件中的设置版本号不合法，可能已损坏。' }
+    return failure(
+      'errorInvalidSettingsVersion',
+      '配置文件中的设置版本号不合法，可能已损坏。',
+    )
   }
 
   if (obj.settingsVersion !== SETTINGS_SCHEMA_VERSION) {
-    return {
-      valid: false,
-      error:
-        obj.settingsVersion > SETTINGS_SCHEMA_VERSION
-          ? `配置文件来自更高版本的插件（版本 ${obj.settingsVersion}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}，请先升级当前插件后再导入。`
-          : `配置文件来自旧版本的插件（版本 ${obj.settingsVersion}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}。请在源端升级 YOLO 插件后重新导出。`,
+    if (obj.settingsVersion > SETTINGS_SCHEMA_VERSION) {
+      return failure(
+        'errorFileFromNewerVersion',
+        `配置文件来自更高版本的插件（版本 ${obj.settingsVersion}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}，请先升级当前插件后再导入。`,
+        {
+          fileVersion: obj.settingsVersion,
+          currentVersion: SETTINGS_SCHEMA_VERSION,
+        },
+      )
     }
+    return failure(
+      'errorFileFromOlderVersion',
+      `配置文件来自旧版本的插件（版本 ${obj.settingsVersion}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}。请在源端升级 YOLO 插件后重新导出。`,
+      {
+        fileVersion: obj.settingsVersion,
+        currentVersion: SETTINGS_SCHEMA_VERSION,
+      },
+    )
   }
 
   if (!Array.isArray(obj.keys) || obj.keys.length === 0) {
-    return { valid: false, error: '配置文件中没有包含任何配置项。' }
+    return failure('errorEmptyKeys', '配置文件中没有包含任何配置项。')
   }
 
   if (!obj.data || typeof obj.data !== 'object') {
-    return { valid: false, error: '配置文件中的数据字段缺失或不合法。' }
+    return failure('errorMissingData', '配置文件中的数据字段缺失或不合法。')
   }
 
   // 校验 keys 与 data 的一致性
@@ -66,10 +98,11 @@ export async function validateExportFile(
   const declaredKeys = new Set(obj.keys as string[])
   const undeclaredKeys = dataKeys.filter((k) => !declaredKeys.has(k))
   if (undeclaredKeys.length > 0) {
-    return {
-      valid: false,
-      error: `配置文件数据与声明不一致：data 中包含未在 keys 中声明的字段（${undeclaredKeys.join(', ')}），文件可能已被篡改。`,
-    }
+    return failure(
+      'errorTampered',
+      `配置文件数据与声明不一致：data 中包含未在 keys 中声明的字段（${undeclaredKeys.join(', ')}），文件可能已被篡改。`,
+      { fields: undeclaredKeys.join(', ') },
+    )
   }
 
   // 校验 checksum 完整性
@@ -77,10 +110,10 @@ export async function validateExportFile(
     const { checksum, ...payload } = obj
     const expectedChecksum = await computeChecksum(JSON.stringify(payload))
     if (checksum !== expectedChecksum) {
-      return {
-        valid: false,
-        error: '配置文件完整性校验失败，文件内容可能已被修改。',
-      }
+      return failure(
+        'errorChecksumMismatch',
+        '配置文件完整性校验失败，文件内容可能已被修改。',
+      )
     }
   }
 
@@ -96,26 +129,31 @@ export function parseVaultData(
   pluginVersion?: string,
 ): ValidationResult {
   if (!raw || typeof raw !== 'object') {
-    return { valid: false, error: '无法解析目标笔记库的配置数据' }
+    return failure('errorVaultParseFailed', '无法解析目标笔记库的配置数据')
   }
 
   const obj = raw as Record<string, unknown>
 
   if (typeof obj.version !== 'number') {
-    return {
-      valid: false,
-      error: '目标笔记库的配置数据缺少 version 字段，无法判断版本兼容性。',
-    }
+    return failure(
+      'errorVaultMissingVersion',
+      '目标笔记库的配置数据缺少 version 字段，无法判断版本兼容性。',
+    )
   }
 
   if (obj.version !== SETTINGS_SCHEMA_VERSION) {
-    return {
-      valid: false,
-      error:
-        obj.version > SETTINGS_SCHEMA_VERSION
-          ? `目标笔记库使用更高版本的插件（版本 ${obj.version}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}，请先升级当前插件后再导入。`
-          : `目标笔记库使用旧版本的插件（版本 ${obj.version}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}。请先在目标笔记库升级 YOLO 插件后再导入。`,
+    if (obj.version > SETTINGS_SCHEMA_VERSION) {
+      return failure(
+        'errorVaultFromNewerVersion',
+        `目标笔记库使用更高版本的插件（版本 ${obj.version}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}，请先升级当前插件后再导入。`,
+        { vaultVersion: obj.version, currentVersion: SETTINGS_SCHEMA_VERSION },
+      )
     }
+    return failure(
+      'errorVaultFromOlderVersion',
+      `目标笔记库使用旧版本的插件（版本 ${obj.version}），当前插件版本为 ${SETTINGS_SCHEMA_VERSION}。请先在目标笔记库升级 YOLO 插件后再导入。`,
+      { vaultVersion: obj.version, currentVersion: SETTINGS_SCHEMA_VERSION },
+    )
   }
 
   // 严格同版本策略下，未在 EXPORTABLE_CONFIG_KEYS 中声明的顶层字段不应进入
@@ -132,7 +170,7 @@ export function parseVaultData(
   }
 
   if (keys.length === 0) {
-    return { valid: false, error: '目标笔记库的配置数据为空' }
+    return failure('errorVaultEmpty', '目标笔记库的配置数据为空')
   }
 
   const exportFile: ConfigExportFile = {
@@ -161,12 +199,47 @@ export type ImportOptions = {
   mergeStrategy: MergeStrategy
 }
 
+type TranslateFn = (keyPath: string, fallback?: string) => string
+
+function interpolate(
+  template: string,
+  params?: Record<string, string | number>,
+): string {
+  if (!params) return template
+  return template.replace(/\{(\w+)\}/g, (_, name) =>
+    name in params ? String(params[name]) : `{${name}}`,
+  )
+}
+
+/**
+ * 把 ValidationFailure / ImportValidationError 中的 errorKey + fallback + params
+ * 渲染成最终展示给用户的字符串。
+ */
+export function renderImportError(
+  failure:
+    | ValidationFailure
+    | {
+        errorKey: ImportErrorKey
+        fallback: string
+        params?: Record<string, string | number>
+      },
+  t: TranslateFn,
+): string {
+  const template = t(
+    `configTransfer.errors.${failure.errorKey}`,
+    failure.fallback,
+  )
+  return interpolate(template, failure.params)
+}
+
 export class ImportValidationError extends Error {
   constructor(
-    message: string,
-    public readonly issues: string[],
+    public readonly errorKey: ImportErrorKey,
+    public readonly fallback: string,
+    public readonly issues: string[] = [],
+    public readonly params?: Record<string, string | number>,
   ) {
-    super(message)
+    super(fallback)
     this.name = 'ImportValidationError'
   }
 }
@@ -179,6 +252,7 @@ export class ImportValidationError extends Error {
  *
  * 流程：
  * 1. 按合并策略将 importData.data 合并到 currentSettings
+ *    （脱敏导出时先把所有敏感字段清空，避免假凭证被写入）
  * 2. 通过 yoloSettingsSchema 显式校验；失败时抛出 ImportValidationError，
  *    调用方负责提示用户并保留原配置（不静默回退到默认值）
  * 3. 在合法结果上做引用规范化与默认 assistant 兜底
@@ -188,19 +262,30 @@ export function applyImport(options: ImportOptions): YoloSettings {
 
   if (importData.settingsVersion !== SETTINGS_SCHEMA_VERSION) {
     throw new ImportValidationError(
+      'errorApplyVersionMismatch',
       `导入数据版本（${importData.settingsVersion}）与当前插件版本（${SETTINGS_SCHEMA_VERSION}）不一致，无法导入。`,
       [],
+      {
+        importVersion: importData.settingsVersion,
+        currentVersion: SETTINGS_SCHEMA_VERSION,
+      },
     )
   }
 
-  // 1. 按合并策略合并到当前配置
+  // 1. 按合并策略合并到当前配置。脱敏导出时所有敏感字段（apiKey/password/
+  //    headers/env/customHeaders.value）已是随机字符串，导入前清空，
+  //    避免被当成真凭证写回 providers/webSearch/mcp。
+  const incomingData = importData.redacted
+    ? (clearSensitive(importData.data) as Record<string, unknown>)
+    : importData.data
+
   const currentRaw = currentSettings as unknown as Record<string, unknown>
   const merged: Record<string, unknown> = { ...currentRaw }
 
   for (const key of selectedKeys) {
     if (EXCLUDED_KEYS.has(key)) continue
 
-    const importedValue = importData.data[key]
+    const importedValue = incomingData[key]
     if (importedValue === undefined) continue
 
     if (mergeStrategy === 'overwrite') {
@@ -235,6 +320,7 @@ export function applyImport(options: ImportOptions): YoloSettings {
       return `${path}: ${issue.message}`
     })
     throw new ImportValidationError(
+      'errorApplySchema',
       '导入的配置未通过校验，可能存在字段缺失或格式错误。',
       issues,
     )

--- a/src/features/config-transfer/index.ts
+++ b/src/features/config-transfer/index.ts
@@ -1,0 +1,19 @@
+export { EXPORTABLE_CONFIG_KEYS, EXCLUDED_KEYS } from './config-keys'
+export {
+  buildExportData,
+  redactApiKeys,
+  computeChecksum,
+} from './export-config'
+export {
+  validateExportFile,
+  parseVaultData,
+  applyImport,
+} from './import-config'
+export { deepMerge } from './merge-utils'
+export type {
+  ConfigExportFile,
+  ImportSource,
+  MergeStrategy,
+  ConfigKeyMeta,
+} from './types'
+export { CONFIG_EXPORT_FORMAT_VERSION } from './types'

--- a/src/features/config-transfer/index.ts
+++ b/src/features/config-transfer/index.ts
@@ -1,15 +1,12 @@
 export { EXPORTABLE_CONFIG_KEYS, EXCLUDED_KEYS } from './config-keys'
-export {
-  buildExportData,
-  redactApiKeys,
-  computeChecksum,
-} from './export-config'
+export { buildExportData, computeChecksum } from './export-config'
 export {
   validateExportFile,
   parseVaultData,
   applyImport,
 } from './import-config'
 export { deepMerge } from './merge-utils'
+export { redactSensitive, clearSensitive } from './redact'
 export type {
   ConfigExportFile,
   ImportSource,

--- a/src/features/config-transfer/merge-utils.test.ts
+++ b/src/features/config-transfer/merge-utils.test.ts
@@ -1,0 +1,125 @@
+import { deepMerge } from './merge-utils'
+
+describe('deepMerge', () => {
+  it('should merge flat objects, incoming overrides base', () => {
+    const base = { a: 1, b: 2, c: 3 }
+    const incoming = { b: 20, d: 4 }
+    const result = deepMerge(base, incoming)
+    expect(result).toEqual({ a: 1, b: 20, c: 3, d: 4 })
+  })
+
+  it('should recursively merge nested objects', () => {
+    const base = {
+      ragOptions: {
+        enabled: true,
+        chunkSize: 1000,
+        limit: 10,
+        excludePatterns: ['*.tmp'],
+      },
+    }
+    const incoming = {
+      ragOptions: {
+        chunkSize: 800,
+        limit: 20,
+      },
+    }
+    const result = deepMerge(base, incoming)
+    expect(result).toEqual({
+      ragOptions: {
+        enabled: true,
+        chunkSize: 800,
+        limit: 20,
+        excludePatterns: ['*.tmp'],
+      },
+    })
+  })
+
+  it('should replace arrays entirely (not merge them)', () => {
+    const base = { items: [1, 2, 3] }
+    const incoming = { items: [4, 5] }
+    const result = deepMerge(base, incoming)
+    expect(result).toEqual({ items: [4, 5] })
+  })
+
+  it('should handle incoming overriding object with primitive', () => {
+    const base = { nested: { a: 1 } }
+    const incoming = { nested: 'replaced' }
+    const result = deepMerge(
+      base,
+      incoming as unknown as Record<string, unknown>,
+    )
+    expect(result).toEqual({ nested: 'replaced' })
+  })
+
+  it('should handle incoming overriding primitive with object', () => {
+    const base = { value: 'string' }
+    const incoming = { value: { nested: true } }
+    const result = deepMerge(
+      base as unknown as Record<string, unknown>,
+      incoming as unknown as Record<string, unknown>,
+    )
+    expect(result).toEqual({ value: { nested: true } })
+  })
+
+  it('should not mutate the base object', () => {
+    const base = { a: 1, nested: { b: 2 } }
+    const incoming = { nested: { b: 3, c: 4 } }
+    const result = deepMerge(base, incoming)
+    expect(base.nested.b).toBe(2)
+    expect(result).toEqual({ a: 1, nested: { b: 3, c: 4 } })
+  })
+
+  it('should handle empty incoming object', () => {
+    const base = { a: 1, b: 2 }
+    const result = deepMerge(base, {})
+    expect(result).toEqual({ a: 1, b: 2 })
+  })
+
+  it('should handle empty base object', () => {
+    const incoming = { a: 1, b: 2 }
+    const result = deepMerge({}, incoming)
+    expect(result).toEqual({ a: 1, b: 2 })
+  })
+
+  it('should deeply merge multiple levels', () => {
+    const base = {
+      level1: {
+        level2: {
+          level3: { a: 1, b: 2 },
+          other: 'keep',
+        },
+      },
+    }
+    const incoming = {
+      level1: {
+        level2: {
+          level3: { b: 20, c: 3 },
+        },
+      },
+    }
+    const result = deepMerge(base, incoming)
+    expect(result).toEqual({
+      level1: {
+        level2: {
+          level3: { a: 1, b: 20, c: 3 },
+          other: 'keep',
+        },
+      },
+    })
+  })
+
+  it('should allow null in incoming to override object in base', () => {
+    const base = { config: { a: 1, b: 2 } }
+    const incoming = { config: null }
+    const result = deepMerge(
+      base as unknown as Record<string, unknown>,
+      incoming as unknown as Record<string, unknown>,
+    )
+    expect(result).toEqual({ config: null })
+  })
+
+  it('should handle both base and incoming being empty', () => {
+    const result = deepMerge({}, {})
+    expect(result).toEqual({})
+  })
+})

--- a/src/features/config-transfer/merge-utils.ts
+++ b/src/features/config-transfer/merge-utils.ts
@@ -1,0 +1,44 @@
+/**
+ * JSON deep merge 工具
+ *
+ * 合并规则：
+ * - 对象类型：递归合并，导入数据的字段覆盖同名字段，当前独有字段保留
+ * - 数组类型：导入数据的数组直接替换当前数组
+ * - 基本类型：导入数据覆盖当前值
+ */
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  )
+}
+
+/**
+ * 深度合并两个对象。
+ * incoming 中的值会覆盖 base 中的同名字段，
+ * base 中独有的字段会被保留。
+ */
+export function deepMerge(
+  base: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+): Record<string, unknown> {
+  const result = { ...base }
+
+  for (const key of Object.keys(incoming)) {
+    const baseValue = base[key]
+    const incomingValue = incoming[key]
+
+    if (isPlainObject(baseValue) && isPlainObject(incomingValue)) {
+      // 递归合并对象
+      result[key] = deepMerge(baseValue, incomingValue)
+    } else {
+      // 数组、基本类型：直接覆盖
+      result[key] = incomingValue
+    }
+  }
+
+  return result
+}

--- a/src/features/config-transfer/redact.ts
+++ b/src/features/config-transfer/redact.ts
@@ -97,6 +97,42 @@ export function clearSensitive(data: unknown): unknown {
   return mapSensitiveValues(data, () => '')
 }
 
+/**
+ * 探测对象树中是否实际存在任意"非空字符串"的敏感值。
+ * 用于 UI 动态判定某个顶层 key 的实例是否真的含凭证，
+ * 替代过去基于类目的静态 `sensitive: true` 标记，
+ * 避免给"没配 apiKey 的 Ollama / 无 env 的 MCP"误打标。
+ */
+export function hasNonEmptyCredentials(data: unknown): boolean {
+  if (Array.isArray(data)) {
+    return data.some((item) => hasNonEmptyCredentials(item))
+  }
+  if (!isPlainObject(data)) return false
+
+  for (const [key, value] of Object.entries(data)) {
+    if (SENSITIVE_STRING_FIELDS.has(key)) {
+      if (typeof value === 'string' && value.length > 0) return true
+      continue
+    }
+    if (SENSITIVE_RECORD_FIELDS.has(key) && isPlainObject(value)) {
+      for (const inner of Object.values(value)) {
+        if (typeof inner === 'string' && inner.length > 0) return true
+      }
+      continue
+    }
+    if (key === 'customHeaders' && Array.isArray(value)) {
+      for (const item of value) {
+        if (!isPlainObject(item)) continue
+        const v = item['value']
+        if (typeof v === 'string' && v.length > 0) return true
+      }
+      continue
+    }
+    if (hasNonEmptyCredentials(value)) return true
+  }
+  return false
+}
+
 function randomString(length: number): string {
   const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
   let result = ''

--- a/src/features/config-transfer/redact.ts
+++ b/src/features/config-transfer/redact.ts
@@ -1,0 +1,107 @@
+/**
+ * 配置导入/导出过程中的敏感字段处理。
+ *
+ * 敏感字段覆盖范围（来自当前 settings schema 实际可能存放凭证的位置）：
+ * - `apiKey: string`：providers、各 webSearch provider 都用这个字段名
+ * - `password: string`：webSearch.searxng
+ * - `headers: { [k]: string }` 内所有 value：mcp http/sse transport
+ * - `env: { [k]: string }` 内所有 value：mcp stdio transport
+ * - `customHeaders: [{ key, value }]` 中每项的 value：providers 的自定义请求头
+ *
+ * 走单一 walker，导出用 replace（随机字符串），导入用 strip（清空字符串）。
+ * 不在白名单内的字段名一律不动，避免误杀业务数据。
+ */
+
+type WalkOp = (value: string) => string
+
+const SENSITIVE_STRING_FIELDS = new Set(['apiKey', 'password'])
+const SENSITIVE_RECORD_FIELDS = new Set(['headers', 'env'])
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  )
+}
+
+function transformRecord(
+  record: Record<string, unknown>,
+  op: WalkOp,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(record)) {
+    if (typeof v === 'string') {
+      out[k] = op(v)
+    } else {
+      out[k] = v
+    }
+  }
+  return out
+}
+
+function transformCustomHeaders(items: unknown[], op: WalkOp): unknown[] {
+  return items.map((item) => {
+    if (!isPlainObject(item)) return item
+    const value = item['value']
+    if (typeof value !== 'string') return item
+    return { ...item, value: op(value) }
+  })
+}
+
+/**
+ * 递归扫描配置树，对所有已知敏感字段应用 op。
+ * 返回新对象，不修改输入。
+ */
+export function mapSensitiveValues(data: unknown, op: WalkOp): unknown {
+  if (Array.isArray(data)) {
+    return data.map((item) => mapSensitiveValues(item, op))
+  }
+  if (!isPlainObject(data)) return data
+
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    if (SENSITIVE_STRING_FIELDS.has(key) && typeof value === 'string') {
+      result[key] = op(value)
+      continue
+    }
+    if (SENSITIVE_RECORD_FIELDS.has(key) && isPlainObject(value)) {
+      result[key] = transformRecord(value, op)
+      continue
+    }
+    if (key === 'customHeaders' && Array.isArray(value)) {
+      result[key] = transformCustomHeaders(value, op)
+      continue
+    }
+    result[key] = mapSensitiveValues(value, op)
+  }
+  return result
+}
+
+/**
+ * 用等长随机字符串替换所有敏感值。空字符串保持空。
+ * 仅用于视觉脱敏，不需要密码学强度。
+ */
+export function redactSensitive(data: unknown): unknown {
+  return mapSensitiveValues(data, (value) =>
+    value.length > 0 ? randomString(value.length) : '',
+  )
+}
+
+/**
+ * 把所有敏感值清空（设为空字符串）。
+ * 用于导入端：脱敏导出文件里的随机字符串绝不能当真 key 写入。
+ */
+export function clearSensitive(data: unknown): unknown {
+  return mapSensitiveValues(data, () => '')
+}
+
+function randomString(length: number): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+  let result = ''
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length))
+  }
+  return result
+}

--- a/src/features/config-transfer/types.ts
+++ b/src/features/config-transfer/types.ts
@@ -36,8 +36,6 @@ export type ConfigKeyMeta = {
   key: string
   /** i18n 缺失时使用的可读默认 label（中文） */
   fallbackLabel: string
-  /** 是否包含敏感信息（API Key / 凭证等） */
-  sensitive?: boolean
 }
 
 /** 当前导出文件格式版本 */

--- a/src/features/config-transfer/types.ts
+++ b/src/features/config-transfer/types.ts
@@ -1,0 +1,44 @@
+/**
+ * 配置导入/导出功能的类型定义
+ */
+
+/** 导出文件的顶层结构 */
+export type ConfigExportFile = {
+  /** 固定标识，用于校验文件格式 */
+  $schema: 'yolo-config-export'
+  /** 导出文件格式版本（未来格式变更时递增） */
+  formatVersion: number
+  /** 导出时的 SETTINGS_SCHEMA_VERSION，导入时用于驱动迁移链 */
+  settingsVersion: number
+  /** 导出时间 ISO 字符串 */
+  exportedAt: string
+  /** 导出时的插件版本号 */
+  pluginVersion: string
+  /** 是否为脱敏导出（API Key 已替换为随机字符串） */
+  redacted: boolean
+  /** 导出的配置 key 列表 */
+  keys: string[]
+  /** 实际配置数据（仅包含 keys 中列出的字段） */
+  data: Record<string, unknown>
+  /** 除 checksum 外所有字段的 JSON 序列化 SHA-256 哈希（hex），用于完整性校验 */
+  checksum: string
+}
+
+/** 导入来源类型 */
+export type ImportSource = 'file' | 'vault'
+
+/** 导入合并策略 */
+export type MergeStrategy = 'overwrite' | 'merge'
+
+/** 配置 key 的元信息 */
+export type ConfigKeyMeta = {
+  /** data.json 中的 key */
+  key: string
+  /** 显示名称 */
+  label: string
+  /** 是否包含敏感信息（API Key） */
+  sensitive?: boolean
+}
+
+/** 当前导出文件格式版本 */
+export const CONFIG_EXPORT_FORMAT_VERSION = 1

--- a/src/features/config-transfer/types.ts
+++ b/src/features/config-transfer/types.ts
@@ -14,7 +14,7 @@ export type ConfigExportFile = {
   exportedAt: string
   /** 导出时的插件版本号 */
   pluginVersion: string
-  /** 是否为脱敏导出（API Key 已替换为随机字符串） */
+  /** 是否为脱敏导出（敏感字段已替换为随机字符串） */
   redacted: boolean
   /** 导出的配置 key 列表 */
   keys: string[]
@@ -34,11 +34,33 @@ export type MergeStrategy = 'overwrite' | 'merge'
 export type ConfigKeyMeta = {
   /** data.json 中的 key */
   key: string
-  /** 显示名称 */
-  label: string
-  /** 是否包含敏感信息（API Key） */
+  /** i18n 缺失时使用的可读默认 label（中文） */
+  fallbackLabel: string
+  /** 是否包含敏感信息（API Key / 凭证等） */
   sensitive?: boolean
 }
 
 /** 当前导出文件格式版本 */
 export const CONFIG_EXPORT_FORMAT_VERSION = 1
+
+/**
+ * 导入/校验失败时使用的错误 key，配合 `configTransfer.errors.*` 翻译条目。
+ */
+export type ImportErrorKey =
+  | 'errorNotJson'
+  | 'errorNotExportFile'
+  | 'errorInvalidFormatVersion'
+  | 'errorInvalidSettingsVersion'
+  | 'errorFileFromNewerVersion'
+  | 'errorFileFromOlderVersion'
+  | 'errorEmptyKeys'
+  | 'errorMissingData'
+  | 'errorTampered'
+  | 'errorChecksumMismatch'
+  | 'errorVaultParseFailed'
+  | 'errorVaultMissingVersion'
+  | 'errorVaultFromNewerVersion'
+  | 'errorVaultFromOlderVersion'
+  | 'errorVaultEmpty'
+  | 'errorApplyVersionMismatch'
+  | 'errorApplySchema'

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -23,6 +23,8 @@ export const en: TranslationKeys = {
     triggerTabCompletion: 'Trigger tab completion',
     acceptInlineSuggestion: 'Accept completion',
     capturePdfRegion: 'Capture PDF region to chat',
+    exportSettings: 'Export plugin settings',
+    importSettings: 'Import plugin settings',
   },
 
   common: {
@@ -1083,6 +1085,14 @@ export const en: TranslationKeys = {
     },
     etc: {
       title: 'Other',
+      exportConfig: 'Export settings',
+      exportConfigDesc:
+        'Export current plugin settings to a JSON file for use in other vaults.',
+      export: 'Export',
+      importConfig: 'Import settings',
+      importConfigDesc:
+        'Import plugin settings from an export file or another vault.',
+      import: 'Import',
       resetSettings: 'Reset settings',
       resetSettingsDesc: 'Reset all settings to default values',
       resetSettingsConfirm:

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1663,6 +1663,109 @@ export const en: TranslationKeys = {
     extraHighDesc: 'Maximum thinking, for the toughest reasoning',
   },
 
+  configTransfer: {
+    export: {
+      title: 'Export settings',
+      description: 'Select the settings to export',
+      selectAll: 'Select all',
+      selectNone: 'Select none',
+      sensitive: 'Contains credentials',
+      redactedOption:
+        'Redact credentials (replace API keys / passwords / headers / env vars with random strings)',
+      submit: 'Export',
+      cancel: 'Cancel',
+      noticeAtLeastOne: 'Please select at least one item',
+      noticeReadFailed: 'Failed to read current settings',
+      noticeSuccess: 'Settings exported as {fileName}',
+      noticeFailed: 'Failed to export settings — check console for details',
+    },
+    import: {
+      title: 'Import settings',
+      sourceFile: 'Import from file',
+      sourceFileDesc: 'Choose a previously exported .json file',
+      sourceVault: 'Import from another vault',
+      sourceVaultDesc: 'Choose a vault directory with YOLO installed',
+      description: 'Select the settings to import',
+      selectAll: 'Select all',
+      selectNone: 'Select none',
+      sensitive: 'Contains credentials',
+      strategyOverwriteTitle: 'Overwrite',
+      strategyOverwriteDesc: 'Replace selected settings with the imported ones',
+      strategyMergeTitle: 'JSON merge',
+      strategyMergeDesc:
+        'Deep merge, keep existing values for fields not present in the import',
+      submit: 'Import',
+      back: 'Back',
+      cancel: 'Cancel',
+      noticeInvalidJson:
+        'File is not valid JSON. Please pick the correct settings file.',
+      noticeFileReadFailed: 'Failed to read the file. Please try again.',
+      noticeRedactedHint:
+        'Note: this export was redacted. All API keys / passwords / headers / env vars have been cleared and must be re-entered after import.',
+      noticeRedactedReminder:
+        'Note: this export was redacted. All API keys / passwords / headers / env vars have been cleared — please re-enter them in settings.',
+      noticePluginNotFound:
+        'No YOLO plugin settings found in the selected directory.',
+      noticeAtLeastOne: 'Please select at least one item',
+      noticeSuccess: 'Settings imported successfully',
+      noticeFailed: 'Failed to import settings',
+    },
+    errors: {
+      errorNotJson: 'File content is not a valid JSON object.',
+      errorNotExportFile:
+        'This file is not a YOLO plugin export file. Please pick a .json produced by the "Export settings" feature.',
+      errorInvalidFormatVersion:
+        'Invalid export format version — the file may be corrupted.',
+      errorInvalidSettingsVersion:
+        'Invalid settings version in the export file — it may be corrupted.',
+      errorFileFromNewerVersion:
+        'This file was exported by a newer plugin version ({fileVersion}); current plugin schema is {currentVersion}. Please upgrade this plugin before importing.',
+      errorFileFromOlderVersion:
+        'This file was exported by an older plugin version ({fileVersion}); current plugin schema is {currentVersion}. Please upgrade YOLO on the source vault and re-export.',
+      errorEmptyKeys: 'The export file contains no settings to import.',
+      errorMissingData:
+        'The data field is missing or invalid in the export file.',
+      errorTampered:
+        'Export file is inconsistent: data contains fields not declared in keys ({fields}). The file may have been tampered with.',
+      errorChecksumMismatch:
+        'Export file integrity check failed — the content may have been modified.',
+      errorVaultParseFailed:
+        'Could not parse the settings data from the target vault.',
+      errorVaultMissingVersion:
+        'Target vault settings are missing the version field — cannot check compatibility.',
+      errorVaultFromNewerVersion:
+        'Target vault uses a newer plugin version ({vaultVersion}); current is {currentVersion}. Please upgrade this plugin before importing.',
+      errorVaultFromOlderVersion:
+        'Target vault uses an older plugin version ({vaultVersion}); current is {currentVersion}. Please upgrade YOLO in the target vault before importing.',
+      errorVaultEmpty: 'Target vault contains no exportable settings.',
+      errorApplyVersionMismatch:
+        'Import data version ({importVersion}) does not match current plugin schema ({currentVersion}).',
+      errorApplySchema:
+        'The imported settings failed validation — fields may be missing or malformed.',
+    },
+    keyLabels: {
+      providers: 'AI providers',
+      chatModels: 'Chat models',
+      embeddingModels: 'Embedding models',
+      chatModelId: 'Default chat model',
+      chatTitleModelId: 'Title-generation model',
+      embeddingModelId: 'Default embedding model',
+      systemPrompt: 'System prompt',
+      ragOptions: 'Knowledge base settings',
+      mcp: 'MCP tools',
+      webSearch: 'Web search',
+      skills: 'Skills',
+      yolo: 'Base settings',
+      debug: 'Debug settings',
+      chatOptions: 'Chat preferences',
+      notificationOptions: 'Notifications',
+      continuationOptions: 'Continuation & completion',
+      assistants: 'Agents',
+      currentAssistantId: 'Current agent',
+      quickAskAssistantId: 'Quick Ask agent',
+    },
+  },
+
   update: {
     newVersionAvailable: 'New version {version} is available',
     currentVersion: 'Current',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -23,6 +23,8 @@ export const zh: TranslationKeys = {
     triggerTabCompletion: '触发 Tab 补全',
     acceptInlineSuggestion: '接受补全',
     capturePdfRegion: '截取 PDF 区域到聊天',
+    exportSettings: '导出插件配置',
+    importSettings: '导入插件配置',
   },
 
   common: {
@@ -1002,6 +1004,13 @@ export const zh: TranslationKeys = {
     },
     etc: {
       title: '其他',
+      exportConfig: '导出配置',
+      exportConfigDesc:
+        '将当前插件配置导出为 JSON 文件，方便在其他笔记库中导入使用。',
+      export: '导出',
+      importConfig: '导入配置',
+      importConfigDesc: '从导出文件或其他笔记库导入插件配置。',
+      import: '导入',
       resetSettings: '重置设置',
       resetSettingsDesc: '将所有设置重置为默认值',
       resetSettingsConfirm: '确定要将所有设置重置为默认值吗？此操作无法撤销。',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -1557,6 +1557,101 @@ export const zh: TranslationKeys = {
     extraHighDesc: '极致思考，处理最棘手的推理',
   },
 
+  configTransfer: {
+    export: {
+      title: '导出配置',
+      description: '选择要导出的配置项',
+      selectAll: '全选',
+      selectNone: '全不选',
+      sensitive: '含凭证',
+      redactedOption:
+        '脱敏导出（替换 API Key / 密码 / Header / 环境变量等凭证为随机字符串）',
+      submit: '导出',
+      cancel: '取消',
+      noticeAtLeastOne: '请至少选择一项配置',
+      noticeReadFailed: '无法读取当前配置数据',
+      noticeSuccess: '配置已导出为 {fileName}',
+      noticeFailed: '配置导出失败，请检查控制台日志',
+    },
+    import: {
+      title: '导入配置',
+      sourceFile: '从配置文件导入',
+      sourceFileDesc: '选择之前导出的 .json 文件',
+      sourceVault: '从其他笔记库导入',
+      sourceVaultDesc: '选择已安装 YOLO 的笔记库目录',
+      description: '选择要导入的配置项',
+      selectAll: '全选',
+      selectNone: '全不选',
+      sensitive: '含凭证',
+      strategyOverwriteTitle: '全量覆盖',
+      strategyOverwriteDesc: '用导入的配置替换选中项',
+      strategyMergeTitle: 'JSON 合并',
+      strategyMergeDesc: '深度合并，保留未冲突的现有值',
+      submit: '确认导入',
+      back: '返回',
+      cancel: '取消',
+      noticeInvalidJson:
+        '文件不是有效的 JSON 格式，请确认选择了正确的配置文件。',
+      noticeFileReadFailed: '文件读取失败，请重试。',
+      noticeRedactedHint:
+        '注意：该配置为脱敏导出，所有 API Key / 密码 / Header / 环境变量已被清空，需导入后手动补填。',
+      noticeRedactedReminder:
+        '注意：该配置为脱敏导出，所有 API Key / 密码 / Header / 环境变量已被清空，请前往设置补填。',
+      noticePluginNotFound: '未在该目录找到 YOLO 插件配置',
+      noticeAtLeastOne: '请至少选择一项配置',
+      noticeSuccess: '配置导入成功',
+      noticeFailed: '配置导入失败',
+    },
+    errors: {
+      errorNotJson: '文件内容不是有效的 JSON 对象',
+      errorNotExportFile:
+        '该文件不是 YOLO 插件的配置导出文件，请选择通过「导出配置」功能生成的 .json 文件。',
+      errorInvalidFormatVersion: '配置文件格式版本不合法，可能已损坏。',
+      errorInvalidSettingsVersion: '配置文件中的设置版本号不合法，可能已损坏。',
+      errorFileFromNewerVersion:
+        '配置文件来自更高版本的插件（版本 {fileVersion}），当前插件版本为 {currentVersion}，请先升级当前插件后再导入。',
+      errorFileFromOlderVersion:
+        '配置文件来自旧版本的插件（版本 {fileVersion}），当前插件版本为 {currentVersion}。请在源端升级 YOLO 插件后重新导出。',
+      errorEmptyKeys: '配置文件中没有包含任何配置项。',
+      errorMissingData: '配置文件中的数据字段缺失或不合法。',
+      errorTampered:
+        '配置文件数据与声明不一致：data 中包含未在 keys 中声明的字段（{fields}），文件可能已被篡改。',
+      errorChecksumMismatch: '配置文件完整性校验失败，文件内容可能已被修改。',
+      errorVaultParseFailed: '无法解析目标笔记库的配置数据',
+      errorVaultMissingVersion:
+        '目标笔记库的配置数据缺少 version 字段，无法判断版本兼容性。',
+      errorVaultFromNewerVersion:
+        '目标笔记库使用更高版本的插件（版本 {vaultVersion}），当前插件版本为 {currentVersion}，请先升级当前插件后再导入。',
+      errorVaultFromOlderVersion:
+        '目标笔记库使用旧版本的插件（版本 {vaultVersion}），当前插件版本为 {currentVersion}。请先在目标笔记库升级 YOLO 插件后再导入。',
+      errorVaultEmpty: '目标笔记库的配置数据为空',
+      errorApplyVersionMismatch:
+        '导入数据版本（{importVersion}）与当前插件版本（{currentVersion}）不一致，无法导入。',
+      errorApplySchema: '导入的配置未通过校验，可能存在字段缺失或格式错误。',
+    },
+    keyLabels: {
+      providers: 'AI 服务商',
+      chatModels: '对话模型',
+      embeddingModels: '嵌入模型',
+      chatModelId: '默认对话模型',
+      chatTitleModelId: '标题生成模型',
+      embeddingModelId: '默认嵌入模型',
+      systemPrompt: '系统提示词',
+      ragOptions: '知识库设置',
+      mcp: 'MCP 工具',
+      webSearch: '联网搜索',
+      skills: '技能设置',
+      yolo: '基础设置',
+      debug: '调试设置',
+      chatOptions: '对话偏好',
+      notificationOptions: '通知设置',
+      continuationOptions: '续写与补全',
+      assistants: 'Agent 配置',
+      currentAssistantId: '当前 Agent',
+      quickAskAssistantId: 'Quick Ask Agent',
+    },
+  },
+
   update: {
     newVersionAvailable: '新版本 {version} 已发布',
     currentVersion: '当前版本',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1445,6 +1445,90 @@ export type TranslationKeys = {
     extraHighDesc?: string
   }
 
+  // Config import / export
+  configTransfer?: {
+    export: {
+      title: string
+      description: string
+      selectAll: string
+      selectNone: string
+      sensitive: string
+      redactedOption: string
+      submit: string
+      cancel: string
+      noticeAtLeastOne: string
+      noticeReadFailed: string
+      noticeSuccess: string
+      noticeFailed: string
+    }
+    import: {
+      title: string
+      sourceFile: string
+      sourceFileDesc: string
+      sourceVault: string
+      sourceVaultDesc: string
+      description: string
+      selectAll: string
+      selectNone: string
+      sensitive: string
+      strategyOverwriteTitle: string
+      strategyOverwriteDesc: string
+      strategyMergeTitle: string
+      strategyMergeDesc: string
+      submit: string
+      back: string
+      cancel: string
+      noticeInvalidJson: string
+      noticeFileReadFailed: string
+      noticeRedactedHint: string
+      noticeRedactedReminder: string
+      noticePluginNotFound: string
+      noticeAtLeastOne: string
+      noticeSuccess: string
+      noticeFailed: string
+    }
+    errors: {
+      errorNotJson: string
+      errorNotExportFile: string
+      errorInvalidFormatVersion: string
+      errorInvalidSettingsVersion: string
+      errorFileFromNewerVersion: string
+      errorFileFromOlderVersion: string
+      errorEmptyKeys: string
+      errorMissingData: string
+      errorTampered: string
+      errorChecksumMismatch: string
+      errorVaultParseFailed: string
+      errorVaultMissingVersion: string
+      errorVaultFromNewerVersion: string
+      errorVaultFromOlderVersion: string
+      errorVaultEmpty: string
+      errorApplyVersionMismatch: string
+      errorApplySchema: string
+    }
+    keyLabels: {
+      providers: string
+      chatModels: string
+      embeddingModels: string
+      chatModelId: string
+      chatTitleModelId: string
+      embeddingModelId: string
+      systemPrompt: string
+      ragOptions: string
+      mcp: string
+      webSearch: string
+      skills: string
+      yolo: string
+      debug: string
+      chatOptions: string
+      notificationOptions: string
+      continuationOptions: string
+      assistants: string
+      currentAssistantId: string
+      quickAskAssistantId: string
+    }
+  }
+
   // Plugin update banner (GitHub release check)
   update: {
     newVersionAvailable: string

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -24,6 +24,8 @@ export type TranslationKeys = {
     triggerTabCompletion: string
     acceptInlineSuggestion: string
     capturePdfRegion?: string
+    exportSettings?: string
+    importSettings?: string
   }
 
   // UI Common
@@ -850,6 +852,12 @@ export type TranslationKeys = {
     }
     etc: {
       title: string
+      exportConfig?: string
+      exportConfigDesc?: string
+      export?: string
+      importConfig?: string
+      importConfigDesc?: string
+      import?: string
       resetSettings: string
       resetSettingsDesc: string
       resetSettingsConfirm: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,8 @@ import {
 } from './features/chat/chatLeafSessionManager'
 import { ChatViewNavigator } from './features/chat/chatViewNavigator'
 import { NewTabEmptyStateEnhancer } from './features/chat/newTabEmptyStateEnhancer'
+import { ExportConfigModal } from './features/config-transfer/components/ExportConfigModal'
+import { ImportConfigModal } from './features/config-transfer/components/ImportConfigModal'
 import { DiffReviewController } from './features/editor/diff-review/diffReviewController'
 import {
   buildFullReviewBlocks,
@@ -1875,6 +1877,23 @@ export default class YoloPlugin extends Plugin {
         }
       },
     })
+
+    this.addCommand({
+      id: 'export-settings',
+      name: this.t('commands.exportSettings', '导出插件配置'),
+      callback: () => {
+        new ExportConfigModal(this.app, this).open()
+      },
+    })
+
+    this.addCommand({
+      id: 'import-settings',
+      name: this.t('commands.importSettings', '导入插件配置'),
+      callback: () => {
+        new ImportConfigModal(this.app, this).open()
+      },
+    })
+
     // This adds a settings tab so the user can configure various aspects of the plugin
     this.addSettingTab(new YoloSettingTab(this.app, this))
 

--- a/src/styles/chat/todo-list-panel.css
+++ b/src/styles/chat/todo-list-panel.css
@@ -85,7 +85,6 @@ button.yolo-todo-panel__header {
   overflow: hidden;
 }
 
-
 .yolo-todo-panel__list {
   list-style: none;
   margin: 0;

--- a/src/styles/config-transfer.css
+++ b/src/styles/config-transfer.css
@@ -1,0 +1,219 @@
+/* 配置导入/导出 Modal */
+
+.yolo-config-transfer-modal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-4-3);
+  padding: var(--size-4-4) var(--size-4-3) var(--size-4-2);
+}
+
+.yolo-config-transfer-desc {
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+}
+
+/* 来源选择按钮 */
+
+.yolo-config-transfer-source-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: var(--size-4-2);
+}
+
+.yolo-config-transfer-source-btn {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--size-4-3) var(--size-4-4);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+  background: var(--background-primary);
+  cursor: pointer;
+  text-align: center;
+  flex: 1;
+  height: auto;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.yolo-config-transfer-source-btn:hover {
+  background: var(--background-secondary);
+  border-color: var(--interactive-accent);
+}
+
+.yolo-config-transfer-source-btn strong {
+  font-size: var(--font-ui-small);
+  font-weight: var(--font-semibold);
+  color: var(--text-normal);
+  line-height: normal;
+}
+
+.yolo-config-transfer-source-btn span {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  line-height: normal;
+}
+
+/* 配置项列表 */
+
+.yolo-config-transfer-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.yolo-config-transfer-toolbar-actions {
+  display: flex;
+  gap: var(--size-4-1);
+}
+
+.yolo-config-transfer-toolbar-actions button {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-accent);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: var(--radius-s);
+}
+
+.yolo-config-transfer-toolbar-actions button:hover {
+  background: var(--background-modifier-hover);
+}
+
+.yolo-config-transfer-list {
+  display: flex;
+  flex-direction: column;
+  max-height: 300px;
+  overflow-y: auto;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+}
+
+.yolo-config-transfer-item {
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-2);
+  padding: var(--size-4-2) var(--size-4-3);
+  cursor: pointer;
+  margin: 0;
+}
+
+.yolo-config-transfer-item + .yolo-config-transfer-item {
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.yolo-config-transfer-item:hover {
+  background: var(--background-modifier-hover);
+}
+
+.yolo-config-transfer-item input[type='checkbox'] {
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.yolo-config-transfer-item-label {
+  display: flex;
+  align-items: baseline;
+  gap: var(--size-4-2);
+  flex: 1;
+  min-width: 0;
+  font-size: var(--font-ui-small);
+  color: var(--text-normal);
+}
+
+.yolo-config-transfer-item-key {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-faint);
+  font-family: var(--font-monospace);
+}
+
+.yolo-config-transfer-sensitive {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-warning);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* 脱敏选项 */
+
+.yolo-config-transfer-option {
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-2);
+  padding: var(--size-4-2) var(--size-4-3);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+  font-size: var(--font-ui-small);
+  cursor: pointer;
+}
+
+.yolo-config-transfer-option:hover {
+  background: var(--background-modifier-hover);
+}
+
+.yolo-config-transfer-option input[type='checkbox'] {
+  margin: 0;
+}
+
+/* 合并策略 */
+
+.yolo-config-transfer-strategy {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+  overflow: hidden;
+}
+
+.yolo-config-transfer-strategy-option {
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-2);
+  padding: var(--size-4-2) var(--size-4-3);
+  cursor: pointer;
+  margin: 0;
+  font-size: var(--font-ui-small);
+  color: var(--text-normal);
+}
+
+.yolo-config-transfer-strategy-option + .yolo-config-transfer-strategy-option {
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.yolo-config-transfer-strategy-option:hover {
+  background: var(--background-modifier-hover);
+}
+
+.yolo-config-transfer-strategy-option.is-selected {
+  background: var(--background-secondary);
+}
+
+.yolo-config-transfer-strategy-option strong {
+  font-weight: var(--font-semibold);
+}
+
+.yolo-config-transfer-radio {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--text-faint);
+  flex-shrink: 0;
+  transition: border-color 0.15s ease;
+}
+
+.yolo-config-transfer-strategy-option.is-selected .yolo-config-transfer-radio {
+  border-color: var(--interactive-accent);
+}
+
+.yolo-config-transfer-radio-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--interactive-accent);
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -25,3 +25,4 @@
 @import './editor/tab-completion.css';
 
 @import './pdf-screenshot.css';
+@import './config-transfer.css';

--- a/styles.css
+++ b/styles.css
@@ -15782,3 +15782,223 @@ body.yolo-quick-ask-global-interaction * {
   color: var(--text-normal);
   background: var(--background-modifier-hover);
 }
+
+/* 配置导入/导出 Modal */
+
+.yolo-config-transfer-modal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-4-3);
+  padding: var(--size-4-4) var(--size-4-3) var(--size-4-2);
+}
+
+.yolo-config-transfer-desc {
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+}
+
+/* 来源选择按钮 */
+
+.yolo-config-transfer-source-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: var(--size-4-2);
+}
+
+.yolo-config-transfer-source-btn {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--size-4-3) var(--size-4-4);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+  background: var(--background-primary);
+  cursor: pointer;
+  text-align: center;
+  flex: 1;
+  height: auto;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.yolo-config-transfer-source-btn:hover {
+  background: var(--background-secondary);
+  border-color: var(--interactive-accent);
+}
+
+.yolo-config-transfer-source-btn strong {
+  font-size: var(--font-ui-small);
+  font-weight: var(--font-semibold);
+  color: var(--text-normal);
+  line-height: normal;
+}
+
+.yolo-config-transfer-source-btn span {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  line-height: normal;
+}
+
+/* 配置项列表 */
+
+.yolo-config-transfer-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.yolo-config-transfer-toolbar-actions {
+  display: flex;
+  gap: var(--size-4-1);
+}
+
+.yolo-config-transfer-toolbar-actions button {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-accent);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: var(--radius-s);
+}
+
+.yolo-config-transfer-toolbar-actions button:hover {
+  background: var(--background-modifier-hover);
+}
+
+.yolo-config-transfer-list {
+  display: flex;
+  flex-direction: column;
+  max-height: 300px;
+  overflow-y: auto;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+}
+
+.yolo-config-transfer-item {
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-2);
+  padding: var(--size-4-2) var(--size-4-3);
+  cursor: pointer;
+  margin: 0;
+}
+
+.yolo-config-transfer-item + .yolo-config-transfer-item {
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.yolo-config-transfer-item:hover {
+  background: var(--background-modifier-hover);
+}
+
+.yolo-config-transfer-item input[type='checkbox'] {
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.yolo-config-transfer-item-label {
+  display: flex;
+  align-items: baseline;
+  gap: var(--size-4-2);
+  flex: 1;
+  min-width: 0;
+  font-size: var(--font-ui-small);
+  color: var(--text-normal);
+}
+
+.yolo-config-transfer-item-key {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-faint);
+  font-family: var(--font-monospace);
+}
+
+.yolo-config-transfer-sensitive {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-warning);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* 脱敏选项 */
+
+.yolo-config-transfer-option {
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-2);
+  padding: var(--size-4-2) var(--size-4-3);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+  font-size: var(--font-ui-small);
+  cursor: pointer;
+}
+
+.yolo-config-transfer-option:hover {
+  background: var(--background-modifier-hover);
+}
+
+.yolo-config-transfer-option input[type='checkbox'] {
+  margin: 0;
+}
+
+/* 合并策略 */
+
+.yolo-config-transfer-strategy {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+  overflow: hidden;
+}
+
+.yolo-config-transfer-strategy-option {
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-2);
+  padding: var(--size-4-2) var(--size-4-3);
+  cursor: pointer;
+  margin: 0;
+  font-size: var(--font-ui-small);
+  color: var(--text-normal);
+}
+
+.yolo-config-transfer-strategy-option + .yolo-config-transfer-strategy-option {
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.yolo-config-transfer-strategy-option:hover {
+  background: var(--background-modifier-hover);
+}
+
+.yolo-config-transfer-strategy-option.is-selected {
+  background: var(--background-secondary);
+}
+
+.yolo-config-transfer-strategy-option strong {
+  font-weight: var(--font-semibold);
+}
+
+.yolo-config-transfer-radio {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--text-faint);
+  flex-shrink: 0;
+  transition: border-color 0.15s ease;
+}
+
+.yolo-config-transfer-strategy-option.is-selected .yolo-config-transfer-radio {
+  border-color: var(--interactive-accent);
+}
+
+.yolo-config-transfer-radio-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--interactive-accent);
+}


### PR DESCRIPTION
## 概述

新增配置导入/导出功能，解决用户在多个笔记库之间重复配置的痛点。

## 功能

### 导出
- 可视化选择要导出的配置项（以 data.json 第一层级 key 为粒度）
- 支持脱敏导出（将 API Key 替换为等长随机字符串）
- 导出为带 SHA-256 完整性校验的 JSON 文件

### 导入
- 两种来源：从导出的 .json 文件导入 / 从其他笔记库目录导入
- 可视化选择要导入哪些配置项
- 两种合并策略：全量覆盖 / JSON 深度合并
- 自动通过迁移链升级旧版本配置
- 导入后自动校验引用完整性（normalizeYoloSettingsReferences）

### 安全
- 文件格式校验（$schema 标识）
- keys 与 data 一致性校验（防篡改）
- SHA-256 checksum 完整性校验
- 含 API Key 的配置项标注提醒
- 移动端隐藏不支持的「从笔记库导入」选项

## 入口

- 设置页面：其他 → 维护 → 导出配置 / 导入配置
- 命令面板：`导出插件配置` / `导入插件配置`

## 改动文件

### 新增
| 文件 | 说明 |
|------|------|
| `src/features/config-transfer/types.ts` | 导出文件格式、合并策略等类型定义 |
| `src/features/config-transfer/config-keys.ts` | 可导入导出的 key 列表 + 显示名称 |
| `src/features/config-transfer/export-config.ts` | 导出逻辑（提取 key、脱敏、checksum） |
| `src/features/config-transfer/import-config.ts` | 导入逻辑（校验、迁移、合并） |
| `src/features/config-transfer/merge-utils.ts` | JSON deep merge 工具 |
| `src/features/config-transfer/index.ts` | 统一导出 |
| `src/features/config-transfer/export-config.test.ts` | 导出逻辑单元测试 |
| `src/features/config-transfer/import-config.test.ts` | 导入逻辑单元测试 |
| `src/features/config-transfer/merge-utils.test.ts` | 合并工具单元测试 |
| `src/features/config-transfer/components/ExportConfigModal.tsx` | 导出选择 Modal |
| `src/features/config-transfer/components/ImportConfigModal.tsx` | 导入来源 + 配置选择 Modal |
| `src/styles/config-transfer.css` | Modal 样式 |

### 修改
| 文件 | 说明 |
|------|------|
| `src/main.ts` | 注册 export-settings / import-settings 命令 |
| `src/components/settings/sections/EtcSection.tsx` | 维护区块添加导入/导出按钮 |
| `src/i18n/locales/zh.ts` | 中文翻译 |
| `src/i18n/locales/en.ts` | 英文翻译 |
| `src/i18n/types.ts` | 翻译类型定义 |
| `src/styles/index.css` | 引入 config-transfer.css |
| `styles.css` | postcss 编译输出 |

## 截图
<img width="725" height="208" alt="Xnip2026-05-12_09-48-36" src="https://github.com/user-attachments/assets/ef831b4b-1078-49ff-94ea-603d6f77774c" />
<img width="556" height="547" alt="Xnip2026-05-12_09-48-49" src="https://github.com/user-attachments/assets/391d94c4-2c6d-4e99-a2a4-1a54c71c8003" />
<img width="562" height="222" alt="Xnip2026-05-12_09-48-59" src="https://github.com/user-attachments/assets/3466a773-28c6-4d5d-b918-48ec0328dc4d" />
<img width="559" height="582" alt="Xnip2026-05-12_09-49-11" src="https://github.com/user-attachments/assets/5fe1eaad-387d-4cd7-9168-78e7775d5053" />


## 测试

- 56 个单元测试覆盖核心逻辑
- TypeScript 编译通过
- ESLint + Prettier 检查通过
- 全量测试套件 150 suites / 1033 tests 通过

Closes #296
