### PR TITLE
feat: add get_current_time built-in tool

### DIFF
--- a/src/core/agent/builtinToolUiMeta.ts
+++ b/src/core/agent/builtinToolUiMeta.ts
@@ -137,6 +137,13 @@ export const BUILTIN_TOOL_UI_META: Record<string, BuiltinToolUiMeta> = {
     descFallback:
       'Pause the run and ask the user 1-3 structured questions (free text / single / multi). The agent resumes after the user submits answers.',
   },
+  get_current_time: {
+    labelKey: 'settings.agent.builtinGetCurrentTimeLabel',
+    descKey: 'settings.agent.builtinGetCurrentTimeDesc',
+    labelFallback: 'Current Time',
+    descFallback:
+      'Get the current date, time, weekday, timezone, and unix timestamp.',
+  },
 }
 
 export const getBuiltinToolUiMeta = (
@@ -163,6 +170,7 @@ const BUILTIN_TOOL_CATEGORY_MAP: Record<string, BuiltinToolCategory> = {
   context_compact: 'context',
   todo_write: 'context',
   ask_user_question: 'context',
+  get_current_time: 'context',
   [MEMORY_OPS_GROUP_TOOL_NAME]: 'context',
   [WEB_OPS_GROUP_TOOL_NAME]: 'external',
   open_skill: 'external',

--- a/src/core/mcp/localFileTools.ts
+++ b/src/core/mcp/localFileTools.ts
@@ -133,6 +133,7 @@ type LocalFileToolName =
   | 'delegate_external_agent'
   | 'todo_write'
   | 'ask_user_question'
+  | 'get_current_time'
 type FsSearchScope = 'files' | 'dirs' | 'content' | 'all'
 type FsSearchMode = 'keyword' | 'rag' | 'hybrid'
 type LegacyFsSearchItem =
@@ -1200,6 +1201,15 @@ export function getLocalFileTools(options?: {
           },
         },
         required: ['todos'],
+      },
+    },
+    {
+      name: 'get_current_time',
+      description:
+        'Get the current date, time, weekday, timezone, and unix timestamp. Use this when you need to know the current time or determine what day it is.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
       },
     },
   ]
@@ -4349,6 +4359,10 @@ export async function callLocalFileTool({
         return executeTodoWrite({ args })
       }
 
+      case 'get_current_time': {
+        return executeGetCurrentTime()
+      }
+
       default:
         throw new Error(`Unknown local file tool: ${toolName}`)
     }
