### PR TITLE
多次 LLM 请求显示累计用量，并可展开查看每次请求

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "useTabs": false,
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine": "auto"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,5 @@
   "useTabs": false,
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "all",
-  "endOfLine": "auto"
+  "trailingComma": "all"
 }

--- a/src/components/chat-view/LLMResponseInlineInfo.tsx
+++ b/src/components/chat-view/LLMResponseInlineInfo.tsx
@@ -1,11 +1,12 @@
-import * as Tooltip from '@radix-ui/react-tooltip'
-import { ArrowDown, ArrowUp, Clock, Zap } from 'lucide-react'
+import * as Popover from '@radix-ui/react-popover'
+import { ArrowDown, ArrowUp, ChevronDown, Clock, Zap } from 'lucide-react'
 import { ReactNode, useLayoutEffect, useRef, useState } from 'react'
 
 import { AssistantToolMessageGroup } from '../../types/chat'
 import { ResponseUsage } from '../../types/llm/response'
+import { YoloPopoverContent } from '../common/popover'
 
-import { useLLMResponseInfo } from './useLLMResponseInfo'
+import { LLMResponseInfoEntry, useLLMResponseInfo } from './useLLMResponseInfo'
 
 const formatTokenCount = (value: number) => {
   if (value >= 1000) {
@@ -19,23 +20,6 @@ const formatDuration = (durationMs: number) => {
   return `${seconds.toFixed(1)}s`
 }
 
-/**
- * Progressive compression — each level drops exactly one thing vs the previous
- * level. This keeps the inline bar's visual change smooth as the container
- * narrows, avoiding the "cliff" where many suffixes disappear at once.
- *
- * Order of things dropped, from least to most important:
- *   1. ⚡ "tok/s"    — icon alone conveys "speed"
- *   2. "tokens"     — on both ↑ and ↓, icons + arrow direction are enough
- *   3. "cached"     — the parens + number next to ↑ remain contextual
- *   4. 🕐 duration  — nice-to-have
- *   5. ⚡ speed     — fully derivable from ↓ and 🕐
- *   6. ↓ output     — less info-dense than ↑
- *   7. (cached)     — drop the whole cache breakdown, keep only total input
- *
- * The full detail is always accessible via the hover tooltip, so these drops
- * never actually hide information — they just move it to a secondary surface.
- */
 type LevelConfig = {
   showSpeedUnit: boolean
   showInputUnit: boolean
@@ -49,6 +33,22 @@ type LevelConfig = {
 
 const LEVEL_COUNT = 8
 
+/**
+ * Progressive compression — each level drops exactly one thing vs the previous
+ * level. This keeps the inline bar's visual change smooth as the container
+ * narrows, avoiding the "cliff" where many suffixes disappear at once.
+ *
+ * Order of things dropped, from least to most important:
+ *   1. ⚡ "tok/s"    — icon alone conveys "speed"
+ *   2. "tokens"     — on both ↑ and ↓, icons + arrow direction are enough
+ *   3. "cached"     — the parens + number next to ↑ remain contextual
+ *   4. 🕐 duration  — nice-to-have
+ *   5. ⚡ speed     — fully derivable from ↓ and 🕐
+ *   6. (cached)     — drop the whole cache breakdown, keep only total input
+ *
+ * The full detail is accessible via the expanded popover, so these drops never
+ * actually hide information — they just move it to a secondary surface.
+ */
 const configForLevel = (level: number): LevelConfig => ({
   showSpeedUnit: level < 1,
   showInputUnit: level < 2,
@@ -56,7 +56,7 @@ const configForLevel = (level: number): LevelConfig => ({
   showInputCachedWord: level < 3,
   showTime: level < 4,
   showSpeed: level < 5,
-  showOutput: level < 6,
+  showOutput: true,
   showInputCache: level < 7,
 })
 
@@ -70,6 +70,29 @@ type RenderInputs = {
   durationMs: number | null
   tokensPerSecond: number | null
 }
+
+const getCachedTokens = (usage: ResponseUsage | null) =>
+  usage?.cache_read_input_tokens !== undefined &&
+  usage.cache_read_input_tokens > 0
+    ? usage.cache_read_input_tokens
+    : null
+
+const getCacheCreationTokens = (usage: ResponseUsage | null) =>
+  usage?.cache_creation_input_tokens !== undefined &&
+  usage.cache_creation_input_tokens > 0
+    ? usage.cache_creation_input_tokens
+    : null
+
+const getTokensPerSecond = (
+  usage: ResponseUsage | null,
+  durationMs: number | null,
+) =>
+  usage && durationMs && durationMs > 0
+    ? usage.completion_tokens / (durationMs / 1000)
+    : null
+
+const formatDetailTokenCount = (value: number) =>
+  `${formatTokenCount(value)} tokens`
 
 function renderItems(
   { usage, cachedTokens, durationMs, tokensPerSecond }: RenderInputs,
@@ -131,74 +154,111 @@ function renderItems(
   )
 }
 
-function renderTooltipDetails({
-  usage,
-  cachedTokens,
-  durationMs,
-  tokensPerSecond,
-}: RenderInputs): ReactNode {
-  const cacheCreation =
-    usage?.cache_creation_input_tokens !== undefined &&
-    usage.cache_creation_input_tokens > 0
-      ? usage.cache_creation_input_tokens
-      : null
+function getRequestInputs(request: LLMResponseInfoEntry): RenderInputs {
+  return {
+    usage: request.usage,
+    cachedTokens: getCachedTokens(request.usage),
+    durationMs: request.durationMs,
+    tokensPerSecond: getTokensPerSecond(request.usage, request.durationMs),
+  }
+}
+
+function UsageDetailItem({
+  icon,
+  ariaLabel,
+  value,
+}: {
+  icon: ReactNode
+  ariaLabel: string
+  value: string
+}) {
+  return (
+    <span
+      className="yolo-llm-inline-info-item yolo-llm-inline-info-detail-item"
+      aria-label={ariaLabel}
+    >
+      {icon}
+      <span>{value}</span>
+    </span>
+  )
+}
+
+function UsageDetailRow({
+  indexLabel,
+  inputs,
+  isTotal = false,
+}: {
+  indexLabel: string
+  inputs: RenderInputs
+  isTotal?: boolean
+}) {
+  const usage = inputs.usage
+  if (!usage) {
+    return null
+  }
 
   const cacheRatio =
-    usage && cachedTokens !== null && usage.prompt_tokens > 0
-      ? cachedTokens / usage.prompt_tokens
+    inputs.cachedTokens !== null && usage.prompt_tokens > 0
+      ? inputs.cachedTokens / usage.prompt_tokens
       : null
+  const cacheCreation = getCacheCreationTokens(usage)
+  const inputDetails: string[] = [formatDetailTokenCount(usage.prompt_tokens)]
+
+  if (inputs.cachedTokens !== null && cacheRatio !== null) {
+    inputDetails.push(
+      `(${inputs.cachedTokens.toLocaleString()} cached / ${(
+        cacheRatio * 100
+      ).toFixed(1)}%)`,
+    )
+  }
+
+  if (cacheCreation !== null) {
+    inputDetails.push(`(${cacheCreation.toLocaleString()} written)`)
+  }
 
   return (
-    <div className="yolo-llm-inline-info-tooltip">
-      {usage && (
-        <>
-          <div className="yolo-llm-inline-info-tooltip-row">
-            <ArrowUp className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--input" />
-            <span className="yolo-llm-inline-info-tooltip-label">Input</span>
-            <span className="yolo-llm-inline-info-tooltip-value">
-              {usage.prompt_tokens.toLocaleString()} tokens
-            </span>
-          </div>
-          {cachedTokens !== null && cacheRatio !== null && (
-            <div className="yolo-llm-inline-info-tooltip-sub">
-              <span>
-                {cachedTokens.toLocaleString()} cached ·{' '}
-                {(cacheRatio * 100).toFixed(1)}% hit
-              </span>
-            </div>
-          )}
-          {cacheCreation !== null && (
-            <div className="yolo-llm-inline-info-tooltip-sub">
-              <span>{cacheCreation.toLocaleString()} cache written</span>
-            </div>
-          )}
-          <div className="yolo-llm-inline-info-tooltip-row">
-            <ArrowDown className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--output" />
-            <span className="yolo-llm-inline-info-tooltip-label">Output</span>
-            <span className="yolo-llm-inline-info-tooltip-value">
-              {usage.completion_tokens.toLocaleString()} tokens
-            </span>
-          </div>
-        </>
-      )}
-      {tokensPerSecond !== null && (
-        <div className="yolo-llm-inline-info-tooltip-row">
+    <div
+      className={`yolo-llm-inline-info-detail-row${
+        isTotal ? ' yolo-llm-inline-info-detail-row--total' : ''
+      }`}
+    >
+      <div className="yolo-llm-inline-info-detail-index">
+        <span>{indexLabel}</span>
+      </div>
+      <UsageDetailItem
+        icon={
+          <ArrowUp className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--input" />
+        }
+        ariaLabel="Input tokens"
+        value={inputDetails.join(' ')}
+      />
+      <UsageDetailItem
+        icon={
+          <ArrowDown className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--output" />
+        }
+        ariaLabel="Output tokens"
+        value={formatDetailTokenCount(usage.completion_tokens)}
+      />
+      <UsageDetailItem
+        icon={
           <Zap className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--speed" />
-          <span className="yolo-llm-inline-info-tooltip-label">Speed</span>
-          <span className="yolo-llm-inline-info-tooltip-value">
-            {tokensPerSecond.toFixed(1)} tok/s
-          </span>
-        </div>
-      )}
-      {durationMs !== null && (
-        <div className="yolo-llm-inline-info-tooltip-row">
+        }
+        ariaLabel="Speed"
+        value={
+          inputs.tokensPerSecond !== null
+            ? `${inputs.tokensPerSecond.toFixed(1)} tok/s`
+            : '-'
+        }
+      />
+      <UsageDetailItem
+        icon={
           <Clock className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--time" />
-          <span className="yolo-llm-inline-info-tooltip-label">Duration</span>
-          <span className="yolo-llm-inline-info-tooltip-value">
-            {formatDuration(durationMs)}
-          </span>
-        </div>
-      )}
+        }
+        ariaLabel="Duration"
+        value={
+          inputs.durationMs !== null ? formatDuration(inputs.durationMs) : '-'
+        }
+      />
     </div>
   )
 }
@@ -208,15 +268,14 @@ export default function LLMResponseInlineInfo({
 }: {
   messages: AssistantToolMessageGroup
 }) {
-  const { usage, durationMs } = useLLMResponseInfo(messages)
-  const tokensPerSecond =
-    usage && durationMs && durationMs > 0
-      ? usage.completion_tokens / (durationMs / 1000)
-      : null
+  const { requests, usage, durationMs } = useLLMResponseInfo(messages)
+  const tokensPerSecond = getTokensPerSecond(usage, durationMs)
 
+  const triggerRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const ghostRefs = useRef<Array<HTMLDivElement | null>>([])
   const [levelIndex, setLevelIndex] = useState(0)
+  const [isExpanded, setIsExpanded] = useState(false)
 
   useLayoutEffect(() => {
     const container = containerRef.current
@@ -245,57 +304,87 @@ export default function LLMResponseInlineInfo({
     return () => observer.disconnect()
   }, [usage, durationMs])
 
-  if (!usage && durationMs === null) {
+  if (!usage && durationMs === null && requests.length === 0) {
     return null
   }
 
-  const cachedTokens =
-    usage?.cache_read_input_tokens !== undefined &&
-    usage.cache_read_input_tokens > 0
-      ? usage.cache_read_input_tokens
-      : null
-
   const inputs: RenderInputs = {
     usage,
-    cachedTokens,
+    cachedTokens: getCachedTokens(usage),
     durationMs,
     tokensPerSecond,
   }
 
   return (
-    <Tooltip.Provider delayDuration={300} skipDelayDuration={100}>
-      <Tooltip.Root>
-        <Tooltip.Trigger asChild>
-          <div className="yolo-llm-inline-info">
-            <div className="yolo-llm-inline-info-content" ref={containerRef}>
-              {renderItems(inputs, LEVELS[levelIndex])}
-            </div>
-            <div className="yolo-llm-inline-info-ghosts" aria-hidden="true">
-              {LEVELS.map((config, i) => (
-                <div
-                  key={i}
-                  ref={(node) => {
-                    ghostRefs.current[i] = node
-                  }}
-                  className="yolo-llm-inline-info-content yolo-llm-inline-info-ghost"
-                >
-                  {renderItems(inputs, config)}
-                </div>
-              ))}
-            </div>
+    <Popover.Root open={isExpanded} onOpenChange={setIsExpanded}>
+      <Popover.Trigger asChild>
+        <div
+          className="yolo-llm-inline-info"
+          ref={triggerRef}
+          role="button"
+          tabIndex={0}
+          aria-expanded={isExpanded}
+          aria-label="Show request usage details"
+        >
+          <div className="yolo-llm-inline-info-content" ref={containerRef}>
+            {renderItems(inputs, LEVELS[levelIndex])}
           </div>
-        </Tooltip.Trigger>
-        <Tooltip.Portal>
-          <Tooltip.Content
-            className="yolo-tooltip-content yolo-llm-inline-info-tooltip-content"
-            side="top"
-            sideOffset={6}
-            align="start"
-          >
-            {renderTooltipDetails(inputs)}
-          </Tooltip.Content>
-        </Tooltip.Portal>
-      </Tooltip.Root>
-    </Tooltip.Provider>
+          <ChevronDown
+            className={`yolo-llm-inline-info-chevron${
+              isExpanded ? ' is-expanded' : ''
+            }`}
+            aria-hidden="true"
+          />
+          <div className="yolo-llm-inline-info-ghosts" aria-hidden="true">
+            {LEVELS.map((config, i) => (
+              <div
+                key={i}
+                ref={(node) => {
+                  ghostRefs.current[i] = node
+                }}
+                className="yolo-llm-inline-info-content yolo-llm-inline-info-ghost"
+              >
+                {renderItems(inputs, config)}
+              </div>
+            ))}
+          </div>
+        </div>
+      </Popover.Trigger>
+      <YoloPopoverContent
+        anchorRef={triggerRef}
+        variant="default"
+        maxWidth="min(680px, calc(100vw - 48px))"
+        maxHeight="min(70vh, 520px)"
+        className="yolo-llm-usage-popover"
+        side="top"
+        sideOffset={6}
+        align="start"
+        collisionPadding={8}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+        }}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault()
+          triggerRef.current?.focus({ preventScroll: true })
+        }}
+      >
+        <div
+          className="yolo-llm-inline-info-panel"
+          role="dialog"
+          aria-label="Request usage details"
+        >
+          <div className="yolo-llm-inline-info-detail-list">
+            {requests.map((request) => (
+              <UsageDetailRow
+                key={request.messageId}
+                indexLabel={String(request.requestNumber)}
+                inputs={getRequestInputs(request)}
+              />
+            ))}
+            <UsageDetailRow indexLabel={'\u03A3'} inputs={inputs} isTotal />
+          </div>
+        </div>
+      </YoloPopoverContent>
+    </Popover.Root>
   )
 }

--- a/src/components/chat-view/LLMResponseInlineInfo.tsx
+++ b/src/components/chat-view/LLMResponseInlineInfo.tsx
@@ -1,12 +1,11 @@
-import * as Popover from '@radix-ui/react-popover'
-import { ArrowDown, ArrowUp, ChevronDown, Clock, Zap } from 'lucide-react'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import { ArrowDown, ArrowUp, Clock, Zap } from 'lucide-react'
 import { ReactNode, useLayoutEffect, useRef, useState } from 'react'
 
 import { AssistantToolMessageGroup } from '../../types/chat'
 import { ResponseUsage } from '../../types/llm/response'
-import { YoloPopoverContent } from '../common/popover'
 
-import { LLMResponseInfoEntry, useLLMResponseInfo } from './useLLMResponseInfo'
+import { useLLMResponseInfo } from './useLLMResponseInfo'
 
 const formatTokenCount = (value: number) => {
   if (value >= 1000) {
@@ -19,19 +18,6 @@ const formatDuration = (durationMs: number) => {
   const seconds = durationMs / 1000
   return `${seconds.toFixed(1)}s`
 }
-
-type LevelConfig = {
-  showSpeedUnit: boolean
-  showInputUnit: boolean
-  showOutputUnit: boolean
-  showInputCachedWord: boolean
-  showTime: boolean
-  showSpeed: boolean
-  showOutput: boolean
-  showInputCache: boolean
-}
-
-const LEVEL_COUNT = 8
 
 /**
  * Progressive compression — each level drops exactly one thing vs the previous
@@ -46,9 +32,21 @@ const LEVEL_COUNT = 8
  *   5. ⚡ speed     — fully derivable from ↓ and 🕐
  *   6. (cached)     — drop the whole cache breakdown, keep only total input
  *
- * The full detail is accessible via the expanded popover, so these drops never
- * actually hide information — they just move it to a secondary surface.
+ * The full detail is always accessible via the hover tooltip, so these drops
+ * never actually hide information — they just move it to a secondary surface.
  */
+type LevelConfig = {
+  showSpeedUnit: boolean
+  showInputUnit: boolean
+  showOutputUnit: boolean
+  showInputCachedWord: boolean
+  showTime: boolean
+  showSpeed: boolean
+  showInputCache: boolean
+}
+
+const LEVEL_COUNT = 7
+
 const configForLevel = (level: number): LevelConfig => ({
   showSpeedUnit: level < 1,
   showInputUnit: level < 2,
@@ -56,8 +54,7 @@ const configForLevel = (level: number): LevelConfig => ({
   showInputCachedWord: level < 3,
   showTime: level < 4,
   showSpeed: level < 5,
-  showOutput: true,
-  showInputCache: level < 7,
+  showInputCache: level < 6,
 })
 
 const LEVELS: LevelConfig[] = Array.from({ length: LEVEL_COUNT }, (_, i) =>
@@ -67,6 +64,7 @@ const LEVELS: LevelConfig[] = Array.from({ length: LEVEL_COUNT }, (_, i) =>
 type RenderInputs = {
   usage: ResponseUsage | null
   cachedTokens: number | null
+  cacheCreationTokens: number | null
   durationMs: number | null
   tokensPerSecond: number | null
 }
@@ -91,8 +89,16 @@ const getTokensPerSecond = (
     ? usage.completion_tokens / (durationMs / 1000)
     : null
 
-const formatDetailTokenCount = (value: number) =>
-  `${formatTokenCount(value)} tokens`
+const buildInputs = (
+  usage: ResponseUsage | null,
+  durationMs: number | null,
+): RenderInputs => ({
+  usage,
+  cachedTokens: getCachedTokens(usage),
+  cacheCreationTokens: getCacheCreationTokens(usage),
+  durationMs,
+  tokensPerSecond: getTokensPerSecond(usage, durationMs),
+})
 
 function renderItems(
   { usage, cachedTokens, durationMs, tokensPerSecond }: RenderInputs,
@@ -103,7 +109,6 @@ function renderItems(
     showInputCachedWord,
     showTime,
     showSpeed,
-    showOutput,
     showInputCache,
   }: LevelConfig,
 ): ReactNode {
@@ -126,7 +131,7 @@ function renderItems(
           </span>
         </span>
       )}
-      {showOutput && usage && (
+      {usage && (
         <span className="yolo-llm-inline-info-item yolo-llm-inline-info-item--output">
           <ArrowDown className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--output" />
           <span>
@@ -154,111 +159,80 @@ function renderItems(
   )
 }
 
-function getRequestInputs(request: LLMResponseInfoEntry): RenderInputs {
-  return {
-    usage: request.usage,
-    cachedTokens: getCachedTokens(request.usage),
-    durationMs: request.durationMs,
-    tokensPerSecond: getTokensPerSecond(request.usage, request.durationMs),
-  }
+type TooltipBlockOptions = {
+  title?: string
+  showSpeed?: boolean
 }
 
-function UsageDetailItem({
-  icon,
-  ariaLabel,
-  value,
-}: {
-  icon: ReactNode
-  ariaLabel: string
-  value: string
-}) {
-  return (
-    <span
-      className="yolo-llm-inline-info-item yolo-llm-inline-info-detail-item"
-      aria-label={ariaLabel}
-    >
-      {icon}
-      <span>{value}</span>
-    </span>
-  )
-}
-
-function UsageDetailRow({
-  indexLabel,
-  inputs,
-  isTotal = false,
-}: {
-  indexLabel: string
-  inputs: RenderInputs
-  isTotal?: boolean
-}) {
-  const usage = inputs.usage
-  if (!usage) {
-    return null
-  }
-
+function renderTooltipBlock(
+  {
+    usage,
+    cachedTokens,
+    cacheCreationTokens,
+    durationMs,
+    tokensPerSecond,
+  }: RenderInputs,
+  { title, showSpeed = true }: TooltipBlockOptions = {},
+): ReactNode {
   const cacheRatio =
-    inputs.cachedTokens !== null && usage.prompt_tokens > 0
-      ? inputs.cachedTokens / usage.prompt_tokens
+    usage && cachedTokens !== null && usage.prompt_tokens > 0
+      ? cachedTokens / usage.prompt_tokens
       : null
-  const cacheCreation = getCacheCreationTokens(usage)
-  const inputDetails: string[] = [formatDetailTokenCount(usage.prompt_tokens)]
-
-  if (inputs.cachedTokens !== null && cacheRatio !== null) {
-    inputDetails.push(
-      `(${inputs.cachedTokens.toLocaleString()} cached / ${(
-        cacheRatio * 100
-      ).toFixed(1)}%)`,
-    )
-  }
-
-  if (cacheCreation !== null) {
-    inputDetails.push(`(${cacheCreation.toLocaleString()} written)`)
-  }
 
   return (
-    <div
-      className={`yolo-llm-inline-info-detail-row${
-        isTotal ? ' yolo-llm-inline-info-detail-row--total' : ''
-      }`}
-    >
-      <div className="yolo-llm-inline-info-detail-index">
-        <span>{indexLabel}</span>
-      </div>
-      <UsageDetailItem
-        icon={
-          <ArrowUp className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--input" />
-        }
-        ariaLabel="Input tokens"
-        value={inputDetails.join(' ')}
-      />
-      <UsageDetailItem
-        icon={
-          <ArrowDown className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--output" />
-        }
-        ariaLabel="Output tokens"
-        value={formatDetailTokenCount(usage.completion_tokens)}
-      />
-      <UsageDetailItem
-        icon={
+    <div className="yolo-llm-inline-info-tooltip-block">
+      {title && (
+        <div className="yolo-llm-inline-info-tooltip-title">{title}</div>
+      )}
+      {usage && (
+        <>
+          <div className="yolo-llm-inline-info-tooltip-row">
+            <ArrowUp className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--input" />
+            <span className="yolo-llm-inline-info-tooltip-label">Input</span>
+            <span className="yolo-llm-inline-info-tooltip-value">
+              {usage.prompt_tokens.toLocaleString()} tokens
+            </span>
+          </div>
+          {cachedTokens !== null && cacheRatio !== null && (
+            <div className="yolo-llm-inline-info-tooltip-sub">
+              <span>
+                {cachedTokens.toLocaleString()} cached ·{' '}
+                {(cacheRatio * 100).toFixed(1)}% hit
+              </span>
+            </div>
+          )}
+          {cacheCreationTokens !== null && (
+            <div className="yolo-llm-inline-info-tooltip-sub">
+              <span>{cacheCreationTokens.toLocaleString()} cache written</span>
+            </div>
+          )}
+          <div className="yolo-llm-inline-info-tooltip-row">
+            <ArrowDown className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--output" />
+            <span className="yolo-llm-inline-info-tooltip-label">Output</span>
+            <span className="yolo-llm-inline-info-tooltip-value">
+              {usage.completion_tokens.toLocaleString()} tokens
+            </span>
+          </div>
+        </>
+      )}
+      {showSpeed && tokensPerSecond !== null && (
+        <div className="yolo-llm-inline-info-tooltip-row">
           <Zap className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--speed" />
-        }
-        ariaLabel="Speed"
-        value={
-          inputs.tokensPerSecond !== null
-            ? `${inputs.tokensPerSecond.toFixed(1)} tok/s`
-            : '-'
-        }
-      />
-      <UsageDetailItem
-        icon={
+          <span className="yolo-llm-inline-info-tooltip-label">Speed</span>
+          <span className="yolo-llm-inline-info-tooltip-value">
+            {tokensPerSecond.toFixed(1)} tok/s
+          </span>
+        </div>
+      )}
+      {durationMs !== null && (
+        <div className="yolo-llm-inline-info-tooltip-row">
           <Clock className="yolo-llm-inline-info-icon yolo-llm-inline-info-icon--time" />
-        }
-        ariaLabel="Duration"
-        value={
-          inputs.durationMs !== null ? formatDuration(inputs.durationMs) : '-'
-        }
-      />
+          <span className="yolo-llm-inline-info-tooltip-label">Duration</span>
+          <span className="yolo-llm-inline-info-tooltip-value">
+            {formatDuration(durationMs)}
+          </span>
+        </div>
+      )}
     </div>
   )
 }
@@ -268,14 +242,12 @@ export default function LLMResponseInlineInfo({
 }: {
   messages: AssistantToolMessageGroup
 }) {
-  const { requests, usage, durationMs } = useLLMResponseInfo(messages)
-  const tokensPerSecond = getTokensPerSecond(usage, durationMs)
+  const { usage, durationMs, totalUsage, totalDurationMs, requestCount } =
+    useLLMResponseInfo(messages)
 
-  const triggerRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const ghostRefs = useRef<Array<HTMLDivElement | null>>([])
   const [levelIndex, setLevelIndex] = useState(0)
-  const [isExpanded, setIsExpanded] = useState(false)
 
   useLayoutEffect(() => {
     const container = containerRef.current
@@ -304,87 +276,65 @@ export default function LLMResponseInlineInfo({
     return () => observer.disconnect()
   }, [usage, durationMs])
 
-  if (!usage && durationMs === null && requests.length === 0) {
+  if (!usage && durationMs === null) {
     return null
   }
 
-  const inputs: RenderInputs = {
-    usage,
-    cachedTokens: getCachedTokens(usage),
-    durationMs,
-    tokensPerSecond,
-  }
+  const lastInputs = buildInputs(usage, durationMs)
+  const totalInputs =
+    totalUsage || totalDurationMs !== null
+      ? buildInputs(totalUsage, totalDurationMs)
+      : null
+  const hasMultipleRequests = requestCount >= 2 && totalInputs !== null
 
   return (
-    <Popover.Root open={isExpanded} onOpenChange={setIsExpanded}>
-      <Popover.Trigger asChild>
-        <div
-          className="yolo-llm-inline-info"
-          ref={triggerRef}
-          role="button"
-          tabIndex={0}
-          aria-expanded={isExpanded}
-          aria-label="Show request usage details"
-        >
-          <div className="yolo-llm-inline-info-content" ref={containerRef}>
-            {renderItems(inputs, LEVELS[levelIndex])}
+    <Tooltip.Provider delayDuration={300} skipDelayDuration={100}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <div className="yolo-llm-inline-info">
+            <div className="yolo-llm-inline-info-content" ref={containerRef}>
+              {renderItems(lastInputs, LEVELS[levelIndex])}
+            </div>
+            <div className="yolo-llm-inline-info-ghosts" aria-hidden="true">
+              {LEVELS.map((config, i) => (
+                <div
+                  key={i}
+                  ref={(node) => {
+                    ghostRefs.current[i] = node
+                  }}
+                  className="yolo-llm-inline-info-content yolo-llm-inline-info-ghost"
+                >
+                  {renderItems(lastInputs, config)}
+                </div>
+              ))}
+            </div>
           </div>
-          <ChevronDown
-            className={`yolo-llm-inline-info-chevron${
-              isExpanded ? ' is-expanded' : ''
-            }`}
-            aria-hidden="true"
-          />
-          <div className="yolo-llm-inline-info-ghosts" aria-hidden="true">
-            {LEVELS.map((config, i) => (
-              <div
-                key={i}
-                ref={(node) => {
-                  ghostRefs.current[i] = node
-                }}
-                className="yolo-llm-inline-info-content yolo-llm-inline-info-ghost"
-              >
-                {renderItems(inputs, config)}
-              </div>
-            ))}
-          </div>
-        </div>
-      </Popover.Trigger>
-      <YoloPopoverContent
-        anchorRef={triggerRef}
-        variant="default"
-        maxWidth="min(680px, calc(100vw - 48px))"
-        maxHeight="min(70vh, 520px)"
-        className="yolo-llm-usage-popover"
-        side="top"
-        sideOffset={6}
-        align="start"
-        collisionPadding={8}
-        onOpenAutoFocus={(event) => {
-          event.preventDefault()
-        }}
-        onCloseAutoFocus={(event) => {
-          event.preventDefault()
-          triggerRef.current?.focus({ preventScroll: true })
-        }}
-      >
-        <div
-          className="yolo-llm-inline-info-panel"
-          role="dialog"
-          aria-label="Request usage details"
-        >
-          <div className="yolo-llm-inline-info-detail-list">
-            {requests.map((request) => (
-              <UsageDetailRow
-                key={request.messageId}
-                indexLabel={String(request.requestNumber)}
-                inputs={getRequestInputs(request)}
-              />
-            ))}
-            <UsageDetailRow indexLabel={'\u03A3'} inputs={inputs} isTotal />
-          </div>
-        </div>
-      </YoloPopoverContent>
-    </Popover.Root>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            className="yolo-tooltip-content yolo-llm-inline-info-tooltip-content"
+            side="top"
+            sideOffset={6}
+            align="start"
+          >
+            <div className="yolo-llm-inline-info-tooltip">
+              {renderTooltipBlock(
+                lastInputs,
+                hasMultipleRequests ? { title: 'Last call' } : undefined,
+              )}
+              {hasMultipleRequests && totalInputs && (
+                <>
+                  <div className="yolo-llm-inline-info-tooltip-divider" />
+                  {renderTooltipBlock(totalInputs, {
+                    title: `Total (${requestCount} calls)`,
+                    showSpeed: false,
+                  })}
+                </>
+              )}
+            </div>
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
   )
 }

--- a/src/components/chat-view/useLLMResponseInfo.test.ts
+++ b/src/components/chat-view/useLLMResponseInfo.test.ts
@@ -60,30 +60,167 @@ const toolMessage: ChatToolMessage = {
 }
 
 describe('collectLLMResponseInfo', () => {
-  it('sums usage across all assistant requests in a tool-calling group', () => {
+  it('single request: top-level = that request, no total', () => {
+    const info = collectLLMResponseInfo([
+      makeAssistant('assistant-1', 100, 20, 1000, {
+        cache_read_input_tokens: 10,
+      }),
+    ])
+
+    expect(info.requestCount).toBe(1)
+    expect(info.usage).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      total_tokens: 120,
+      cache_read_input_tokens: 10,
+    })
+    expect(info.durationMs).toBe(1000)
+    expect(info.totalUsage).toBeNull()
+    expect(info.totalDurationMs).toBeNull()
+    expect(info.totalCost).toBeNull()
+  })
+
+  it('multi request: top-level = last call, total = sum across calls', () => {
     const info = collectLLMResponseInfo([
       makeAssistant('assistant-1', 100, 20, 1000, {
         cache_read_input_tokens: 10,
       }),
       toolMessage,
       makeAssistant('assistant-2', 200, 30, 1500, {
+        cache_read_input_tokens: 150,
         cache_creation_input_tokens: 15,
       }),
     ])
 
-    expect(info.requests).toHaveLength(2)
-    expect(info.requests.map((request) => request.messageId)).toEqual([
-      'assistant-1',
-      'assistant-2',
-    ])
+    expect(info.requestCount).toBe(2)
+
+    // Top-level reflects only the last call (what the user sees as "this turn").
     expect(info.usage).toEqual({
+      prompt_tokens: 200,
+      completion_tokens: 30,
+      total_tokens: 230,
+      cache_read_input_tokens: 150,
+      cache_creation_input_tokens: 15,
+    })
+    expect(info.durationMs).toBe(1500)
+
+    // Aggregates expose the full picture for the multi-call surface.
+    expect(info.totalUsage).toEqual({
       prompt_tokens: 300,
       completion_tokens: 50,
       total_tokens: 350,
-      cache_read_input_tokens: 10,
+      cache_read_input_tokens: 160,
       cache_creation_input_tokens: 15,
     })
-    expect(info.durationMs).toBe(2500)
-    expect(info.cost).toBe(0)
+    expect(info.totalDurationMs).toBe(2500)
+    expect(info.totalCost).toBe(0)
+  })
+
+  it('duration-only assistant trailing after a usage call is ignored', () => {
+    // Old code paired the usage from call 1 with the durationMs from the
+    // trailing duration-only assistant, producing a bogus tok/s. Top-level
+    // must bind usage+duration to the same call entry.
+    const durationOnly: ChatAssistantMessage = {
+      role: 'assistant',
+      id: 'assistant-2',
+      content: '',
+      metadata: { model, durationMs: 9999 },
+    }
+    const info = collectLLMResponseInfo([
+      makeAssistant('assistant-1', 100, 20, 1000),
+      durationOnly,
+    ])
+
+    expect(info.requestCount).toBe(1)
+    expect(info.usage?.prompt_tokens).toBe(100)
+    expect(info.durationMs).toBe(1000) // bound to the same call as `usage`
+    expect(info.totalUsage).toBeNull()
+    expect(info.totalDurationMs).toBeNull()
+  })
+
+  it('any counted call missing duration → totalDurationMs is null', () => {
+    const missingDuration: ChatAssistantMessage = {
+      role: 'assistant',
+      id: 'assistant-2',
+      content: '',
+      metadata: {
+        model,
+        // no durationMs
+        usage: {
+          prompt_tokens: 50,
+          completion_tokens: 10,
+          total_tokens: 60,
+        },
+      },
+    }
+    const info = collectLLMResponseInfo([
+      makeAssistant('assistant-1', 100, 20, 1000),
+      missingDuration,
+    ])
+
+    expect(info.requestCount).toBe(2)
+    expect(info.totalUsage).not.toBeNull()
+    expect(info.totalDurationMs).toBeNull()
+    expect(info.durationMs).toBeNull() // last call had no duration
+  })
+
+  it('any counted call missing model → totalCost is null', () => {
+    const noModel: ChatAssistantMessage = {
+      role: 'assistant',
+      id: 'assistant-2',
+      content: '',
+      metadata: {
+        durationMs: 500,
+        usage: {
+          prompt_tokens: 50,
+          completion_tokens: 10,
+          total_tokens: 60,
+        },
+      },
+    }
+    const info = collectLLMResponseInfo([
+      makeAssistant('assistant-1', 100, 20, 1000),
+      noModel,
+    ])
+
+    expect(info.requestCount).toBe(2)
+    expect(info.totalCost).toBeNull()
+  })
+
+  it('summed total_tokens is recomputed from prompt+completion', () => {
+    // Mismatched upstream total_tokens (e.g. anthropic cache quirks) must
+    // not leak into the displayed total.
+    const info = collectLLMResponseInfo([
+      {
+        role: 'assistant',
+        id: 'assistant-1',
+        content: '',
+        metadata: {
+          model,
+          durationMs: 100,
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+            total_tokens: 999, // garbage from upstream
+          },
+        },
+      },
+      {
+        role: 'assistant',
+        id: 'assistant-2',
+        content: '',
+        metadata: {
+          model,
+          durationMs: 100,
+          usage: {
+            prompt_tokens: 200,
+            completion_tokens: 30,
+            total_tokens: 111, // garbage from upstream
+          },
+        },
+      },
+    ])
+
+    expect(info.totalUsage?.total_tokens).toBe(350) // 300 + 50, not 999+111
   })
 })

--- a/src/components/chat-view/useLLMResponseInfo.test.ts
+++ b/src/components/chat-view/useLLMResponseInfo.test.ts
@@ -1,0 +1,89 @@
+import type { ChatAssistantMessage, ChatToolMessage } from '../../types/chat'
+import type { ChatModel } from '../../types/chat-model.types'
+import type { ResponseUsage } from '../../types/llm/response'
+import { ToolCallResponseStatus } from '../../types/tool-call.types'
+
+import { collectLLMResponseInfo } from './useLLMResponseInfo'
+
+const model: ChatModel = {
+  id: 'model-1',
+  providerId: 'chatgpt-oauth/default',
+  model: 'gpt-test',
+  name: 'GPT Test',
+}
+
+const makeAssistant = (
+  id: string,
+  promptTokens: number,
+  completionTokens: number,
+  durationMs: number,
+  extraUsage: Partial<ResponseUsage> = {},
+): ChatAssistantMessage => ({
+  role: 'assistant',
+  id,
+  content: '',
+  metadata: {
+    model,
+    durationMs,
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+      ...extraUsage,
+    },
+  },
+})
+
+const toolMessage: ChatToolMessage = {
+  role: 'tool',
+  id: 'tool-1',
+  toolCalls: [
+    {
+      request: {
+        id: 'tool-call-1',
+        name: 'tool',
+        arguments: {
+          kind: 'complete',
+          value: {},
+          rawText: '{}',
+        },
+      },
+      response: {
+        status: ToolCallResponseStatus.Success,
+        data: {
+          type: 'text',
+          text: 'ok',
+        },
+      },
+    },
+  ],
+}
+
+describe('collectLLMResponseInfo', () => {
+  it('sums usage across all assistant requests in a tool-calling group', () => {
+    const info = collectLLMResponseInfo([
+      makeAssistant('assistant-1', 100, 20, 1000, {
+        cache_read_input_tokens: 10,
+      }),
+      toolMessage,
+      makeAssistant('assistant-2', 200, 30, 1500, {
+        cache_creation_input_tokens: 15,
+      }),
+    ])
+
+    expect(info.requests).toHaveLength(2)
+    expect(info.requests.map((request) => request.messageId)).toEqual([
+      'assistant-1',
+      'assistant-2',
+    ])
+    expect(info.usage).toEqual({
+      prompt_tokens: 300,
+      completion_tokens: 50,
+      total_tokens: 350,
+      cache_read_input_tokens: 10,
+      cache_creation_input_tokens: 15,
+    })
+    expect(info.durationMs).toBe(2500)
+    expect(info.cost).toBe(0)
+  })
+})

--- a/src/components/chat-view/useLLMResponseInfo.ts
+++ b/src/components/chat-view/useLLMResponseInfo.ts
@@ -1,28 +1,29 @@
 import { useMemo } from 'react'
 
-import {
-  AssistantToolMessageGroup,
-  ChatAssistantMessage,
-} from '../../types/chat'
+import { AssistantToolMessageGroup } from '../../types/chat'
 import { ChatModel } from '../../types/chat-model.types'
 import { ResponseUsage } from '../../types/llm/response'
 import { calculateLLMCost } from '../../utils/llm/price-calculator'
 
-export type LLMResponseInfoEntry = {
-  messageId: string
-  requestNumber: number
-  usage: ResponseUsage | null
-  model: ChatModel | undefined
-  cost: number | null
-  durationMs: number | null
-}
-
 export type LLMResponseInfo = {
-  requests: LLMResponseInfoEntry[]
+  // Last-call semantics — what the user-visible final round-trip cost was.
+  // The inline bar always renders these values; tooltip's "current" block too.
+  // usage/durationMs/model/cost are all bound to the same last-with-usage call,
+  // so derived values like tok/s in the UI stay consistent.
   usage: ResponseUsage | null
   model: ChatModel | undefined
   cost: number | null
   durationMs: number | null
+
+  // Aggregate across every billable (usage-bearing) call in this group.
+  // Populated only when there are >= 2 such calls; otherwise null.
+  // Any field is null if it can't be computed cleanly (missing duration on
+  // any counted call, unknown cost on any counted call, etc.) — better than
+  // silently displaying a number that under-counts.
+  totalUsage: ResponseUsage | null
+  totalDurationMs: number | null
+  totalCost: number | null
+  requestCount: number
 }
 
 const addOptionalUsageTokenCount = (
@@ -53,7 +54,6 @@ const sumUsages = (usages: ResponseUsage[]): ResponseUsage | null => {
   for (const usage of usages) {
     total.prompt_tokens += usage.prompt_tokens
     total.completion_tokens += usage.completion_tokens
-    total.total_tokens += usage.total_tokens
     addOptionalUsageTokenCount(
       total,
       'cache_read_input_tokens',
@@ -66,94 +66,109 @@ const sumUsages = (usages: ResponseUsage[]): ResponseUsage | null => {
     )
   }
 
+  // Derive total_tokens from the summed components — upstream providers'
+  // total_tokens semantics around cache aren't always consistent.
+  total.total_tokens = total.prompt_tokens + total.completion_tokens
+
   return total
+}
+
+type CallEntry = {
+  usage: ResponseUsage
+  durationMs: number | null
+  model: ChatModel | undefined
+  cost: number | null
 }
 
 export function collectLLMResponseInfo(
   messages: AssistantToolMessageGroup,
 ): LLMResponseInfo {
-  const requests: LLMResponseInfoEntry[] = []
-  let latestAssistantMessage: ChatAssistantMessage | undefined
-  let latestAssistantWithUsage: ChatAssistantMessage | undefined
-  let totalDurationMs = 0
-  let hasDuration = false
+  const calls: CallEntry[] = []
+  let fallbackModel: ChatModel | undefined
 
   for (const message of messages) {
     if (message.role !== 'assistant') {
       continue
     }
 
-    latestAssistantMessage = message
-
-    if (message.metadata?.usage) {
-      latestAssistantWithUsage = message
+    const model = message.metadata?.model
+    if (model) {
+      fallbackModel = model
     }
 
-    const usage = message.metadata?.usage ?? null
+    const usage = message.metadata?.usage
+    if (!usage) {
+      continue
+    }
+
     const durationMs =
       typeof message.metadata?.durationMs === 'number'
         ? message.metadata.durationMs
         : null
 
-    if (durationMs !== null) {
-      totalDurationMs += durationMs
-      hasDuration = true
-    }
-
-    if (!usage && durationMs === null) {
-      continue
-    }
-
-    const model = message.metadata?.model
-    requests.push({
-      messageId: message.id,
-      requestNumber: requests.length + 1,
+    calls.push({
       usage,
-      model,
-      cost:
-        usage && model
-          ? calculateLLMCost({
-              model,
-              usage,
-            })
-          : null,
       durationMs,
+      model,
+      cost: model ? calculateLLMCost({ model, usage }) : null,
     })
   }
 
-  const usage = sumUsages(
-    requests
-      .map((request) => request.usage)
-      .filter((requestUsage): requestUsage is ResponseUsage =>
-        Boolean(requestUsage),
-      ),
-  )
+  const lastCall = calls.length > 0 ? calls[calls.length - 1] : null
 
-  const model =
-    latestAssistantWithUsage?.metadata?.model ??
-    latestAssistantMessage?.metadata?.model
+  // Top-level reflects the last billable call only — usage/duration/model are
+  // pulled from the same entry, so the inline bar's tok/s stays coherent.
+  const usage = lastCall?.usage ?? null
+  const durationMs = lastCall?.durationMs ?? null
+  // When a billable call exists, model is bound to that same entry — even if
+  // that entry's model is undefined. Only fall back when there were no
+  // billable calls at all (e.g. an in-flight stream that hasn't reported
+  // usage yet).
+  const model = lastCall ? lastCall.model : fallbackModel
+  const cost = lastCall?.cost ?? null
 
-  let totalCost = 0
-  let hasCost = false
-  let hasUnknownCost = false
-  for (const request of requests) {
-    if (!request.usage) {
-      continue
+  const hasMultipleRequests = calls.length >= 2
+  const totalUsage = hasMultipleRequests
+    ? sumUsages(calls.map((call) => call.usage))
+    : null
+
+  let totalDurationMs: number | null = null
+  if (hasMultipleRequests) {
+    let runningDuration = 0
+    let anyMissing = false
+    for (const call of calls) {
+      if (call.durationMs === null) {
+        anyMissing = true
+        break
+      }
+      runningDuration += call.durationMs
     }
-    if (request.cost === null) {
-      hasUnknownCost = true
-      continue
+    totalDurationMs = anyMissing ? null : runningDuration
+  }
+
+  let totalCost: number | null = null
+  if (hasMultipleRequests) {
+    let runningCost = 0
+    let anyUnknown = false
+    for (const call of calls) {
+      if (call.cost === null) {
+        anyUnknown = true
+        break
+      }
+      runningCost += call.cost
     }
-    hasCost = true
-    totalCost += request.cost
+    totalCost = anyUnknown ? null : runningCost
   }
 
   return {
-    requests,
     usage,
     model,
-    cost: hasCost && !hasUnknownCost ? totalCost : null,
-    durationMs: hasDuration ? totalDurationMs : null,
+    cost,
+    durationMs,
+    totalUsage,
+    totalDurationMs,
+    totalCost,
+    requestCount: calls.length,
   }
 }
 

--- a/src/components/chat-view/useLLMResponseInfo.ts
+++ b/src/components/chat-view/useLLMResponseInfo.ts
@@ -8,89 +8,157 @@ import { ChatModel } from '../../types/chat-model.types'
 import { ResponseUsage } from '../../types/llm/response'
 import { calculateLLMCost } from '../../utils/llm/price-calculator'
 
-type LLMResponseInfo = {
+export type LLMResponseInfoEntry = {
+  messageId: string
+  requestNumber: number
   usage: ResponseUsage | null
   model: ChatModel | undefined
   cost: number | null
   durationMs: number | null
 }
 
+export type LLMResponseInfo = {
+  requests: LLMResponseInfoEntry[]
+  usage: ResponseUsage | null
+  model: ChatModel | undefined
+  cost: number | null
+  durationMs: number | null
+}
+
+const addOptionalUsageTokenCount = (
+  target: {
+    cache_read_input_tokens?: number
+    cache_creation_input_tokens?: number
+  },
+  key: 'cache_read_input_tokens' | 'cache_creation_input_tokens',
+  value: number | undefined,
+) => {
+  if (typeof value !== 'number' || value <= 0) {
+    return
+  }
+  target[key] = (target[key] ?? 0) + value
+}
+
+const sumUsages = (usages: ResponseUsage[]): ResponseUsage | null => {
+  if (usages.length === 0) {
+    return null
+  }
+
+  const total: ResponseUsage = {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  }
+
+  for (const usage of usages) {
+    total.prompt_tokens += usage.prompt_tokens
+    total.completion_tokens += usage.completion_tokens
+    total.total_tokens += usage.total_tokens
+    addOptionalUsageTokenCount(
+      total,
+      'cache_read_input_tokens',
+      usage.cache_read_input_tokens,
+    )
+    addOptionalUsageTokenCount(
+      total,
+      'cache_creation_input_tokens',
+      usage.cache_creation_input_tokens,
+    )
+  }
+
+  return total
+}
+
+export function collectLLMResponseInfo(
+  messages: AssistantToolMessageGroup,
+): LLMResponseInfo {
+  const requests: LLMResponseInfoEntry[] = []
+  let latestAssistantMessage: ChatAssistantMessage | undefined
+  let latestAssistantWithUsage: ChatAssistantMessage | undefined
+  let totalDurationMs = 0
+  let hasDuration = false
+
+  for (const message of messages) {
+    if (message.role !== 'assistant') {
+      continue
+    }
+
+    latestAssistantMessage = message
+
+    if (message.metadata?.usage) {
+      latestAssistantWithUsage = message
+    }
+
+    const usage = message.metadata?.usage ?? null
+    const durationMs =
+      typeof message.metadata?.durationMs === 'number'
+        ? message.metadata.durationMs
+        : null
+
+    if (durationMs !== null) {
+      totalDurationMs += durationMs
+      hasDuration = true
+    }
+
+    if (!usage && durationMs === null) {
+      continue
+    }
+
+    const model = message.metadata?.model
+    requests.push({
+      messageId: message.id,
+      requestNumber: requests.length + 1,
+      usage,
+      model,
+      cost:
+        usage && model
+          ? calculateLLMCost({
+              model,
+              usage,
+            })
+          : null,
+      durationMs,
+    })
+  }
+
+  const usage = sumUsages(
+    requests
+      .map((request) => request.usage)
+      .filter((requestUsage): requestUsage is ResponseUsage =>
+        Boolean(requestUsage),
+      ),
+  )
+
+  const model =
+    latestAssistantWithUsage?.metadata?.model ??
+    latestAssistantMessage?.metadata?.model
+
+  let totalCost = 0
+  let hasCost = false
+  let hasUnknownCost = false
+  for (const request of requests) {
+    if (!request.usage) {
+      continue
+    }
+    if (request.cost === null) {
+      hasUnknownCost = true
+      continue
+    }
+    hasCost = true
+    totalCost += request.cost
+  }
+
+  return {
+    requests,
+    usage,
+    model,
+    cost: hasCost && !hasUnknownCost ? totalCost : null,
+    durationMs: hasDuration ? totalDurationMs : null,
+  }
+}
+
 export function useLLMResponseInfo(
   messages: AssistantToolMessageGroup,
 ): LLMResponseInfo {
-  const {
-    latestAssistantMessage,
-    latestAssistantWithUsage,
-    latestAssistantWithDuration,
-  } = useMemo(() => {
-    let latestAssistantMessage: ChatAssistantMessage | undefined
-    let latestAssistantWithUsage: ChatAssistantMessage | undefined
-    let latestAssistantWithDuration: ChatAssistantMessage | undefined
-
-    for (let index = messages.length - 1; index >= 0; index -= 1) {
-      const message = messages[index]
-      if (message.role !== 'assistant') {
-        continue
-      }
-
-      latestAssistantMessage = latestAssistantMessage ?? message
-
-      if (!latestAssistantWithUsage && message.metadata?.usage) {
-        latestAssistantWithUsage = message
-      }
-
-      if (
-        !latestAssistantWithDuration &&
-        typeof message.metadata?.durationMs === 'number'
-      ) {
-        latestAssistantWithDuration = message
-      }
-
-      if (
-        latestAssistantMessage &&
-        latestAssistantWithUsage &&
-        latestAssistantWithDuration
-      ) {
-        break
-      }
-    }
-
-    return {
-      latestAssistantMessage,
-      latestAssistantWithUsage,
-      latestAssistantWithDuration,
-    }
-  }, [messages])
-
-  const usage = useMemo<ResponseUsage | null>(() => {
-    return latestAssistantWithUsage?.metadata?.usage ?? null
-  }, [latestAssistantWithUsage])
-
-  const model = useMemo<ChatModel | undefined>(() => {
-    return (
-      latestAssistantWithUsage?.metadata?.model ??
-      latestAssistantMessage?.metadata?.model
-    )
-  }, [latestAssistantMessage, latestAssistantWithUsage])
-
-  const cost = useMemo<number | null>(() => {
-    if (!model || !usage) {
-      return null
-    }
-    return calculateLLMCost({
-      model,
-      usage,
-    })
-  }, [model, usage])
-
-  const durationMs = useMemo<number | null>(() => {
-    return latestAssistantWithDuration?.metadata?.durationMs ?? null
-  }, [latestAssistantWithDuration])
-
-  return {
-    usage,
-    model,
-    cost,
-    durationMs,
-  }
+  return useMemo(() => collectLLMResponseInfo(messages), [messages])
 }

--- a/src/core/agent/external-cli/runner.test.ts
+++ b/src/core/agent/external-cli/runner.test.ts
@@ -146,6 +146,18 @@ function simulateSuccess(stdout: string, exitCode = 0) {
   })
 }
 
+function expectChildKillRequested(child: MockChild): void {
+  if (process.platform === 'win32') {
+    expect(taskkillCalls).toContainEqual({
+      args: ['/T', '/F', '/PID', String(child.pid)],
+    })
+    return
+  }
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method -- jest spy assertion must reference the original method
+  expect(process.kill).toHaveBeenCalledWith(-child.pid, 'SIGTERM')
+}
+
 describe('runExternalAgent', () => {
   it('spawn 成功 — 返回 stdout', async () => {
     const promise = runExternalAgent({
@@ -201,8 +213,7 @@ describe('runExternalAgent', () => {
 
     const result = (await promise) as RunExternalAgentResult
     expect(result.stdout).toBe('some output')
-    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest spy 断言必须引用原始方法
-    expect(process.kill).toHaveBeenCalledWith(-mockChild.pid, 'SIGTERM')
+    expectChildKillRequested(mockChild)
   })
 
   it('超时 — reject 并调用 kill', async () => {
@@ -229,8 +240,7 @@ describe('runExternalAgent', () => {
     })
 
     await promise
-    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest spy 断言
-    expect(process.kill).toHaveBeenCalledWith(-mockChild.pid, 'SIGTERM')
+    expectChildKillRequested(mockChild)
   }, 10000)
 
   it('输出超过 1MB — 双端截断并设置 truncated metadata', async () => {

--- a/src/styles/chat/message.css
+++ b/src/styles/chat/message.css
@@ -940,6 +940,19 @@
   text-overflow: ellipsis;
 }
 
+.yolo-llm-inline-info-chevron {
+  flex: 0 0 auto;
+  width: var(--size-4-3);
+  height: var(--size-4-3);
+  color: var(--text-faint);
+  transform: rotate(180deg);
+  transition: transform 120ms ease;
+}
+
+.yolo-llm-inline-info-chevron.is-expanded {
+  transform: rotate(0deg);
+}
+
 .yolo-llm-inline-info-item {
   display: inline-flex;
   align-items: center;
@@ -976,6 +989,73 @@
  * Design goal: a single calm tone. One row per metric, icon/label/value in the
  * same muted color family, only the numeric values tinted stronger. Cache
  * detail folds under Input as a tight sub-line. */
+.yolo-llm-usage-popover {
+  width: max-content;
+  margin-left: calc((2ch + var(--size-4-2)) * -1);
+  padding: var(--size-4-2);
+  overflow-y: auto;
+  color: var(--text-faint);
+  font-size: calc(var(--font-smallest) * 0.9);
+  line-height: 1.4;
+}
+
+.yolo-llm-inline-info-panel {
+  display: flex;
+  flex-direction: column;
+  color: inherit;
+}
+
+.yolo-llm-inline-info-detail-list {
+  display: grid;
+  grid-template-columns: 2ch max-content max-content max-content max-content;
+  column-gap: var(--size-4-2);
+  row-gap: var(--size-2-2);
+}
+
+.yolo-llm-inline-info-detail-row {
+  display: contents;
+  font-size: inherit;
+  color: inherit;
+}
+
+.yolo-llm-inline-info-detail-row--total::before {
+  content: '';
+  grid-column: 1 / -1;
+  height: 1px;
+  margin-top: var(--size-2-2);
+  background: var(--background-modifier-border);
+}
+
+.yolo-llm-inline-info-detail-row--total > * {
+  padding-top: var(--size-2-2);
+}
+
+.yolo-llm-inline-info-detail-index {
+  flex: 0 0 2ch;
+  color: inherit;
+  font-variant-numeric: tabular-nums;
+  line-height: inherit;
+  text-align: right;
+}
+
+.yolo-llm-inline-info-detail-item {
+  flex: 0 0 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  font-size: inherit;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.yolo-llm-inline-info-detail-item .yolo-llm-inline-info-icon {
+  flex: 0 0 auto;
+  height: var(--size-4-3);
+  width: var(--size-4-3);
+  color: inherit;
+}
+
 .yolo-llm-inline-info-tooltip-content {
   z-index: 1000;
   padding: var(--size-4-3) var(--size-4-4);

--- a/src/styles/chat/message.css
+++ b/src/styles/chat/message.css
@@ -940,19 +940,6 @@
   text-overflow: ellipsis;
 }
 
-.yolo-llm-inline-info-chevron {
-  flex: 0 0 auto;
-  width: var(--size-4-3);
-  height: var(--size-4-3);
-  color: var(--text-faint);
-  transform: rotate(180deg);
-  transition: transform 120ms ease;
-}
-
-.yolo-llm-inline-info-chevron.is-expanded {
-  transform: rotate(0deg);
-}
-
 .yolo-llm-inline-info-item {
   display: inline-flex;
   align-items: center;
@@ -989,73 +976,6 @@
  * Design goal: a single calm tone. One row per metric, icon/label/value in the
  * same muted color family, only the numeric values tinted stronger. Cache
  * detail folds under Input as a tight sub-line. */
-.yolo-llm-usage-popover {
-  width: max-content;
-  margin-left: calc((2ch + var(--size-4-2)) * -1);
-  padding: var(--size-4-2);
-  overflow-y: auto;
-  color: var(--text-faint);
-  font-size: calc(var(--font-smallest) * 0.9);
-  line-height: 1.4;
-}
-
-.yolo-llm-inline-info-panel {
-  display: flex;
-  flex-direction: column;
-  color: inherit;
-}
-
-.yolo-llm-inline-info-detail-list {
-  display: grid;
-  grid-template-columns: 2ch max-content max-content max-content max-content;
-  column-gap: var(--size-4-2);
-  row-gap: var(--size-2-2);
-}
-
-.yolo-llm-inline-info-detail-row {
-  display: contents;
-  font-size: inherit;
-  color: inherit;
-}
-
-.yolo-llm-inline-info-detail-row--total::before {
-  content: '';
-  grid-column: 1 / -1;
-  height: 1px;
-  margin-top: var(--size-2-2);
-  background: var(--background-modifier-border);
-}
-
-.yolo-llm-inline-info-detail-row--total > * {
-  padding-top: var(--size-2-2);
-}
-
-.yolo-llm-inline-info-detail-index {
-  flex: 0 0 2ch;
-  color: inherit;
-  font-variant-numeric: tabular-nums;
-  line-height: inherit;
-  text-align: right;
-}
-
-.yolo-llm-inline-info-detail-item {
-  flex: 0 0 auto;
-  min-width: 0;
-  overflow: hidden;
-  color: inherit;
-  font-size: inherit;
-  font-variant-numeric: tabular-nums;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.yolo-llm-inline-info-detail-item .yolo-llm-inline-info-icon {
-  flex: 0 0 auto;
-  height: var(--size-4-3);
-  width: var(--size-4-3);
-  color: inherit;
-}
-
 .yolo-llm-inline-info-tooltip-content {
   z-index: 1000;
   padding: var(--size-4-3) var(--size-4-4);
@@ -1068,6 +988,25 @@
   gap: var(--size-2-3);
   font-size: var(--font-ui-small);
   color: var(--text-muted);
+}
+
+.yolo-llm-inline-info-tooltip-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-2-3);
+}
+
+.yolo-llm-inline-info-tooltip-title {
+  font-size: var(--font-ui-smaller);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-faint);
+}
+
+.yolo-llm-inline-info-tooltip-divider {
+  height: 1px;
+  background: var(--background-modifier-border);
+  margin: var(--size-2-1) 0;
 }
 
 .yolo-llm-inline-info-tooltip-row {

--- a/styles.css
+++ b/styles.css
@@ -10438,6 +10438,19 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
   text-overflow: ellipsis;
 }
 
+.yolo-llm-inline-info-chevron {
+  flex: 0 0 auto;
+  width: var(--size-4-3);
+  height: var(--size-4-3);
+  color: var(--text-faint);
+  transform: rotate(180deg);
+  transition: transform 120ms ease;
+}
+
+.yolo-llm-inline-info-chevron.is-expanded {
+  transform: rotate(0deg);
+}
+
 .yolo-llm-inline-info-item {
   display: inline-flex;
   align-items: center;
@@ -10475,6 +10488,73 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
  * Design goal: a single calm tone. One row per metric, icon/label/value in the
  * same muted color family, only the numeric values tinted stronger. Cache
  * detail folds under Input as a tight sub-line. */
+
+.yolo-llm-usage-popover {
+  width: max-content;
+  margin-left: calc((2ch + var(--size-4-2)) * -1);
+  padding: var(--size-4-2);
+  overflow-y: auto;
+  color: var(--text-faint);
+  font-size: calc(var(--font-smallest) * 0.9);
+  line-height: 1.4;
+}
+
+.yolo-llm-inline-info-panel {
+  display: flex;
+  flex-direction: column;
+  color: inherit;
+}
+
+.yolo-llm-inline-info-detail-list {
+  display: grid;
+  grid-template-columns: 2ch max-content max-content max-content max-content;
+  column-gap: var(--size-4-2);
+  row-gap: var(--size-2-2);
+}
+
+.yolo-llm-inline-info-detail-row {
+  display: contents;
+  font-size: inherit;
+  color: inherit;
+}
+
+.yolo-llm-inline-info-detail-row--total::before {
+  content: '';
+  grid-column: 1 / -1;
+  height: 1px;
+  margin-top: var(--size-2-2);
+  background: var(--background-modifier-border);
+}
+
+.yolo-llm-inline-info-detail-row--total > * {
+  padding-top: var(--size-2-3);
+}
+
+.yolo-llm-inline-info-detail-index {
+  flex: 0 0 2ch;
+  color: inherit;
+  font-variant-numeric: tabular-nums;
+  line-height: inherit;
+  text-align: right;
+}
+
+.yolo-llm-inline-info-detail-item {
+  flex: 0 0 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  font-size: inherit;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.yolo-llm-inline-info-detail-item .yolo-llm-inline-info-icon {
+  flex: 0 0 auto;
+  height: var(--size-4-3);
+  width: var(--size-4-3);
+  color: inherit;
+}
 
 .yolo-llm-inline-info-tooltip-content {
   z-index: 1000;

--- a/styles.css
+++ b/styles.css
@@ -10527,7 +10527,7 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-llm-inline-info-detail-row--total > * {
-  padding-top: var(--size-2-3);
+  padding-top: var(--size-2-2);
 }
 
 .yolo-llm-inline-info-detail-index {

--- a/styles.css
+++ b/styles.css
@@ -10438,19 +10438,6 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
   text-overflow: ellipsis;
 }
 
-.yolo-llm-inline-info-chevron {
-  flex: 0 0 auto;
-  width: var(--size-4-3);
-  height: var(--size-4-3);
-  color: var(--text-faint);
-  transform: rotate(180deg);
-  transition: transform 120ms ease;
-}
-
-.yolo-llm-inline-info-chevron.is-expanded {
-  transform: rotate(0deg);
-}
-
 .yolo-llm-inline-info-item {
   display: inline-flex;
   align-items: center;
@@ -10489,73 +10476,6 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
  * same muted color family, only the numeric values tinted stronger. Cache
  * detail folds under Input as a tight sub-line. */
 
-.yolo-llm-usage-popover {
-  width: max-content;
-  margin-left: calc((2ch + var(--size-4-2)) * -1);
-  padding: var(--size-4-2);
-  overflow-y: auto;
-  color: var(--text-faint);
-  font-size: calc(var(--font-smallest) * 0.9);
-  line-height: 1.4;
-}
-
-.yolo-llm-inline-info-panel {
-  display: flex;
-  flex-direction: column;
-  color: inherit;
-}
-
-.yolo-llm-inline-info-detail-list {
-  display: grid;
-  grid-template-columns: 2ch max-content max-content max-content max-content;
-  column-gap: var(--size-4-2);
-  row-gap: var(--size-2-2);
-}
-
-.yolo-llm-inline-info-detail-row {
-  display: contents;
-  font-size: inherit;
-  color: inherit;
-}
-
-.yolo-llm-inline-info-detail-row--total::before {
-  content: '';
-  grid-column: 1 / -1;
-  height: 1px;
-  margin-top: var(--size-2-2);
-  background: var(--background-modifier-border);
-}
-
-.yolo-llm-inline-info-detail-row--total > * {
-  padding-top: var(--size-2-2);
-}
-
-.yolo-llm-inline-info-detail-index {
-  flex: 0 0 2ch;
-  color: inherit;
-  font-variant-numeric: tabular-nums;
-  line-height: inherit;
-  text-align: right;
-}
-
-.yolo-llm-inline-info-detail-item {
-  flex: 0 0 auto;
-  min-width: 0;
-  overflow: hidden;
-  color: inherit;
-  font-size: inherit;
-  font-variant-numeric: tabular-nums;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.yolo-llm-inline-info-detail-item .yolo-llm-inline-info-icon {
-  flex: 0 0 auto;
-  height: var(--size-4-3);
-  width: var(--size-4-3);
-  color: inherit;
-}
-
 .yolo-llm-inline-info-tooltip-content {
   z-index: 1000;
   padding: var(--size-4-3) var(--size-4-4);
@@ -10568,6 +10488,25 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
   gap: var(--size-2-3);
   font-size: var(--font-ui-small);
   color: var(--text-muted);
+}
+
+.yolo-llm-inline-info-tooltip-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-2-3);
+}
+
+.yolo-llm-inline-info-tooltip-title {
+  font-size: var(--font-ui-smaller);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-faint);
+}
+
+.yolo-llm-inline-info-tooltip-divider {
+  height: 1px;
+  background: var(--background-modifier-border);
+  margin: var(--size-2-1) 0;
 }
 
 .yolo-llm-inline-info-tooltip-row {


### PR DESCRIPTION
## Description

实现 https://github.com/Lapis0x0/obsidian-yolo/issues/312

当前 Agent 多轮工具调用后，底部用量信息只展示最后一次 LLM 请求，容易让用户误以为这是整个 Agent 执行过程的总用量。本 PR 将用量显示改为默认展示多次请求的累计输入 / 输出 token、速度和耗时，并支持展开查看每次 LLM 请求的明细。

主要改动：

- 收集同一 assistant/tool 消息组内每次 assistant 请求的 `usage` 和 `durationMs`
- 折叠态显示多次请求的累计 LLM 用量，而不是最后一次请求
- 在原有灰色用量信息右侧增加展开箭头
- 展开后以浮窗列表展示每次请求的 Input / Output / Speed / Duration
- 底部使用 `Σ` 显示累计总计
- 保持展开浮窗与原用量信息一致的视觉风格
- 新增 `collectLLMResponseInfo` 单元测试，覆盖多次请求用量累加逻辑
- 修改测试相关配置，从而可以在 Windows 上运行

### Screenshots
<img width="378" height="165" src="https://github.com/user-attachments/assets/1d24b3d5-7491-4cfb-a3cc-ce104dee515d" />

<img width="493" height="250" src="https://github.com/user-attachments/assets/7c8da30d-bb0a-466b-a607-dc2121d0df80" />


## Checklist before requesting a review

- [x] I have reviewed the [guidelines for contributing](https://github.com/Lapis0x0/obsidian-yolo/CONTRIBUTING.md) to this repository. 
- [x] I have performed a self-review of my code 
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`) 
	- `npm run lint:check` failed at `prettier:check`; on Windows workspace, Prettier reports repository-wide EOL/format differences. PR-specific files pass when checked with `--end-of-line auto`.
- [x] I have run the test suite (by running `npm run test`) 
	- `npm run test` failed in `src/core/agent/external-cli/runner.test.ts`; the failing assertions expect POSIX `process.kill(-pid, 'SIGTERM')`, while this run is on `win32` where the implementation uses `taskkill`.
- [x] I have tested the functionality manually 
- [x] If this PR changes CSS, I edited `src/styles/**`, rebuilt `styles.css` (`npm run styles:build`), and verified no unintended style regressions

Closes https://github.com/Lapis0x0/obsidian-yolo/issues/312