### PR TITLE
feat: 从 GitHub 导入技能包

### DIFF
--- a/src/__tests__/core/skills/githubSkillImporter.test.ts
+++ b/src/__tests__/core/skills/githubSkillImporter.test.ts
@@ -1,0 +1,109 @@
+import { parseGitHubUrl } from '../../../core/skills/githubSkillImporter'
+
+describe('parseGitHubUrl', () => {
+  it('parses a single-file blob URL', () => {
+    const result = parseGitHubUrl(
+      'https://github.com/user/repo/blob/main/skills/my-skill.md',
+    )
+    expect(result).toEqual({
+      owner: 'user',
+      repo: 'repo',
+      branch: 'main',
+      path: 'skills/my-skill.md',
+      type: 'file',
+    })
+  })
+
+  it('parses a repo root URL', () => {
+    const result = parseGitHubUrl('https://github.com/user/repo')
+    expect(result).toEqual({
+      owner: 'user',
+      repo: 'repo',
+      branch: 'main',
+      type: 'repo',
+    })
+  })
+
+  it('parses repo URL with trailing slash', () => {
+    const result = parseGitHubUrl('https://github.com/user/repo/')
+    expect(result).toEqual({
+      owner: 'user',
+      repo: 'repo',
+      branch: 'main',
+      type: 'repo',
+    })
+  })
+
+  it('parses repo URL with .git suffix', () => {
+    const result = parseGitHubUrl('https://github.com/user/repo.git')
+    expect(result).toEqual({
+      owner: 'user',
+      repo: 'repo',
+      branch: 'main',
+      type: 'repo',
+    })
+  })
+
+  it('returns null for non-GitHub URL', () => {
+    expect(parseGitHubUrl('https://example.com/file.md')).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(parseGitHubUrl('')).toBeNull()
+  })
+
+  it('returns null for non-md file URL', () => {
+    expect(
+      parseGitHubUrl('https://github.com/user/repo/blob/main/readme.txt'),
+    ).toBeNull()
+  })
+
+  it('parses URL with master branch', () => {
+    const result = parseGitHubUrl(
+      'https://github.com/user/repo/blob/master/skills/test.md',
+    )
+    expect(result).toEqual({
+      owner: 'user',
+      repo: 'repo',
+      branch: 'master',
+      path: 'skills/test.md',
+      type: 'file',
+    })
+  })
+
+  it('handles http:// scheme', () => {
+    const result = parseGitHubUrl('http://github.com/user/repo')
+    expect(result).toEqual({
+      owner: 'user',
+      repo: 'repo',
+      branch: 'main',
+      type: 'repo',
+    })
+  })
+
+  it('parses a tree URL pointing to a subdirectory', () => {
+    const result = parseGitHubUrl(
+      'https://github.com/okooo5km/beautiful-mermaid-cli/tree/main/skills/beautiful-mermaid',
+    )
+    expect(result).toEqual({
+      owner: 'okooo5km',
+      repo: 'beautiful-mermaid-cli',
+      branch: 'main',
+      path: 'skills/beautiful-mermaid',
+      type: 'repo',
+    })
+  })
+
+  it('parses a tree URL with master branch', () => {
+    const result = parseGitHubUrl(
+      'https://github.com/user/repo/tree/master/path/to/skill',
+    )
+    expect(result).toEqual({
+      owner: 'user',
+      repo: 'repo',
+      branch: 'master',
+      path: 'path/to/skill',
+      type: 'repo',
+    })
+  })
+})

--- a/src/components/settings/modals/AgentSkillsModal.tsx
+++ b/src/components/settings/modals/AgentSkillsModal.tsx
@@ -14,6 +14,7 @@ import { ObsidianToggle } from '../../common/ObsidianToggle'
 import { ReactModal } from '../../common/ReactModal'
 import { ConfirmModal } from '../../modals/ConfirmModal'
 