@@ -4413,5 +4427,42 @@ function executeTodoWrite({
   return {
     status: ToolCallResponseStatus.Success,
     text: 'Todos updated. Continue tracking your progress with the todo list.',
+  }
+}
+
+function executeGetCurrentTime(): LocalToolCallResult {
+  const now = new Date()
+
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  const hours = String(now.getHours()).padStart(2, '0')
+  const minutes = String(now.getMinutes()).padStart(2, '0')
+  const seconds = String(now.getSeconds()).padStart(2, '0')
+
+  const weekdays = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ]
+
+  const offsetMinutes = -now.getTimezoneOffset()
+  const offsetHours = Math.floor(Math.abs(offsetMinutes) / 60)
+  const offsetMins = Math.abs(offsetMinutes) % 60
+  const offsetSign = offsetMinutes >= 0 ? '+' : '-'
+  const timezoneOffset = `UTC${offsetSign}${offsetHours}${offsetMins > 0 ? `:${String(offsetMins).padStart(2, '0')}` : ''}`
+
+  return {
+    status: ToolCallResponseStatus.Success,
+    text: formatJsonResult({
+      datetime: `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`,
+      weekday: weekdays[now.getDay()],
+      timezone: timezoneOffset,
+      unix: Math.floor(now.getTime() / 1000),
+    }),
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -461,6 +461,9 @@ export const en: TranslationKeys = {
       builtinAskUserQuestionLabel: 'Ask User',
       builtinAskUserQuestionDesc:
         'Ask the user a question when required information is missing, then resume after the answer.',
+      builtinGetCurrentTimeLabel: 'Current Time',
+      builtinGetCurrentTimeDesc:
+        'Get the current date, time, weekday, timezone, and unix timestamp.',
       editorDefaultName: 'New agent',
       editorIntro: "Configure this agent's capabilities, model, and behavior.",
       editorTabProfile: 'Profile',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -464,6 +464,9 @@ export const it: TranslationKeys = {
       builtinAskUserQuestionLabel: "Chiedi all'utente",
       builtinAskUserQuestionDesc:
         "Chiede all'utente quando mancano informazioni necessarie e riprende dopo la risposta.",
+      builtinGetCurrentTimeLabel: 'Ora attuale',
+      builtinGetCurrentTimeDesc:
+        'Ottiene la data, ora, giorno della settimana, fuso orario e timestamp Unix correnti.',
       editorDefaultName: 'Nuovo agent',
       editorIntro:
         'Configura le capacità, il modello e il comportamento di questo agent.',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -417,6 +417,9 @@ export const zh: TranslationKeys = {
       builtinAskUserQuestionLabel: '向用户提问',
       builtinAskUserQuestionDesc:
         '在缺少必要信息时向用户提问，等待回答后继续。',
+      builtinGetCurrentTimeLabel: '当前时间',
+      builtinGetCurrentTimeDesc:
+        '获取当前日期、时间、星期、时区及 Unix 时间戳。',
       editorDefaultName: '新建 Agent',
       editorIntro: '配置此 Agent 的能力、模型与行为。',
       editorTabProfile: '资料',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -333,6 +333,8 @@ export type TranslationKeys = {
       builtinTodoWriteDesc?: string
       builtinAskUserQuestionLabel?: string
       builtinAskUserQuestionDesc?: string
+      builtinGetCurrentTimeLabel?: string
+      builtinGetCurrentTimeDesc?: string
       editorDefaultName?: string
       editorIntro?: string
       editorTabProfile?: string


### PR DESCRIPTION
## Summary

- 新增内置工具 `get_current_time`，让 Agent 能在运行时主动获取当前时间
- 零参数，返回结构化 JSON：`{ datetime, weekday, timezone, unix }`
- 时间为系统本地时间，附带 UTC 偏移量（如 `UTC+8`）
- 归入「Context & Memory」工具分组，设置面板可启用/禁用
- Chat 和 Agent 模式均可使用（只读工具，不设黑名单）
- 覆盖 en/zh/it 三语 i18n

## Background

之前 Agent 仅通过系统提示词变量 `{{current_minute}}` 等感知时间，但该变量在构建时一次性解析，长对话/长循环中时间会过时。新工具让 Agent 可随时获取最新时间。

## Files Changed

| File | Change |
|------|--------|
| `src/core/mcp/localFileTools.ts` | 工具定义 + handler + 类型 |
| `src/core/agent/builtinToolUiMeta.ts` | UI 元数据 + 分类 |
| `src/i18n/types.ts` | i18n 类型 |
| `src/i18n/locales/{en,zh,it}.ts` | 三语标签 |

## Test Plan

- [ ] 在 Agent 模式下让 Agent 回答「现在几点」
- [ ] 在 Chat 模式下验证工具也可用
- [ ] 在设置面板「Context & Memory」分组中验证开关可切换
- [ ] 验证返回的 timezone 与系统时区一致

## Notes

通过工具获取时间相比提示词变量的优势：

1. **时间始终最新** — 提示词变量在构建时一次性解析，长对话/多轮循环中时间会过时；工具每次调用都返回实时时间
2. **按需调用，节省 token** — 提示词变量无论是否需要都占用 system prompt token；工具仅在 Agent 需要时调用
3. **结构化返回** — 返回 JSON 包含 datetime、weekday、timezone、unix，比纯文本变量更丰富且易解析

后续将评估移除 `{{current_date}}`、`{{current_hour}}`、`{{current_minute}}`、`{{current_weekday}}` 提示词变量，统一由 `get_current_time` 工具替代。