### PR TITLE
新增设置项控制侧边栏图标点击后 Chat 视图打开位置

### DIFF
--- a/src/components/settings/tabs/OthersTab.tsx
+++ b/src/components/settings/tabs/OthersTab.tsx
@@ -1,4 +1,4 @@
-import { App } from 'obsidian'
+import { App, Platform } from 'obsidian'
 
 import { useLanguage } from '../../../contexts/language-context'
 import { useSettings } from '../../../contexts/settings-context'
@@ -81,6 +81,7 @@ export function OthersTab({ app, plugin }: OthersTabProps) {
     ) {
       return
     }
+    if (value === 'window' && !Platform.isDesktop) return
     void (async () => {
       try {
         await setSettings({
@@ -162,7 +163,14 @@ export function OthersTab({ app, plugin }: OthersTabProps) {
                   ),
                   tab: t('settings.etc.ribbonClickActionTab', '新标签页'),
                   split: t('settings.etc.ribbonClickActionSplit', '右侧分屏'),
-                  window: t('settings.etc.ribbonClickActionWindow', '独立窗口'),
+                  ...(Platform.isDesktop
+                    ? {
+                        window: t(
+                          'settings.etc.ribbonClickActionWindow',
+                          '独立窗口',
+                        ),
+                      }
+                    : {}),
                   last: t('settings.etc.ribbonClickActionLast', '上次的位置'),
                 }}
                 onChange={handleRibbonClickActionChange}

--- a/src/components/settings/tabs/OthersTab.tsx
+++ b/src/components/settings/tabs/OthersTab.tsx
@@ -71,6 +71,31 @@ export function OthersTab({ app, plugin }: OthersTabProps) {
     })()
   }
 
+  const handleRibbonClickActionChange = (value: string) => {
+    if (
+      value !== 'sidebar' &&
+      value !== 'tab' &&
+      value !== 'split' &&
+      value !== 'window' &&
+      value !== 'last'
+    ) {
+      return
+    }
+    void (async () => {
+      try {
+        await setSettings({
+          ...settings,
+          chatOptions: {
+            ...settings.chatOptions,
+            ribbonClickAction: value,
+          },
+        })
+      } catch (error: unknown) {
+        console.error('Failed to update ribbon click action', error)
+      }
+    })()
+  }
+
   const handlePersistSelectionHighlightChange = (value: boolean) => {
     void (async () => {
       try {
@@ -120,6 +145,29 @@ export function OthersTab({ app, plugin }: OthersTabProps) {
           </div>
 
           <div className="yolo-settings-block-content">
+            <ObsidianSetting
+              name={t('settings.etc.ribbonClickAction', '侧边栏图标点击位置')}
+              desc={t(
+                'settings.etc.ribbonClickActionDesc',
+                '选择点击左侧边栏 YOLO 图标时，Chat 视图在哪里打开。若选定位置已有 Chat 视图会直接激活复用，否则新建。',
+              )}
+              className="yolo-settings-card"
+            >
+              <ObsidianDropdown
+                value={settings.chatOptions.ribbonClickAction ?? 'sidebar'}
+                options={{
+                  sidebar: t(
+                    'settings.etc.ribbonClickActionSidebar',
+                    '右侧边栏',
+                  ),
+                  tab: t('settings.etc.ribbonClickActionTab', '新标签页'),
+                  split: t('settings.etc.ribbonClickActionSplit', '右侧分屏'),
+                  window: t('settings.etc.ribbonClickActionWindow', '独立窗口'),
+                  last: t('settings.etc.ribbonClickActionLast', '上次的位置'),
+                }}
+                onChange={handleRibbonClickActionChange}
+              />
+            </ObsidianSetting>
             <ObsidianSetting
               name={t('settings.etc.mentionDisplayMode', '引用内容显示位置')}
               desc={t(

--- a/src/features/chat/chatViewNavigator.ts
+++ b/src/features/chat/chatViewNavigator.ts
@@ -81,6 +81,8 @@ export class ChatViewNavigator {
       return
     }
 
+    void this.persistLastChatPlacement(targetLeaf)
+
     if (!existingLeaf) {
       await this.activateChatLeaf(targetLeaf)
       return
@@ -107,6 +109,26 @@ export class ChatViewNavigator {
     }
 
     await this.activateChatLeaf(targetLeaf)
+  }
+
+  private async persistLastChatPlacement(leaf: WorkspaceLeaf): Promise<void> {
+    const placement =
+      this.plugin.getChatLeafSessionManager().getLeafPlacement(leaf) ??
+      this.plugin.getChatLeafSessionManager().inferLeafPlacement(leaf)
+    const current = this.plugin.settings.chatOptions.lastChatPlacement
+    if (current === placement) return
+
+    try {
+      await this.plugin.setSettings({
+        ...this.plugin.settings,
+        chatOptions: {
+          ...this.plugin.settings.chatOptions,
+          lastChatPlacement: placement,
+        },
+      })
+    } catch (error: unknown) {
+      console.error('Failed to persist lastChatPlacement', error)
+    }
   }
 
   async openChatInSidebar(openNewChat = false) {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1295,6 +1295,14 @@ export const en: TranslationKeys = {
       yoloBaseDirDesc:
         'Enter a vault-relative path (without a leading /). Example: use YOLO at vault root, or setting/YOLO under the setting folder. Current skills directory: {path}.',
       yoloBaseDirPlaceholder: 'YOLO',
+      ribbonClickAction: 'Ribbon icon opens chat in',
+      ribbonClickActionDesc:
+        'Where the YOLO ribbon icon opens the Chat view. If a chat already exists in the chosen location it is activated; otherwise a new one is created.',
+      ribbonClickActionSidebar: 'Right sidebar',
+      ribbonClickActionTab: 'New tab',
+      ribbonClickActionSplit: 'Right split',
+      ribbonClickActionWindow: 'New window',
+      ribbonClickActionLast: 'Last used location',
       mentionDisplayMode: 'Mention display position',
       mentionDisplayModeDesc:
         'Choose whether @ file mentions and / skill selections are shown inline in the editor or as badges above the input box.',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1242,6 +1242,14 @@ export const it: TranslationKeys = {
       yoloBaseDirDesc:
         'Inserisci un percorso relativo al vault (senza / iniziale). Esempio: YOLO nella radice del vault, oppure setting/YOLO nella cartella setting. Directory skill attuale: {path}.',
       yoloBaseDirPlaceholder: 'YOLO',
+      ribbonClickAction: 'Icona ribbon apre la chat in',
+      ribbonClickActionDesc:
+        'Dove l’icona ribbon di YOLO apre la vista Chat. Se nella posizione scelta esiste già una chat viene attivata; altrimenti ne viene creata una nuova.',
+      ribbonClickActionSidebar: 'Barra laterale destra',
+      ribbonClickActionTab: 'Nuova scheda',
+      ribbonClickActionSplit: 'Split destro',
+      ribbonClickActionWindow: 'Nuova finestra',
+      ribbonClickActionLast: 'Ultima posizione usata',
       mentionDisplayMode: 'Posizione visualizzazione mention',
       mentionDisplayModeDesc:
         "Scegli se mostrare i file selezionati con @ e le skill selezionate con / nel testo dell'input o come badge sopra la casella.",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -1194,6 +1194,14 @@ export const zh: TranslationKeys = {
       yoloBaseDirDesc:
         '填写库内相对路径（不要以 / 开头）。例如：放在库根目录填 YOLO；放在 setting 文件夹下填 setting/YOLO。当前技能目录：{path}。',
       yoloBaseDirPlaceholder: 'YOLO',
+      ribbonClickAction: '侧边栏图标点击位置',
+      ribbonClickActionDesc:
+        '选择点击左侧边栏 YOLO 图标时，Chat 视图在哪里打开。若选定位置已有 Chat 视图会直接激活复用，否则新建。',
+      ribbonClickActionSidebar: '右侧边栏',
+      ribbonClickActionTab: '新标签页',
+      ribbonClickActionSplit: '右侧分屏',
+      ribbonClickActionWindow: '独立窗口',
+      ribbonClickActionLast: '上次的位置',
       mentionDisplayMode: '引用内容显示位置',
       mentionDisplayModeDesc:
         '选择 @ 文件引用和 / 技能选择是在输入框内显示，还是在输入框顶部以徽章显示。',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1004,6 +1004,13 @@ export type TranslationKeys = {
       yoloBaseDir?: string
       yoloBaseDirDesc?: string
       yoloBaseDirPlaceholder?: string
+      ribbonClickAction?: string
+      ribbonClickActionDesc?: string
+      ribbonClickActionSidebar?: string
+      ribbonClickActionTab?: string
+      ribbonClickActionSplit?: string
+      ribbonClickActionWindow?: string
+      ribbonClickActionLast?: string
       mentionDisplayMode?: string
       mentionDisplayModeDesc?: string
       mentionDisplayModeInline?: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -1707,7 +1707,7 @@ export default class YoloPlugin extends Plugin {
 
     // This creates an icon in the left ribbon.
     this.addRibbonIcon('wand-sparkles', this.t('commands.openChat'), () => {
-      void this.openChatView({ placement: 'sidebar' })
+      void this.openChatView({ placement: this.resolveRibbonPlacement() })
     })
 
     this.setupBackgroundActivityStatusBar()
@@ -2580,6 +2580,15 @@ ${validationResult.error.issues.map((v) => v.message).join('\n')}`)
     forceNewLeaf?: boolean
   }) {
     await this.getChatViewNavigator().openChatView(options)
+  }
+
+  resolveRibbonPlacement(): ChatLeafPlacement {
+    const action = this.settings.chatOptions.ribbonClickAction ?? 'sidebar'
+    if (action === 'last') {
+      const last = this.settings.chatOptions.lastChatPlacement
+      return last ?? 'sidebar'
+    }
+    return action
   }
 
   async openCurrentOrSidebarNewChat() {

--- a/src/settings/schema/migrations/58_to_59.test.ts
+++ b/src/settings/schema/migrations/58_to_59.test.ts
@@ -1,0 +1,33 @@
+import { migrateFrom58To59 } from './58_to_59'
+
+describe('migrateFrom58To59', () => {
+  it('sets chatOptions.ribbonClickAction to "sidebar" when missing', () => {
+    const result = migrateFrom58To59({
+      version: 58,
+      chatOptions: { includeCurrentFileContent: true },
+    })
+
+    expect(result.version).toBe(59)
+    const chatOptions = result.chatOptions as Record<string, unknown>
+    expect(chatOptions.ribbonClickAction).toBe('sidebar')
+    expect(chatOptions.includeCurrentFileContent).toBe(true)
+  })
+
+  it('preserves an existing ribbonClickAction value', () => {
+    const result = migrateFrom58To59({
+      version: 58,
+      chatOptions: { ribbonClickAction: 'tab' },
+    })
+
+    const chatOptions = result.chatOptions as Record<string, unknown>
+    expect(chatOptions.ribbonClickAction).toBe('tab')
+  })
+
+  it('creates chatOptions when entirely absent', () => {
+    const result = migrateFrom58To59({ version: 58 })
+
+    expect(result.version).toBe(59)
+    const chatOptions = result.chatOptions as Record<string, unknown>
+    expect(chatOptions.ribbonClickAction).toBe('sidebar')
+  })
+})

--- a/src/settings/schema/migrations/58_to_59.ts
+++ b/src/settings/schema/migrations/58_to_59.ts
@@ -1,0 +1,21 @@
+import type { SettingMigration } from '../setting.types'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
+ * v58→v59: add `ribbonClickAction` so users can choose where the ribbon icon
+ * opens the Chat view (sidebar / tab / split / window / last). Default to
+ * `'sidebar'` to preserve existing behavior.
+ */
+export const migrateFrom58To59: SettingMigration['migrate'] = (data) => {
+  const next: Record<string, unknown> = { ...data, version: 59 }
+
+  const chatOptions = isRecord(next.chatOptions) ? { ...next.chatOptions } : {}
+  if (typeof chatOptions.ribbonClickAction !== 'string') {
+    chatOptions.ribbonClickAction = 'sidebar'
+  }
+  next.chatOptions = chatOptions
+
+  return next
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -53,13 +53,14 @@ import { migrateFrom54To55 } from './54_to_55'
 import { migrateFrom55To56 } from './55_to_56'
 import { migrateFrom56To57 } from './56_to_57'
 import { migrateFrom57To58 } from './57_to_58'
+import { migrateFrom58To59 } from './58_to_59'
 import { migrateFrom5To6 } from './5_to_6'
 import { migrateFrom6To7 } from './6_to_7'
 import { migrateFrom7To8 } from './7_to_8'
 import { migrateFrom8To9 } from './8_to_9'
 import { migrateFrom9To10 } from './9_to_10'
 
-export const SETTINGS_SCHEMA_VERSION = 58
+export const SETTINGS_SCHEMA_VERSION = 59
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -351,5 +352,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 57,
     toVersion: 58,
     migrate: migrateFrom57To58,
+  },
+  {
+    fromVersion: 58,
+    toVersion: 59,
+    migrate: migrateFrom58To59,
   },
 ]

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -376,6 +376,15 @@ export const yoloSettingsSchema = z.object({
       imageCompressionQuality: z.number().min(1).max(100).optional(),
       // Fetch external (http/https) image URLs referenced in Markdown
       externalImageFetchEnabled: z.boolean().optional(),
+      // Where the ribbon icon should open the Chat view
+      ribbonClickAction: z
+        .enum(['sidebar', 'tab', 'split', 'window', 'last'])
+        .optional(),
+      // Last placement actually used to open a chat leaf; only consulted when
+      // `ribbonClickAction === 'last'`
+      lastChatPlacement: z
+        .enum(['sidebar', 'tab', 'split', 'window'])
+        .optional(),
     })
     .catch({
       includeCurrentFileContent: true,
@@ -398,6 +407,8 @@ export const yoloSettingsSchema = z.object({
       imageCompressionEnabled: true,
       imageCompressionQuality: 85,
       externalImageFetchEnabled: false,
+      ribbonClickAction: 'sidebar',
+      lastChatPlacement: undefined,
     }),
 
   notificationOptions: notificationOptionsSchema,


### PR DESCRIPTION
支持「右侧边栏 / 新标签页 / 右侧分屏 / 独立窗口 / 上次位置」5 种选择，默认保持原行为（右侧边栏）。每次成功打开 Chat 时把实际 placement 写入 lastChatPlacement，作为「上次位置」的依据。