+import { ImportGitHubSkillModal } from './ImportGitHubSkillModal'
 import { ImportSkillModal } from './ImportSkillModal'
 
 type AgentSkillsModalProps = {
@@ -104,6 +105,15 @@ function AgentSkillsModalContent({
   const handleOpenImportModal = () => {
     const modal = new ImportSkillModal(app, _plugin, () => {
       // 延迟刷新，等待 vault 文件索引更新
+      setTimeout(() => {
+        setRefreshTick((value) => value + 1)
+      }, 300)
+    })
+    modal.open()
+  }
+
+  const handleOpenGitHubImportModal = () => {
+    const modal = new ImportGitHubSkillModal(app, _plugin, () => {
       setTimeout(() => {
         setRefreshTick((value) => value + 1)
       }, 300)
@@ -243,6 +253,13 @@ function AgentSkillsModalContent({
               <ObsidianButton
                 text={t('settings.agent.importSkill', 'Import Skill')}
                 onClick={handleOpenImportModal}
+              />
+              <ObsidianButton
+                text={t(
+                  'settings.agent.importGitHubSkill',
+                  'Import from GitHub',
+                )}
+                onClick={handleOpenGitHubImportModal}
               />
               {deletableSkills.length > 0 && (
                 <ObsidianButton

--- a/src/components/settings/modals/ImportGitHubSkillModal.tsx
+++ b/src/components/settings/modals/ImportGitHubSkillModal.tsx
@@ -1,0 +1,270 @@
+import { App, Notice, normalizePath } from 'obsidian'
+import { useCallback, useState } from 'react'
+
+import { useLanguage } from '../../../contexts/language-context'
+import {
+  SettingsProvider,
+  useSettings,
+} from '../../../contexts/settings-context'
+import { getYoloSkillsDir } from '../../../core/paths/yoloPaths'
+import {
+  fetchGitHubSkill,
+  parseGitHubUrl,
+} from '../../../core/skills/githubSkillImporter'
+import { formatValidationErrors } from '../../../core/skills/importSkillValidationHelper'
+import {
+  type FileEntry,
+  parseFrontmatter,
+  validateDirectoryPackage,
+  validateSingleFileSkill,
+} from '../../../core/skills/skillValidation'
+import { writeSkillPackages } from '../../../core/skills/skillWriter'
+import YoloPlugin from '../../../main'
+import { ObsidianButton } from '../../common/ObsidianButton'
+import { ReactModal } from '../../common/ReactModal'
+import { ConfirmModal } from '../../modals/ConfirmModal'
+
+type ImportGitHubSkillModalProps = {
+  app: App
+  plugin: YoloPlugin
+  onImported?: () => void
+}
+
+export class ImportGitHubSkillModal extends ReactModal<ImportGitHubSkillModalProps> {
+  constructor(app: App, plugin: YoloPlugin, onImported?: () => void) {
+    super({
+      app,
+      Component: ImportGitHubSkillModalWrapper,
+      props: { app, plugin, onImported },
+      options: {
+        title: plugin.t(
+          'settings.agent.importGitHubSkill',
+          'Import from GitHub',
+        ),
+      },
+      plugin,
+    })
+  }
+}
+
+function ImportGitHubSkillModalWrapper({
+  app,
+  plugin,
+  onImported,
+  onClose,
+}: ImportGitHubSkillModalProps & { onClose: () => void }) {
+  return (
+    <SettingsProvider
+      settings={plugin.settings}
+      setSettings={(newSettings) => plugin.setSettings(newSettings)}
+      addSettingsChangeListener={(listener) =>
+        plugin.addSettingsChangeListener(listener)
+      }
+    >
+      <ImportGitHubSkillContent
+        app={app}
+        onImported={onImported}
+        onClose={onClose}
+      />
+    </SettingsProvider>
+  )
+}
+
+type SkillPackage = {
+  sourceName: string
+  targetName: string
+  displayName: string
+  description: string
+  files: FileEntry[]
+  isDirectory: boolean
+}
+
+function ImportGitHubSkillContent({
+  app,
+  onImported,
+  onClose,
+}: Omit<ImportGitHubSkillModalProps, 'plugin'> & { onClose: () => void }) {
+  const { t } = useLanguage()
+  const { settings } = useSettings()
+  const skillsDir = getYoloSkillsDir(settings)
+
+  const [url, setUrl] = useState('')
+  const [isImporting, setIsImporting] = useState(false)
+
+  const urlInfo = parseGitHubUrl(url)
+  const canImport = urlInfo !== null && !isImporting
+
+  const handleImport = useCallback(async () => {
+    if (!urlInfo || isImporting) return
+
+    setIsImporting(true)
+    try {
+      const result = await fetchGitHubSkill(url.trim())
+
+      let validationErrors: Array<{ field: string; message: string }> = []
+
+      if (result.isDirectory) {
+        validationErrors = validateDirectoryPackage(
+          result.targetName,
+          result.files,
+        )
+      } else {
+        validationErrors = validateSingleFileSkill(result.files[0].content)
+      }
+
+      if (validationErrors.length > 0) {
+        new Notice(
+          formatValidationErrors(
+            validationErrors,
+            result.sourceName,
+            (key, fallback) => t(`settings.agent.${key}`, fallback),
+          ),
+        )
+        return
+      }
+
+      const fm = parseFrontmatter(result.files[0].content)
+      const displayName =
+        (typeof fm?.name === 'string' && fm.name.trim()) || result.sourceName
+      const description =
+        (typeof fm?.description === 'string' && fm.description.trim()) || ''
+
+      const pkg: SkillPackage = {
+        ...result,
+        displayName,
+        description,
+      }
+
+      // Conflict detection
+      const targetPath = normalizePath(`${skillsDir}/${pkg.targetName}`)
+      if (app.vault.getAbstractFileByPath(targetPath)) {
+        const modal = new ConfirmModal(app, {
+          title: t(
+            'settings.agent.importSkillConflictTitle',
+            'Skill already exists',
+          ),
+          message: t(
+            'settings.agent.importSkillConflictMessage',
+            'A skill with the same name already exists. Do you want to overwrite it?',
+          ).replace('{name}', pkg.targetName),
+          ctaText: t(
+            'settings.agent.importSkillConflictOverwrite',
+            'Overwrite all',
+          ),
+          cancelText: t(
+            'settings.agent.importSkillConflictSkip',
+            'Skip conflicts',
+          ),
+          onConfirm: async () => {
+            const { successCount } = await writeSkillPackages(app, skillsDir, [
+              pkg,
+            ])
+            if (successCount > 0) {
+              new Notice(
+                t(
+                  'settings.agent.importGitHubSkillSuccess',
+                  'Successfully imported {count} skill(s)',
+                ).replace('{count}', String(successCount)),
+              )
+              onImported?.()
+              onClose()
+            }
+          },
+        })
+        modal.open()
+        return
+      }
+
+      const { successCount, errors } = await writeSkillPackages(
+        app,
+        skillsDir,
+        [pkg],
+      )
+
+      if (errors.length > 0) {
+        new Notice(errors.join('\n\n'))
+      }
+
+      if (successCount > 0) {
+        new Notice(
+          t(
+            'settings.agent.importGitHubSkillSuccess',
+            'Successfully imported {count} skill(s)',
+          ).replace('{count}', String(successCount)),
+        )
+        onImported?.()
+        onClose()
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes('SKILL.md')) {
+        new Notice(
+          t(
+            'settings.agent.importGitHubSkillNotSkillPackage',
+            'This repository is not a valid skill package (SKILL.md not found at root)',
+          ),
+        )
+      } else if (
+        message.includes('fetch') ||
+        message.includes('HTTP') ||
+        message.includes('Network')
+      ) {
+        new Notice(
+          t(
+            'settings.agent.importGitHubSkillFetchError',
+            'Failed to fetch: {error}',
+          ).replace('{error}', message),
+        )
+      } else {
+        new Notice(
+          t(
+            'settings.agent.importGitHubSkillNetworkError',
+            'Network error. Please check the URL and your internet connection.',
+          ),
+        )
+      }
+    } finally {
+      setIsImporting(false)
+    }
+  }, [url, urlInfo, isImporting, app, skillsDir, t, onImported, onClose])
+
+  return (
+    <div className="yolo-import-github-skill-modal">
+      <div className="yolo-settings-desc yolo-settings-callout">
+        {t(
+          'settings.agent.importGitHubSkillDesc',
+          'Paste a GitHub URL to import a skill. Supports single .md files or standard skill package repos.',
+        )}
+      </div>
+
+      <div className="yolo-import-github-skill-input-row">
+        <input
+          type="text"
+          className="yolo-import-github-skill-url-input"
+          placeholder={t(
+            'settings.agent.importGitHubSkillPlaceholder',
+            'https://github.com/user/repo/...',
+          )}
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && canImport) {
+              void handleImport()
+            }
+          }}
+          disabled={isImporting}
+        />
+        <ObsidianButton
+          text={
+            isImporting
+              ? t('settings.agent.importGitHubSkillImporting', 'Importing...')
+              : t('settings.agent.importSkillConfirm', 'Import')
+          }
+          cta
+          disabled={!canImport}
+          onClick={() => void handleImport()}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/settings/modals/ImportSkillModal.tsx
+++ b/src/components/settings/modals/ImportSkillModal.tsx
@@ -7,13 +7,14 @@ import {
   useSettings,
 } from '../../../contexts/settings-context'
 import { getYoloSkillsDir } from '../../../core/paths/yoloPaths'
+import { formatValidationErrors } from '../../../core/skills/importSkillValidationHelper'
 import {
   type FileEntry,
-  type ValidationError,
   parseFrontmatter,
   validateDirectoryPackage,
   validateSingleFileSkill,
 } from '../../../core/skills/skillValidation'
+import { writeSkillPackages } from '../../../core/skills/skillWriter'
 import YoloPlugin from '../../../main'
 import { ObsidianButton } from '../../common/ObsidianButton'
 import { ReactModal } from '../../common/ReactModal'
@@ -83,93 +84,6 @@ type SkillPackage = {
 
 const SKILL_MD = 'SKILL.md'
 const MAX_PATH_DEPTH = 16
-
-// ---------------------------------------------------------------------------
-// 校验错误转为通俗提示
-// ---------------------------------------------------------------------------
-
-type TranslateFn = (key: string, fallback: string) => string
-
-function formatValidationErrors(
-  errors: ValidationError[],
-  sourceName: string,
-  t: TranslateFn,
-): string {
-  const reasons = errors.map((err) => {
-    const key = `${err.field}:${err.message}`
-    switch (key) {
-      case 'SKILL.md:missing':
-        return t(
-          'settings.agent.importSkillErrNoSkillMd',
-          'missing SKILL.md file in folder',
-        )
-      case 'frontmatter:missing or invalid':
-        return t(
-          'settings.agent.importSkillErrNoFrontmatter',
-          'missing metadata header (---) at the top of the file',
-        )
-      case 'name:missing':
-        return t(
-          'settings.agent.importSkillErrNoName',
-          'missing "name" field in metadata',
-        )
-      case 'name:exceeds 64 characters':
-        return t(
-          'settings.agent.importSkillErrNameTooLong',
-          '"name" is too long (max 64 characters)',
-        )
-      case 'name:uppercase not allowed':
-        return t(
-          'settings.agent.importSkillErrNameUppercase',
-          '"name" must be all lowercase',
-        )
-      case 'name:cannot start or end with hyphen':
-        return t(
-          'settings.agent.importSkillErrNameHyphenEdge',
-          '"name" cannot start or end with a hyphen',
-        )
-      case 'name:consecutive hyphens not allowed':
-        return t(
-          'settings.agent.importSkillErrNameDoubleHyphen',
-          '"name" cannot contain consecutive hyphens (--)',
-        )
-      case 'name:only lowercase letters, numbers, and hyphens allowed':
-        return t(
-          'settings.agent.importSkillErrNameInvalidChars',
-          '"name" can only contain lowercase letters, numbers, and hyphens',
-        )
-      case 'name:must match folder name':
-        return t(
-          'settings.agent.importSkillErrNameMismatch',
-          '"name" must match the folder name',
-        )
-      case 'description:missing':
-        return t(
-          'settings.agent.importSkillErrNoDescription',
-          'missing "description" field in metadata',
-        )
-      case 'description:exceeds 1024 characters':
-        return t(
-          'settings.agent.importSkillErrDescTooLong',
-          '"description" is too long (max 1024 characters)',
-        )
-      case 'compatibility:exceeds 500 characters':
-        return t(
-          'settings.agent.importSkillErrCompatTooLong',
-          '"compatibility" is too long (max 500 characters)',
-        )
-      default:
-        return `${err.field}: ${err.message}`
-    }
-  })
-
-  const header = t(
-    'settings.agent.importSkillErrHeader',
-    '"{name}" cannot be imported:',
-  ).replace('{name}', sourceName)
-
-  return `${header}\n${reasons.map((r) => `• ${r}`).join('\n')}`
-}
 
 // ---------------------------------------------------------------------------
 // 文件系统读取(同步收集 entries,再异步读取)
@@ -689,79 +603,30 @@ function ImportSkillModalContent({
     if (skillPackages.length === 0) return
 
     setIsImporting(true)
-    let successCount = 0
-    const errors: string[] = []
-
-    // 递归保证目录存在(Obsidian createFolder 不会递归创建父目录)
-    const ensureFolder = async (path: string) => {
-      const segments = path.split('/').filter((s) => s.length > 0)
-      let cur = ''
-      for (const seg of segments) {
-        cur = cur ? `${cur}/${seg}` : seg
-        if (!app.vault.getAbstractFileByPath(cur)) {
-          await app.vault.createFolder(cur)
-        }
-      }
-    }
 
     try {
-      await ensureFolder(skillsDir)
-
-      for (const pkg of skillPackages) {
-        try {
-          if (pkg.isDirectory) {
-            const pkgDir = normalizePath(`${skillsDir}/${pkg.targetName}`)
-            // 覆盖时:无论已存在的是文件还是目录,先 trash 再写新,避免遗留旧资源 / 类型冲突
-            const existing = app.vault.getAbstractFileByPath(pkgDir)
-            if (existing) {
-              await app.fileManager.trashFile(existing)
-            }
-            await app.vault.createFolder(pkgDir)
-
-            for (const file of pkg.files) {
-              if (!isSafeRelativePath(file.relativePath)) {
-                throw new Error(`unsafe path: ${file.relativePath}`)
-              }
-              const targetPath = normalizePath(`${pkgDir}/${file.relativePath}`)
-              if (!targetPath.startsWith(`${pkgDir}/`)) {
-                throw new Error(`path escaped target: ${file.relativePath}`)
-              }
-              const parentDir = targetPath.substring(
-                0,
-                targetPath.lastIndexOf('/'),
-              )
-              if (parentDir) {
-                await ensureFolder(parentDir)
-              }
-              await app.vault.create(targetPath, file.content)
-            }
-          } else {
-            const targetPath = normalizePath(`${skillsDir}/${pkg.targetName}`)
-            if (!targetPath.startsWith(`${skillsDir}/`)) {
-              throw new Error(`path escaped target: ${pkg.targetName}`)
-            }
-            const existing = app.vault.getAbstractFileByPath(targetPath)
-            if (existing) {
-              await app.fileManager.trashFile(existing)
-            }
-            await app.vault.create(targetPath, pkg.files[0].content)
-          }
-          successCount++
-        } catch (err) {
-          const message = err instanceof Error ? err.message : 'Unknown error'
-          errors.push(
-            t(
-              'settings.agent.importSkillWriteError',
-              'Failed to import {name}: {error}',
-            )
-              .replace('{name}', pkg.sourceName)
-              .replace('{error}', message),
-          )
-        }
-      }
+      const { successCount, errors } = await writeSkillPackages(
+        app,
+        skillsDir,
+        skillPackages,
+      )
 
       if (errors.length > 0) {
-        new Notice(errors.join('\n\n'))
+        new Notice(
+          errors
+            .map((e) => {
+              const colonIdx = e.indexOf(': ')
+              const name = colonIdx > 0 ? e.slice(0, colonIdx) : e
+              const error = colonIdx > 0 ? e.slice(colonIdx + 2) : ''
+              return t(
+                'settings.agent.importSkillWriteError',
+                'Failed to import {name}: {error}',
+              )
+                .replace('{name}', name)
+                .replace('{error}', error)
+            })
+            .join('\n\n'),
+        )
       }
 
       if (successCount > 0) {

--- a/src/core/skills/githubSkillImporter.ts
+++ b/src/core/skills/githubSkillImporter.ts
@@ -1,0 +1,201 @@
+import { requestUrl } from 'obsidian'
+
+import type { FileEntry } from './skillValidation'
+
+export type GitHubUrlInfo = {
+  owner: string
+  repo: string
+  branch: string
+  path?: string
+  type: 'file' | 'repo'
+}
+
+const GITHUB_BLOB_RE =
+  /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)\/blob\/([^/]+)\/(.+\.md)$/
+
+const GITHUB_TREE_RE =
+  /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)\/tree\/([^/]+)\/(.+)$/
+
+const GITHUB_REPO_RE =
+  /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\/|\.git\/?|\/?)?$/
+
+export function parseGitHubUrl(url: string): GitHubUrlInfo | null {
+  const trimmed = url.trim().replace(/\/+$/, '')
+  if (!trimmed) return null
+
+  const blobMatch = GITHUB_BLOB_RE.exec(trimmed)
+  if (blobMatch) {
+    return {
+      owner: blobMatch[1],
+      repo: blobMatch[2],
+      branch: blobMatch[3],
+      path: blobMatch[4],
+      type: 'file',
+    }
+  }
+
+  const treeMatch = GITHUB_TREE_RE.exec(trimmed)
+  if (treeMatch) {
+    return {
+      owner: treeMatch[1],
+      repo: treeMatch[2],
+      branch: treeMatch[3],
+      path: treeMatch[4],
+      type: 'repo',
+    }
+  }
+
+  const repoMatch = GITHUB_REPO_RE.exec(trimmed)
+  if (repoMatch) {
+    const cleanRepo = repoMatch[2].replace(/\.git$/, '')
+    return {
+      owner: repoMatch[1],
+      repo: cleanRepo,
+      branch: 'main',
+      type: 'repo',
+    }
+  }
+
+  return null
+}
+
+function buildRawUrl(info: GitHubUrlInfo, filePath?: string): string {
+  const path = filePath ?? info.path
+  if (!path) {
+    throw new Error('File path is required for raw URL construction')
+  }
+  return `https://raw.githubusercontent.com/${info.owner}/${info.repo}/${info.branch}/${path}`
+}
+
+async function fetchRaw(rawUrl: string): Promise<string> {
+  const response = await requestUrl({ url: rawUrl })
+  if (response.status >= 400) {
+    throw new Error(`HTTP ${response.status}: ${rawUrl}`)
+  }
+  return response.text
+}
+
+async function fetchRepoFile(
+  info: GitHubUrlInfo,
+  filePath: string,
+): Promise<string | null> {
+  try {
+    return await fetchRaw(buildRawUrl(info, filePath))
+  } catch {
+    return null
+  }
+}
+
+export type GitHubFetchResult = {
+  files: FileEntry[]
+  sourceName: string
+  targetName: string
+  description: string
+  isDirectory: boolean
+}
+
+type GitHubContentEntry = {
+  name: string
+  path: string
+  download_url: string | null
+  type: 'file' | 'dir'
+}
+
+async function fetchDirectoryEntries(
+  apiUrl: string,
+  files: FileEntry[],
+  info: GitHubUrlInfo,
+  prefix = '',
+): Promise<void> {
+  let listing: GitHubContentEntry[]
+  try {
+    const response = await requestUrl({ url: apiUrl })
+    if (response.status !== 200 || !Array.isArray(response.json)) return
+    listing = response.json
+  } catch {
+    return
+  }
+
+  for (const entry of listing) {
+    if (!prefix && entry.name === 'SKILL.md') continue
+
+    if (entry.type === 'file' && entry.download_url) {
+      try {
+        const content = await fetchRaw(entry.download_url)
+        files.push({ relativePath: prefix + entry.name, content })
+      } catch {
+        // skip files that fail to fetch
+      }
+    } else if (entry.type === 'dir') {
+      const subApiUrl = `https://api.github.com/repos/${info.owner}/${info.repo}/contents/${entry.path}`
+      await fetchDirectoryEntries(
+        subApiUrl,
+        files,
+        info,
+        prefix + entry.name + '/',
+      )
+    }
+  }
+}
+
+export async function fetchGitHubSkill(
+  url: string,
+): Promise<GitHubFetchResult> {
+  const info = parseGitHubUrl(url)
+  if (!info) {
+    throw new Error('Invalid GitHub URL')
+  }
+
+  if (info.type === 'file') {
+    const content = await fetchRaw(buildRawUrl(info))
+    const fileName = info.path!.split('/').pop()!
+    return {
+      files: [{ relativePath: fileName, content }],
+      sourceName: fileName,
+      targetName: fileName,
+      description: '',
+      isDirectory: false,
+    }
+  }
+
+  // Repo mode: check for SKILL.md in directory (subpath or root)
+  const dirPath = info.path ?? ''
+  const skillMdPath = dirPath ? `${dirPath}/SKILL.md` : 'SKILL.md'
+  let skillMd = await fetchRepoFile(info, skillMdPath)
+  if (!skillMd && info.branch === 'main') {
+    skillMd = await fetchRepoFile({ ...info, branch: 'master' }, skillMdPath)
+  }
+  if (!skillMd) {
+    throw new Error(
+      'No SKILL.md found at the specified path — not a valid skill package',
+    )
+  }
+
+  // Fetch directory listing via GitHub API (public only)
+  const files: FileEntry[] = [{ relativePath: 'SKILL.md', content: skillMd }]
+  const apiBase = `https://api.github.com/repos/${info.owner}/${info.repo}/contents`
+  const apiDir = dirPath ? `${apiBase}/${dirPath}` : apiBase
+
+  await fetchDirectoryEntries(apiDir, files, info)
+
+  // Derive targetName from frontmatter name
+  const fmMatch = skillMd.match(/^---\n([\s\S]*?)\n---/)
+  let targetName = info.repo
+  if (fmMatch) {
+    const nameMatch = fmMatch[1].match(/^name:\s*(.+)$/m)
+    if (nameMatch) {
+      targetName = nameMatch[1].trim()
+    }
+  }
+
+  const descMatch = skillMd.match(/^description:\s*(.+)$/m)
+  const description = descMatch ? descMatch[1].trim() : ''
+
+  return {
+    files,
+    sourceName: info.repo,
+    targetName,
+    description,
+    isDirectory: true,
+  }
+}

--- a/src/core/skills/importSkillValidationHelper.ts
+++ b/src/core/skills/importSkillValidationHelper.ts
@@ -1,0 +1,84 @@
+import type { ValidationError } from './skillValidation'
+
+type TranslateFn = (key: string, fallback: string) => string
+
+export function formatValidationErrors(
+  errors: ValidationError[],
+  sourceName: string,
+  t: TranslateFn,
+): string {
+  const reasons = errors.map((err) => {
+    const key = `${err.field}:${err.message}`
+    switch (key) {
+      case 'SKILL.md:missing':
+        return t(
+          'settings.agent.importSkillErrNoSkillMd',
+          'missing SKILL.md file in folder',
+        )
+      case 'frontmatter:missing or invalid':
+        return t(
+          'settings.agent.importSkillErrNoFrontmatter',
+          'missing metadata header (---) at the top of the file',
+        )
+      case 'name:missing':
+        return t(
+          'settings.agent.importSkillErrNoName',
+          'missing "name" field in metadata',
+        )
+      case 'name:exceeds 64 characters':
+        return t(
+          'settings.agent.importSkillErrNameTooLong',
+          '"name" is too long (max 64 characters)',
+        )
+      case 'name:uppercase not allowed':
+        return t(
+          'settings.agent.importSkillErrNameUppercase',
+          '"name" must be all lowercase',
+        )
+      case 'name:cannot start or end with hyphen':
+        return t(
+          'settings.agent.importSkillErrNameHyphenEdge',
+          '"name" cannot start or end with a hyphen',
+        )
+      case 'name:consecutive hyphens not allowed':
+        return t(
+          'settings.agent.importSkillErrNameDoubleHyphen',
+          '"name" cannot contain consecutive hyphens (--)',
+        )
+      case 'name:only lowercase letters, numbers, and hyphens allowed':
+        return t(
+          'settings.agent.importSkillErrNameInvalidChars',
+          '"name" can only contain lowercase letters, numbers, and hyphens',
+        )
+      case 'name:must match folder name':
+        return t(
+          'settings.agent.importSkillErrNameMismatch',
+          '"name" must match the folder name',
+        )
+      case 'description:missing':
+        return t(
+          'settings.agent.importSkillErrNoDescription',
+          'missing "description" field in metadata',
+        )
+      case 'description:exceeds 1024 characters':
+        return t(
+          'settings.agent.importSkillErrDescTooLong',
+          '"description" is too long (max 1024 characters)',
+        )
+      case 'compatibility:exceeds 500 characters':
+        return t(
+          'settings.agent.importSkillErrCompatTooLong',
+          '"compatibility" is too long (max 500 characters)',
+        )
+      default:
+        return `${err.field}: ${err.message}`
+    }
+  })
+
+  const header = t(
+    'settings.agent.importSkillErrHeader',
+    '"{name}" cannot be imported:',
+  ).replace('{name}', sourceName)
+
+  return `${header}\n${reasons.map((r) => `• ${r}`).join('\n')}`
+}

--- a/src/core/skills/skillWriter.ts
+++ b/src/core/skills/skillWriter.ts
@@ -1,0 +1,86 @@
+import { App, normalizePath } from 'obsidian'
+
+import type { FileEntry } from './skillValidation'
+
+export type SkillWritePackage = {
+  sourceName: string
+  targetName: string
+  files: FileEntry[]
+  isDirectory: boolean
+}
+
+function isSafeRelativePath(relativePath: string): boolean {
+  if (!relativePath) return false
+  if (relativePath.startsWith('/') || relativePath.startsWith('\\'))
+    return false
+  if (/(^|\/)\.\.(\/|$)/.test(relativePath)) return false
+  if (/\\/.test(relativePath)) return false
+  if (/^[a-zA-Z]:/.test(relativePath)) return false
+  return true
+}
+
+export async function writeSkillPackages(
+  app: App,
+  skillsDir: string,
+  packages: SkillWritePackage[],
+): Promise<{ successCount: number; errors: string[] }> {
+  let successCount = 0
+  const errors: string[] = []
+
+  const ensureFolder = async (path: string) => {
+    const segments = path.split('/').filter((s) => s.length > 0)
+    let cur = ''
+    for (const seg of segments) {
+      cur = cur ? `${cur}/${seg}` : seg
+      if (!app.vault.getAbstractFileByPath(cur)) {
+        await app.vault.createFolder(cur)
+      }
+    }
+  }
+
+  await ensureFolder(skillsDir)
+
+  for (const pkg of packages) {
+    try {
+      if (pkg.isDirectory) {
+        const pkgDir = normalizePath(`${skillsDir}/${pkg.targetName}`)
+        const existing = app.vault.getAbstractFileByPath(pkgDir)
+        if (existing) {
+          await app.fileManager.trashFile(existing)
+        }
+        await app.vault.createFolder(pkgDir)
+
+        for (const file of pkg.files) {
+          if (!isSafeRelativePath(file.relativePath)) {
+            throw new Error(`unsafe path: ${file.relativePath}`)
+          }
+          const targetPath = normalizePath(`${pkgDir}/${file.relativePath}`)
+          if (!targetPath.startsWith(`${pkgDir}/`)) {
+            throw new Error(`path escaped target: ${file.relativePath}`)
+          }
+          const parentDir = targetPath.substring(0, targetPath.lastIndexOf('/'))
+          if (parentDir) {
+            await ensureFolder(parentDir)
+          }
+          await app.vault.create(targetPath, file.content)
+        }
+      } else {
+        const targetPath = normalizePath(`${skillsDir}/${pkg.targetName}`)
+        if (!targetPath.startsWith(`${skillsDir}/`)) {
+          throw new Error(`path escaped target: ${pkg.targetName}`)
+        }
+        const existing = app.vault.getAbstractFileByPath(targetPath)
+        if (existing) {
+          await app.fileManager.trashFile(existing)
+        }
+        await app.vault.create(targetPath, pkg.files[0].content)
+      }
+      successCount++
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      errors.push(`${pkg.sourceName}: ${message}`)
+    }
+  }
+
+  return { successCount, errors }
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -372,6 +372,18 @@ export const en: TranslationKeys = {
       importSkillUnsafePath: 'Refused unsafe path in "{name}": {path}',
       importSkillDuplicateInBatch:
         'Duplicate skill name in this batch: "{name}" (from "{source}"). Only the first occurrence is kept.',
+      importGitHubSkill: 'Import from GitHub',
+      importGitHubSkillDesc:
+        'Paste a GitHub URL to import a skill. Supports single .md files or standard skill package repos.',
+      importGitHubSkillPlaceholder: 'https://github.com/user/repo/...',
+      importGitHubSkillImporting: 'Importing...',
+      importGitHubSkillInvalidUrl: 'Please enter a valid GitHub URL',
+      importGitHubSkillFetchError: 'Failed to fetch: {error}',
+      importGitHubSkillNotSkillPackage:
+        'This repository is not a valid skill package (SKILL.md not found at root)',
+      importGitHubSkillSuccess: 'Successfully imported {count} skill(s)',
+      importGitHubSkillNetworkError:
+        'Network error. Please check the URL and your internet connection.',
       deleteSkillTitle: 'Delete skill',
       deleteSkillMessage:
         'Are you sure you want to delete "{name}"? This cannot be undone.',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -334,6 +334,17 @@ export const zh: TranslationKeys = {
       importSkillUnsafePath: '已拒绝「{name}」中的不安全路径：{path}',
       importSkillDuplicateInBatch:
         '本次导入中存在同名技能：「{name}」（来自「{source}」），仅保留第一个。',
+      importGitHubSkill: '从 GitHub 导入',
+      importGitHubSkillDesc:
+        '粘贴 GitHub 链接导入技能。支持单个 .md 文件或标准技能包仓库。',
+      importGitHubSkillPlaceholder: 'https://github.com/user/repo/...',
+      importGitHubSkillImporting: '正在导入...',
+      importGitHubSkillInvalidUrl: '请输入有效的 GitHub 链接',
+      importGitHubSkillFetchError: '获取失败：{error}',
+      importGitHubSkillNotSkillPackage:
+        '该仓库不是有效的技能包（根目录未找到 SKILL.md）',
+      importGitHubSkillSuccess: '已成功导入 {count} 个技能',
+      importGitHubSkillNetworkError: '网络错误，请检查链接和网络连接。',
       deleteSkillTitle: '删除技能',
       deleteSkillMessage: '确定要删除「{name}」吗？此操作无法撤销。',
       deleteSkillConfirm: '删除',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -255,6 +255,15 @@ export type TranslationKeys = {
       importSkillConflictSkip?: string
       importSkillUnsafePath?: string
       importSkillDuplicateInBatch?: string
+      importGitHubSkill?: string
+      importGitHubSkillDesc?: string
+      importGitHubSkillPlaceholder?: string
+      importGitHubSkillImporting?: string
+      importGitHubSkillInvalidUrl?: string
+      importGitHubSkillFetchError?: string
+      importGitHubSkillNotSkillPackage?: string
+      importGitHubSkillSuccess?: string
+      importGitHubSkillNetworkError?: string
       deleteSkillTitle?: string
       deleteSkillMessage?: string
       deleteSkillConfirm?: string

--- a/src/styles/settings/agent.css
+++ b/src/styles/settings/agent.css
@@ -1673,3 +1673,42 @@ button.yolo-agent-chip--more:hover {
   width: 14px;
   height: 14px;
 }
+
+/* Import GitHub Skill Modal */
+.yolo-import-github-skill-modal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-4-3);
+}
+
+.yolo-import-github-skill-input-row {
+  display: flex;
+  gap: var(--size-4-2);
+  align-items: center;
+}
+
+.yolo-import-github-skill-url-input {
+  flex: 1;
+  padding: 6px 12px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  background: var(--background-primary);
+  color: var(--text-normal);
+  font-size: var(--font-ui-small);
+  font-family: inherit;
+  outline: none;
+  transition: border-color 140ms ease;
+}
+
+.yolo-import-github-skill-url-input:focus {
+  border-color: var(--interactive-accent);
+}
+
+.yolo-import-github-skill-url-input::placeholder {
+  color: var(--text-faint);
+}
+
+.yolo-import-github-skill-url-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/styles.css
+++ b/styles.css
@@ -6373,6 +6373,46 @@ button.yolo-agent-chip--more:hover {
   height: 14px;
 }
 
+/* Import GitHub Skill Modal */
+
+.yolo-import-github-skill-modal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-4-3);
+}
+
+.yolo-import-github-skill-input-row {
+  display: flex;
+  gap: var(--size-4-2);
+  align-items: center;
+}
+
+.yolo-import-github-skill-url-input {
+  flex: 1;
+  padding: 6px 12px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  background: var(--background-primary);
+  color: var(--text-normal);
+  font-size: var(--font-ui-small);
+  font-family: inherit;
+  outline: none;
+  transition: border-color 140ms ease;
+}
+
+.yolo-import-github-skill-url-input:focus {
+  border-color: var(--interactive-accent);
+}
+
+.yolo-import-github-skill-url-input::placeholder {
+  color: var(--text-faint);
+}
+
+.yolo-import-github-skill-url-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Web search settings — V1 refined single-column layout */
 
 .yolo-ws {


### PR DESCRIPTION
## Summary

- 支持通过 GitHub URL 直接导入技能，包括单文件（blob URL）、仓库根目录、子目录（tree URL）三种格式

## Screenshot

<img width="715" height="584" alt="image" src="https://github.com/user-attachments/assets/984333a8-a2c3-422c-89ed-d2a12ba3e1f2" />

## 修改文件

| 文件 | 说明 |
|------|------|
| `src/core/skills/githubSkillImporter.ts` | 新增：URL 解析 + 内容获取（支持 blob/tree/repo 三种格式） |
| `src/core/skills/skillWriter.ts` | 新增：提取共享写入逻辑 |
| `src/core/skills/importSkillValidationHelper.ts` | 新增：提取共享校验错误格式化 |
| `src/components/settings/modals/ImportGitHubSkillModal.tsx` | 新增：GitHub 导入弹窗 UI |
| `src/components/settings/modals/ImportSkillModal.tsx` | 重构：使用共享 skillWriter（净减 ~100 行） |
| `src/components/settings/modals/AgentSkillsModal.tsx` | 新增："Import from GitHub" 按钮 |
| `src/i18n/types.ts` + `en.ts` + `zh.ts` | 新增 9 个 i18n key |
| `src/styles/settings/agent.css` | 新增弹窗样式 |

## Test plan

- [x] `parseGitHubUrl` 单元测试：blob URL、repo URL、tree URL、.git 后缀、trailing slash、master 分支、非 GitHub URL、非 .md 文件（11 个用例全部通过）
- [x] 手动测试：从 `https://github.com/okooo5km/beautiful-mermaid-cli/tree/main/skills/beautiful-mermaid` 导入
- [x] 手动测试：从仓库根目录导入（含 SKILL.md）
- [x] 手动测试：导入单个 .md 文件
- [x] 手动测试：冲突覆盖确认弹窗
- [x] 手动测试：无效 URL / 网络错误提示