### PR TITLE
新增 chatExport 设置 schema 与 58→59 迁移

### DIFF
--- a/src/components/settings/sections/ChatPreferencesSection.tsx
+++ b/src/components/settings/sections/ChatPreferencesSection.tsx
@@ -1,7 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { useLanguage } from '../../../contexts/language-context'
+import { usePlugin } from '../../../contexts/plugin-context'
 import { useSettings } from '../../../contexts/settings-context'
+import { readUniqueNoteConfig } from '../../../utils/obsidian/unique-note'
+import { ObsidianDropdown } from '../../common/ObsidianDropdown'
 import { ObsidianSetting } from '../../common/ObsidianSetting'
 import { ObsidianTextInput } from '../../common/ObsidianTextInput'
 import { ObsidianToggle } from '../../common/ObsidianToggle'
@@ -21,6 +24,7 @@ export function ChatPreferencesSection({
 }: ChatPreferencesSectionProps) {
   const { settings, setSettings } = useSettings()
   const { t } = useLanguage()
+  const plugin = usePlugin()
   const [historyArchiveThresholdInput, setHistoryArchiveThresholdInput] =
     useState(
       String(
@@ -56,6 +60,34 @@ export function ChatPreferencesSection({
       }
     })()
   }
+
+  const updateChatExport = (
+    patch: Partial<typeof settings.chatExport>,
+    context: string,
+  ) => {
+    void (async () => {
+      try {
+        await setSettings({
+          ...settings,
+          chatExport: {
+            ...settings.chatExport,
+            ...patch,
+          },
+        })
+      } catch (error: unknown) {
+        console.error(`Failed to update chat export options: ${context}`, error)
+      }
+    })()
+  }
+
+  const uniqueNoteConfig = useMemo(
+    () => readUniqueNoteConfig(plugin.app),
+    [plugin, settings.chatExport.followUniqueNote],
+  )
+  const uniqueNoteAvailable =
+    uniqueNoteConfig !== null && uniqueNoteConfig.enabled
+  const followingUniqueNote =
+    settings.chatExport.followUniqueNote && uniqueNoteAvailable
 
   const settingsContent = (
     <>
@@ -127,6 +159,106 @@ export function ChatPreferencesSection({
                 },
                 'historyArchiveThreshold',
               )
+            }
+          }}
+        />
+      </ObsidianSetting>
+
+      <ObsidianSetting
+        name={t('settings.chatPreferences.chatExport.followUniqueNote')}
+        desc={
+          settings.chatExport.followUniqueNote && !uniqueNoteAvailable
+            ? t(
+                'settings.chatPreferences.chatExport.followUniqueNoteUnavailable',
+              )
+            : t('settings.chatPreferences.chatExport.followUniqueNoteDesc')
+        }
+        className="yolo-settings-card"
+      >
+        <ObsidianToggle
+          value={settings.chatExport.followUniqueNote}
+          onChange={(value) => {
+            updateChatExport({ followUniqueNote: value }, 'followUniqueNote')
+          }}
+        />
+      </ObsidianSetting>
+
+      <ObsidianSetting
+        name={t('settings.chatPreferences.chatExport.folder')}
+        desc={t('settings.chatPreferences.chatExport.folderDesc')}
+        className="yolo-settings-card"
+      >
+        <ObsidianTextInput
+          value={settings.chatExport.folder ?? ''}
+          placeholder="YOLO/Exports"
+          disabled={followingUniqueNote}
+          onChange={(value) => {
+            updateChatExport({ folder: value }, 'folder')
+          }}
+        />
+      </ObsidianSetting>
+
+      <ObsidianSetting
+        name={t('settings.chatPreferences.chatExport.filenameTemplate')}
+        desc={
+          followingUniqueNote && uniqueNoteConfig
+            ? `${t(
+                'settings.chatPreferences.chatExport.filenameTemplateFollowing',
+              )} ${uniqueNoteConfig.format}`
+            : t('settings.chatPreferences.chatExport.filenameTemplateDesc')
+        }
+        className="yolo-settings-card"
+      >
+        <ObsidianTextInput
+          value={settings.chatExport.filenameTemplate ?? ''}
+          placeholder="{{title}} - {{date}}"
+          disabled={followingUniqueNote}
+          onChange={(value) => {
+            updateChatExport({ filenameTemplate: value }, 'filenameTemplate')
+          }}
+        />
+      </ObsidianSetting>
+
+      {settings.chatExport.followUniqueNote ? (
+        <ObsidianSetting
+          name={t(
+            'settings.chatPreferences.chatExport.appendTitleWhenFollowing',
+          )}
+          desc={t(
+            'settings.chatPreferences.chatExport.appendTitleWhenFollowingDesc',
+          )}
+          className="yolo-settings-card"
+        >
+          <ObsidianToggle
+            value={settings.chatExport.appendTitleWhenFollowing}
+            onChange={(value) => {
+              updateChatExport(
+                { appendTitleWhenFollowing: value },
+                'appendTitleWhenFollowing',
+              )
+            }}
+          />
+        </ObsidianSetting>
+      ) : null}
+
+      <ObsidianSetting
+        name={t('settings.chatPreferences.chatExport.conflictStrategy')}
+        desc={t('settings.chatPreferences.chatExport.conflictStrategyDesc')}
+        className="yolo-settings-card"
+      >
+        <ObsidianDropdown
+          value={settings.chatExport.conflictStrategy}
+          options={{
+            suffix: t(
+              'settings.chatPreferences.chatExport.conflictStrategySuffix',
+            ),
+            overwrite: t(
+              'settings.chatPreferences.chatExport.conflictStrategyOverwrite',
+            ),
+          }}
+          onChange={(value) => {
+            if (value === 'suffix' || value === 'overwrite') {
+              updateChatExport({ conflictStrategy: value }, 'conflictStrategy')
             }
           }}
         />

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -276,6 +276,29 @@ export const en: TranslationKeys = {
       historyArchiveThreshold: 'Recent conversation limit',
       historyArchiveThresholdDesc:
         'Number of latest non-pinned conversations shown before archiving the rest (20-500).',
+      chatExport: {
+        followUniqueNote: 'Follow "Unique note creator"',
+        followUniqueNoteDesc:
+          'Reuse the folder and filename format configured in the core "Unique note creator" plugin.',
+        followUniqueNoteUnavailable:
+          'Core plugin "Unique note creator" is not enabled — falling back to the custom settings below.',
+        folder: 'Export folder',
+        folderDesc:
+          'Path relative to the vault root. Leave empty to use the default {baseDir}/Exports.',
+        filenameTemplate: 'Filename template',
+        filenameTemplateDesc:
+          'Placeholders: {{title}}, {{date}}, {{time}}, {{datetime}}, {{timestamp}}. Custom formats like {{date:YYYYMM}} are supported.',
+        filenameTemplateFollowing:
+          'Using the date format from "Unique note creator":',
+        appendTitleWhenFollowing: 'Append conversation title',
+        appendTitleWhenFollowingDesc:
+          'When on, filenames become "timestamp_title"; when off, only the timestamp is used (matching the official plugin).',
+        conflictStrategy: 'Filename conflict handling',
+        conflictStrategyDesc:
+          'How to handle the case when a file with the same name already exists.',
+        conflictStrategySuffix: 'Append a counter (2), (3)…',
+        conflictStrategyOverwrite: 'Overwrite existing file',
+      },
     },
     assistants: {
       title: 'Assistants',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -275,6 +275,29 @@ export const it: TranslationKeys = {
       historyArchiveThreshold: 'Limite conversazioni recenti',
       historyArchiveThresholdDesc:
         'Numero di conversazioni non appuntate recenti da mostrare prima di archiviare le altre (20-500).',
+      chatExport: {
+        followUniqueNote: 'Segui "Generatore di note timestamp"',
+        followUniqueNoteDesc:
+          'Riusa la cartella e il formato del nome file configurati nel plugin core "Unique note creator".',
+        followUniqueNoteUnavailable:
+          'Il plugin core "Unique note creator" non è attivo — verrà usata la configurazione personalizzata qui sotto.',
+        folder: 'Cartella di esportazione',
+        folderDesc:
+          'Percorso relativo alla radice del vault. Lascia vuoto per usare il valore predefinito {baseDir}/Exports.',
+        filenameTemplate: 'Modello nome file',
+        filenameTemplateDesc:
+          'Segnaposto: {{title}}, {{date}}, {{time}}, {{datetime}}, {{timestamp}}. Sono supportati formati come {{date:YYYYMM}}.',
+        filenameTemplateFollowing:
+          'Verrà usato il formato data di "Unique note creator":',
+        appendTitleWhenFollowing: 'Aggiungi il titolo della conversazione',
+        appendTitleWhenFollowingDesc:
+          'Se attivo, il nome file diventa "timestamp_titolo"; se disattivo, viene usato solo il timestamp (come il plugin ufficiale).',
+        conflictStrategy: 'Gestione conflitti nome file',
+        conflictStrategyDesc:
+          'Come gestire il caso in cui esista già un file con lo stesso nome.',
+        conflictStrategySuffix: 'Aggiungi un contatore (2), (3)…',
+        conflictStrategyOverwrite: 'Sovrascrivi il file esistente',
+      },
     },
     assistants: {
       title: 'Assistenti',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -241,6 +241,27 @@ export const zh: TranslationKeys = {
       historyArchiveThreshold: '近期会话数量',
       historyArchiveThresholdDesc:
         '超过该数量的未置顶会话会进入归档（20-500）。',
+      chatExport: {
+        followUniqueNote: '跟随"时间戳笔记生成器"',
+        followUniqueNoteDesc:
+          '复用 Obsidian 核心插件「时间戳笔记生成器」的输出文件夹和文件名格式。',
+        followUniqueNoteUnavailable:
+          '核心插件「时间戳笔记生成器」未启用，将回退到下方自定义设置。',
+        folder: '导出文件夹',
+        folderDesc:
+          '相对于库根目录的路径，留空则使用默认位置 {baseDir}/Exports。',
+        filenameTemplate: '文件名模板',
+        filenameTemplateDesc:
+          '可用占位符：{{title}}、{{date}}、{{time}}、{{datetime}}、{{timestamp}}；支持 {{date:YYYYMM}} 等自定义格式。',
+        filenameTemplateFollowing: '将使用「时间戳笔记生成器」的时间格式：',
+        appendTitleWhenFollowing: '跟随时附加会话标题',
+        appendTitleWhenFollowingDesc:
+          '开启后文件名形如「时间戳_会话标题」；关闭则只用时间戳，与官方插件完全一致。',
+        conflictStrategy: '同名冲突处理',
+        conflictStrategyDesc: '当目标文件夹已存在同名文件时的处理方式。',
+        conflictStrategySuffix: '追加序号 (2)、(3)…',
+        conflictStrategyOverwrite: '覆盖现有文件',
+      },
     },
     assistants: {
       title: '助手',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -165,6 +165,22 @@ export type TranslationKeys = {
       historyArchiveEnabledDesc?: string
       historyArchiveThreshold?: string
       historyArchiveThresholdDesc?: string
+      chatExport?: {
+        followUniqueNote?: string
+        followUniqueNoteDesc?: string
+        followUniqueNoteUnavailable?: string
+        folder?: string
+        folderDesc?: string
+        filenameTemplate?: string
+        filenameTemplateDesc?: string
+        filenameTemplateFollowing?: string
+        appendTitleWhenFollowing?: string
+        appendTitleWhenFollowingDesc?: string
+        conflictStrategy?: string
+        conflictStrategyDesc?: string
+        conflictStrategySuffix?: string
+        conflictStrategyOverwrite?: string
+      }
     }
     assistants: {
       title: string

--- a/src/settings/schema/migrations/58_to_59.test.ts
+++ b/src/settings/schema/migrations/58_to_59.test.ts
@@ -1,0 +1,55 @@
+import { migrateFrom58To59 } from './58_to_59'
+
+describe('Migration from v58 to v59', () => {
+  it('seeds default chatExport when absent', () => {
+    const oldSettings = { version: 58 }
+    const result = migrateFrom58To59(oldSettings)
+    expect(result.version).toBe(59)
+    expect(result.chatExport).toEqual({
+      followUniqueNote: false,
+      folder: '',
+      filenameTemplate: '{{title}} - {{date}}',
+      appendTitleWhenFollowing: true,
+      conflictStrategy: 'suffix',
+    })
+  })
+
+  it('preserves an already-set chatExport object', () => {
+    const oldSettings = {
+      version: 58,
+      chatExport: {
+        followUniqueNote: true,
+        folder: 'Inbox/Chats',
+        filenameTemplate: 'Chat_{{datetime}}',
+        appendTitleWhenFollowing: false,
+        conflictStrategy: 'overwrite',
+      },
+    }
+    const result = migrateFrom58To59(oldSettings)
+    expect(result.version).toBe(59)
+    expect(result.chatExport).toEqual(oldSettings.chatExport)
+  })
+
+  it('overwrites a non-object chatExport value with defaults', () => {
+    const oldSettings = { version: 58, chatExport: 'invalid' }
+    const result = migrateFrom58To59(oldSettings)
+    expect(result.chatExport).toEqual({
+      followUniqueNote: false,
+      folder: '',
+      filenameTemplate: '{{title}} - {{date}}',
+      appendTitleWhenFollowing: true,
+      conflictStrategy: 'suffix',
+    })
+  })
+
+  it('keeps unrelated fields untouched', () => {
+    const oldSettings = {
+      version: 58,
+      yolo: { baseDir: 'MyVault' },
+      providers: [{ id: 'openai' }],
+    }
+    const result = migrateFrom58To59(oldSettings)
+    expect(result.yolo).toEqual({ baseDir: 'MyVault' })
+    expect(result.providers).toEqual([{ id: 'openai' }])
+  })
+})

--- a/src/settings/schema/migrations/58_to_59.ts
+++ b/src/settings/schema/migrations/58_to_59.ts
@@ -1,0 +1,26 @@
+import type { SettingMigration } from '../setting.types'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+/**
+ * v58→v59: introduce `chatExport` for per-user chat export folder/filename
+ * configuration, including optional sync with Obsidian's core `unique-note`
+ * plugin. Older settings have no such field; seed safe defaults so existing
+ * exports keep landing at `{baseDir}/Exports/{title} - YYYY-MM-DD.md`.
+ */
+export const migrateFrom58To59: SettingMigration['migrate'] = (data) => {
+  const next: Record<string, unknown> = { ...data, version: 59 }
+
+  if (!isRecord(next.chatExport)) {
+    next.chatExport = {
+      followUniqueNote: false,
+      folder: '',
+      filenameTemplate: '{{title}} - {{date}}',
+      appendTitleWhenFollowing: true,
+      conflictStrategy: 'suffix',
+    }
+  }
+
+  return next
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -53,13 +53,14 @@ import { migrateFrom54To55 } from './54_to_55'
 import { migrateFrom55To56 } from './55_to_56'
 import { migrateFrom56To57 } from './56_to_57'
 import { migrateFrom57To58 } from './57_to_58'
+import { migrateFrom58To59 } from './58_to_59'
 import { migrateFrom5To6 } from './5_to_6'
 import { migrateFrom6To7 } from './6_to_7'
 import { migrateFrom7To8 } from './7_to_8'
 import { migrateFrom8To9 } from './8_to_9'
 import { migrateFrom9To10 } from './9_to_10'
 
-export const SETTINGS_SCHEMA_VERSION = 58
+export const SETTINGS_SCHEMA_VERSION = 59
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -351,5 +352,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 57,
     toVersion: 58,
     migrate: migrateFrom57To58,
+  },
+  {
+    fromVersion: 58,
+    toVersion: 59,
+    migrate: migrateFrom58To59,
   },
 ]

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -332,6 +332,23 @@ export const yoloSettingsSchema = z.object({
       baseDir: 'YOLO',
     }),
 
+  // Chat conversation export configuration
+  chatExport: z
+    .object({
+      followUniqueNote: z.boolean().catch(false),
+      folder: z.string().catch(''),
+      filenameTemplate: z.string().catch('{{title}} - {{date}}'),
+      appendTitleWhenFollowing: z.boolean().catch(true),
+      conflictStrategy: z.enum(['suffix', 'overwrite']).catch('suffix'),
+    })
+    .catch({
+      followUniqueNote: false,
+      folder: '',
+      filenameTemplate: '{{title}} - {{date}}',
+      appendTitleWhenFollowing: true,
+      conflictStrategy: 'suffix',
+    }),
+
   debug: z
     .object({
       captureRawRequestDebug: z.boolean().optional(),

--- a/src/types/obsidian-internal.d.ts
+++ b/src/types/obsidian-internal.d.ts
@@ -1,0 +1,18 @@
+import 'obsidian'
+
+declare module 'obsidian' {
+  interface App {
+    internalPlugins?: {
+      getPluginById?: (id: string) => InternalPluginInstance | null
+      plugins?: Record<string, InternalPluginInstance | undefined>
+    }
+  }
+}
+
+type InternalPluginInstance = {
+  enabled?: boolean
+  _loaded?: boolean
+  instance?: {
+    options?: Record<string, unknown>
+  }
+}

--- a/src/types/obsidian-internal.d.ts
+++ b/src/types/obsidian-internal.d.ts
@@ -1,6 +1,7 @@
 import 'obsidian'
 
 declare module 'obsidian' {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- module augmentation requires interface
   interface App {
     internalPlugins?: {
       getPluginById?: (id: string) => InternalPluginInstance | null

--- a/src/utils/chat/exportConversation.test.ts
+++ b/src/utils/chat/exportConversation.test.ts
@@ -13,7 +13,10 @@ type UniqueNoteOptions = {
   format?: string
 }
 
-function makeApp(unique?: { enabled: boolean; options?: UniqueNoteOptions }): App {
+function makeApp(unique?: {
+  enabled: boolean
+  options?: UniqueNoteOptions
+}): App {
   if (!unique) return {} as App
   return {
     internalPlugins: {
@@ -110,8 +113,9 @@ describe('renderFilenameTemplate', () => {
   const date = new Date(2026, 4, 21, 17, 14, 30) // 2026-05-21 17:14:30
 
   it('renders title and default date/time', () => {
-    expect(renderFilenameTemplate('{{title}} - {{date}}', { title: 'Foo', date }))
-      .toBe('Foo - 2026-05-21')
+    expect(
+      renderFilenameTemplate('{{title}} - {{date}}', { title: 'Foo', date }),
+    ).toBe('Foo - 2026-05-21')
     expect(renderFilenameTemplate('{{time}}', { title: 'x', date })).toBe(
       '171430',
     )
@@ -130,9 +134,9 @@ describe('renderFilenameTemplate', () => {
     expect(renderFilenameTemplate('{{datetime}}', { title: 'x', date })).toBe(
       '2026-05-21_171430',
     )
-    expect(
-      renderFilenameTemplate('{{timestamp}}', { title: 'x', date }),
-    ).toBe(String(Math.floor(date.getTime() / 1000)))
+    expect(renderFilenameTemplate('{{timestamp}}', { title: 'x', date })).toBe(
+      String(Math.floor(date.getTime() / 1000)),
+    )
   })
 
   it('falls back to default template on empty input', () => {
@@ -187,7 +191,6 @@ describe('buildExportFileBaseName', () => {
 })
 
 describe('conversationToMarkdown', () => {
-
   it('renders assistant thinking before the final response content', () => {
     const markdown = conversationToMarkdown(
       {

--- a/src/utils/chat/exportConversation.test.ts
+++ b/src/utils/chat/exportConversation.test.ts
@@ -1,19 +1,192 @@
+import type { App } from 'obsidian'
+
 import {
+  applyDateTokens,
+  buildExportFileBaseName,
   conversationToMarkdown,
   getChatExportFolderPath,
+  renderFilenameTemplate,
 } from './exportConversation'
 
-describe('conversationToMarkdown', () => {
-  it('uses the yolo base directory for exported chat files', () => {
-    expect(getChatExportFolderPath()).toBe('YOLO/Exports')
+type UniqueNoteOptions = {
+  folder?: string
+  format?: string
+}
+
+function makeApp(unique?: { enabled: boolean; options?: UniqueNoteOptions }): App {
+  if (!unique) return {} as App
+  return {
+    internalPlugins: {
+      getPluginById: (id: string) =>
+        id === 'unique-note'
+          ? {
+              enabled: unique.enabled,
+              instance: { options: unique.options ?? {} },
+            }
+          : null,
+    },
+  } as unknown as App
+}
+
+describe('getChatExportFolderPath', () => {
+  it('defaults to {baseDir}/Exports when no chatExport config is provided', () => {
+    expect(getChatExportFolderPath(makeApp())).toBe('YOLO/Exports')
     expect(
-      getChatExportFolderPath({
-        yolo: {
-          baseDir: 'Config/YOLO',
-        },
+      getChatExportFolderPath(makeApp(), {
+        yolo: { baseDir: 'Config/YOLO' },
       }),
     ).toBe('Config/YOLO/Exports')
   })
+
+  it('honors a custom chatExport.folder over the default', () => {
+    expect(
+      getChatExportFolderPath(makeApp(), {
+        chatExport: { folder: 'Inbox/Chats' },
+      }),
+    ).toBe('Inbox/Chats')
+  })
+
+  it('strips leading/trailing slashes from a custom folder', () => {
+    expect(
+      getChatExportFolderPath(makeApp(), {
+        chatExport: { folder: '/Inbox/Chats/' },
+      }),
+    ).toBe('Inbox/Chats')
+  })
+
+  it('reads unique-note folder when followUniqueNote is on and plugin enabled', () => {
+    const app = makeApp({
+      enabled: true,
+      options: { folder: 'Daily', format: 'YYYY-MM-DD HHmm' },
+    })
+    expect(
+      getChatExportFolderPath(app, {
+        chatExport: { followUniqueNote: true, folder: 'Inbox/Chats' },
+      }),
+    ).toBe('Daily')
+  })
+
+  it('falls back to custom folder when followUniqueNote is on but plugin disabled', () => {
+    const app = makeApp({ enabled: false })
+    expect(
+      getChatExportFolderPath(app, {
+        chatExport: { followUniqueNote: true, folder: 'Inbox/Chats' },
+      }),
+    ).toBe('Inbox/Chats')
+  })
+
+  it('returns "/" when unique-note folder is empty (vault root)', () => {
+    const app = makeApp({
+      enabled: true,
+      options: { folder: '', format: 'YYYYMMDDHHmmss' },
+    })
+    expect(
+      getChatExportFolderPath(app, {
+        chatExport: { followUniqueNote: true },
+      }),
+    ).toBe('/')
+  })
+})
+
+describe('applyDateTokens', () => {
+  const date = new Date(2026, 4, 21, 17, 14, 30, 7) // 2026-05-21 17:14:30.007
+
+  it('replaces year/month/day/hour/minute/second tokens', () => {
+    expect(applyDateTokens('YYYY-MM-DD HH:mm:ss', date)).toBe(
+      '2026-05-21 17:14:30',
+    )
+  })
+
+  it('supports YY 2-digit year and SSS milliseconds', () => {
+    expect(applyDateTokens('YY/SSS', date)).toBe('26/007')
+  })
+
+  it('leaves non-token characters intact', () => {
+    expect(applyDateTokens('YYYY_MM-DD', date)).toBe('2026_05-21')
+  })
+})
+
+describe('renderFilenameTemplate', () => {
+  const date = new Date(2026, 4, 21, 17, 14, 30) // 2026-05-21 17:14:30
+
+  it('renders title and default date/time', () => {
+    expect(renderFilenameTemplate('{{title}} - {{date}}', { title: 'Foo', date }))
+      .toBe('Foo - 2026-05-21')
+    expect(renderFilenameTemplate('{{time}}', { title: 'x', date })).toBe(
+      '171430',
+    )
+  })
+
+  it('honors {{date:FMT}} and {{time:FMT}} arguments', () => {
+    expect(
+      renderFilenameTemplate('{{date:YYYYMM}}-{{time:HHmm}}', {
+        title: 'x',
+        date,
+      }),
+    ).toBe('202605-1714')
+  })
+
+  it('supports {{datetime}} and {{timestamp}} shortcuts', () => {
+    expect(renderFilenameTemplate('{{datetime}}', { title: 'x', date })).toBe(
+      '2026-05-21_171430',
+    )
+    expect(
+      renderFilenameTemplate('{{timestamp}}', { title: 'x', date }),
+    ).toBe(String(Math.floor(date.getTime() / 1000)))
+  })
+
+  it('falls back to default template on empty input', () => {
+    expect(renderFilenameTemplate('', { title: 'Foo', date })).toBe(
+      'Foo - 2026-05-21',
+    )
+  })
+
+  it('drops unknown placeholders to keep filenames clean', () => {
+    expect(
+      renderFilenameTemplate('{{title}}{{unknown}}', { title: 'Foo', date }),
+    ).toBe('Foo')
+  })
+})
+
+describe('buildExportFileBaseName', () => {
+  const date = new Date(2026, 4, 21, 17, 14, 30)
+
+  it('uses the template when no unique-note format is provided', () => {
+    expect(
+      buildExportFileBaseName('Hello', date, {
+        template: '{{title}} - {{date}}',
+      }),
+    ).toBe('Hello - 2026-05-21')
+  })
+
+  it('renders unique-note format alone when appendTitle is false', () => {
+    expect(
+      buildExportFileBaseName('Hello', date, {
+        uniqueNoteFormat: 'YYYYMMDDHHmmss',
+        appendTitleWhenFollowing: false,
+      }),
+    ).toBe('20260521171430')
+  })
+
+  it('appends title when appendTitleWhenFollowing is true', () => {
+    expect(
+      buildExportFileBaseName('Hello', date, {
+        uniqueNoteFormat: 'YYYYMMDDHHmmss',
+        appendTitleWhenFollowing: true,
+      }),
+    ).toBe('20260521171430_Hello')
+  })
+
+  it('sanitizes illegal filename characters', () => {
+    expect(
+      buildExportFileBaseName('Foo/Bar:Baz', date, {
+        template: '{{title}}',
+      }),
+    ).toBe('Foo_Bar_Baz')
+  })
+})
+
+describe('conversationToMarkdown', () => {
 
   it('renders assistant thinking before the final response content', () => {
     const markdown = conversationToMarkdown(

--- a/src/utils/chat/exportConversation.ts
+++ b/src/utils/chat/exportConversation.ts
@@ -1,5 +1,5 @@
 import type { App } from 'obsidian'
-import { TFolder, normalizePath } from 'obsidian'
+import { TFile, TFolder, normalizePath } from 'obsidian'
 
 import { editorStateToPlainText } from '../../components/chat-view/chat-input/utils/editor-state-to-plain-text'
 import type { ChatManager } from '../../database/json/chat/ChatManager'
@@ -19,10 +19,20 @@ import {
   ToolCallResponseStatus,
   getToolCallArgumentsText,
 } from '../../types/tool-call.types'
+import { readUniqueNoteConfig } from '../obsidian/unique-note'
+
+type ChatExportConflictStrategy = 'suffix' | 'overwrite'
 
 type YoloSettingsLike = {
   yolo?: {
     baseDir?: string
+  }
+  chatExport?: {
+    followUniqueNote?: boolean
+    folder?: string
+    filenameTemplate?: string
+    appendTitleWhenFollowing?: boolean
+    conflictStrategy?: ChatExportConflictStrategy
   }
 }
 
@@ -69,8 +79,78 @@ function formatDateYmd(date: Date): string {
   return `${y}-${m}-${d}`
 }
 
-export function buildExportFileBaseName(title: string, date: Date): string {
-  return `${sanitizeExportFileBaseName(title)} - ${formatDateYmd(date)}`
+const DATE_TOKEN_PATTERN = /YYYY|YY|MM|DD|HH|mm|ss|SSS/g
+
+export function applyDateTokens(fmt: string, date: Date): string {
+  const tokens: Record<string, string> = {
+    YYYY: String(date.getFullYear()),
+    YY: String(date.getFullYear()).slice(-2),
+    MM: String(date.getMonth() + 1).padStart(2, '0'),
+    DD: String(date.getDate()).padStart(2, '0'),
+    HH: String(date.getHours()).padStart(2, '0'),
+    mm: String(date.getMinutes()).padStart(2, '0'),
+    ss: String(date.getSeconds()).padStart(2, '0'),
+    SSS: String(date.getMilliseconds()).padStart(3, '0'),
+  }
+  return fmt.replace(DATE_TOKEN_PATTERN, (token) => tokens[token] ?? token)
+}
+
+const TEMPLATE_PLACEHOLDER_PATTERN = /\{\{\s*([a-zA-Z]+)(?::([^}]+))?\s*\}\}/g
+const DEFAULT_FILENAME_TEMPLATE = '{{title}} - {{date}}'
+const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD'
+const DEFAULT_TIME_FORMAT = 'HHmmss'
+
+export function renderFilenameTemplate(
+  template: string,
+  ctx: { title: string; date: Date },
+): string {
+  const effective = template?.trim() ? template : DEFAULT_FILENAME_TEMPLATE
+  return effective.replace(
+    TEMPLATE_PLACEHOLDER_PATTERN,
+    (_match, rawName: string, rawArg?: string) => {
+      const name = rawName.toLowerCase()
+      const arg = rawArg?.trim()
+      switch (name) {
+        case 'title':
+          return ctx.title
+        case 'date':
+          return applyDateTokens(arg && arg.length > 0 ? arg : DEFAULT_DATE_FORMAT, ctx.date)
+        case 'time':
+          return applyDateTokens(arg && arg.length > 0 ? arg : DEFAULT_TIME_FORMAT, ctx.date)
+        case 'datetime':
+          return `${applyDateTokens(DEFAULT_DATE_FORMAT, ctx.date)}_${applyDateTokens(DEFAULT_TIME_FORMAT, ctx.date)}`
+        case 'timestamp':
+          return String(Math.floor(ctx.date.getTime() / 1000))
+        default:
+          return ''
+      }
+    },
+  )
+}
+
+export type BuildExportFileBaseNameOptions = {
+  template?: string
+  uniqueNoteFormat?: string | null
+  appendTitleWhenFollowing?: boolean
+}
+
+export function buildExportFileBaseName(
+  title: string,
+  date: Date,
+  options: BuildExportFileBaseNameOptions = {},
+): string {
+  const { template, uniqueNoteFormat, appendTitleWhenFollowing } = options
+
+  if (uniqueNoteFormat) {
+    const datePart = applyDateTokens(uniqueNoteFormat, date)
+    const raw = appendTitleWhenFollowing
+      ? `${datePart}_${title}`
+      : datePart
+    return sanitizeExportFileBaseName(raw)
+  }
+
+  const rendered = renderFilenameTemplate(template ?? '', { title, date })
+  return sanitizeExportFileBaseName(rendered)
 }
 
 function yamlDoubleQuotedString(value: string): string {
@@ -578,11 +658,36 @@ export type ExportChatConversationParams = {
   settings?: YoloSettingsLike | null
 }
 
+function cleanFolderPath(input: string): string {
+  return input.replace(/^\/+/, '').replace(/\/+$/, '')
+}
+
+function defaultExportFolderPath(settings?: YoloSettingsLike | null): string {
+  const baseDir = settings?.yolo?.baseDir?.trim() || 'YOLO'
+  return normalizePath(`${cleanFolderPath(baseDir)}/Exports`)
+}
+
 export function getChatExportFolderPath(
+  app: App,
   settings?: YoloSettingsLike | null,
 ): string {
-  const baseDir = settings?.yolo?.baseDir?.trim() || 'YOLO'
-  return normalizePath(`${baseDir.replace(/^\/+/, '')}/Exports`)
+  const cfg = settings?.chatExport
+
+  if (cfg?.followUniqueNote) {
+    const unique = readUniqueNoteConfig(app)
+    if (unique?.enabled) {
+      const folder = cleanFolderPath(unique.folder ?? '')
+      return folder.length > 0 ? normalizePath(folder) : '/'
+    }
+  }
+
+  const customFolder = cfg?.folder?.trim()
+  if (customFolder) {
+    const folder = cleanFolderPath(customFolder)
+    return folder.length > 0 ? normalizePath(folder) : '/'
+  }
+
+  return defaultExportFolderPath(settings)
 }
 
 /**
@@ -592,7 +697,7 @@ export async function exportChatConversationToVault(
   params: ExportChatConversationParams,
 ): Promise<{ path: string }> {
   const { app, chatManager, conversationId, settings } = params
-  const folderPath = getChatExportFolderPath(settings)
+  const folderPath = getChatExportFolderPath(app, settings)
 
   const conversation = await chatManager.findById(conversationId)
   if (!conversation) {
@@ -612,9 +717,37 @@ export async function exportChatConversationToVault(
 
   await ensureDirectoryPathExists(app, folderPath)
 
-  const baseName = buildExportFileBaseName(conversation.title, new Date())
-  const filePath = await resolveUniqueMarkdownPath(app, folderPath, baseName)
+  const cfg = settings?.chatExport
+  const followUnique = cfg?.followUniqueNote === true
+  const uniqueFormat = followUnique
+    ? readUniqueNoteConfig(app)?.format ?? null
+    : null
 
+  const baseName = buildExportFileBaseName(conversation.title, new Date(), {
+    template: cfg?.filenameTemplate,
+    uniqueNoteFormat: followUnique && uniqueFormat ? uniqueFormat : null,
+    appendTitleWhenFollowing: cfg?.appendTitleWhenFollowing ?? true,
+  })
+
+  const conflictStrategy: ChatExportConflictStrategy =
+    cfg?.conflictStrategy ?? 'suffix'
+
+  if (conflictStrategy === 'overwrite') {
+    const sanitizedBase = sanitizeExportFileBaseName(baseName)
+    const candidate = normalizePath(`${folderPath}/${sanitizedBase}.md`)
+    const existing = app.vault.getAbstractFileByPath(candidate)
+    if (existing) {
+      if (existing instanceof TFile) {
+        await app.vault.modify(existing, markdown)
+        return { path: candidate }
+      }
+      throw new Error(`Export target exists and is not a file: ${candidate}`)
+    }
+    await app.vault.create(candidate, markdown)
+    return { path: candidate }
+  }
+
+  const filePath = await resolveUniqueMarkdownPath(app, folderPath, baseName)
   await app.vault.create(filePath, markdown)
 
   return { path: filePath }

--- a/src/utils/chat/exportConversation.ts
+++ b/src/utils/chat/exportConversation.ts
@@ -72,13 +72,6 @@ export function sanitizeExportFileBaseName(raw: string): string {
   return collapsed.length > 0 ? collapsed : 'chat'
 }
 
-function formatDateYmd(date: Date): string {
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  return `${y}-${m}-${d}`
-}
-
 const DATE_TOKEN_PATTERN = /YYYY|YY|MM|DD|HH|mm|ss|SSS/g
 
 export function applyDateTokens(fmt: string, date: Date): string {
@@ -114,9 +107,15 @@ export function renderFilenameTemplate(
         case 'title':
           return ctx.title
         case 'date':
-          return applyDateTokens(arg && arg.length > 0 ? arg : DEFAULT_DATE_FORMAT, ctx.date)
+          return applyDateTokens(
+            arg && arg.length > 0 ? arg : DEFAULT_DATE_FORMAT,
+            ctx.date,
+          )
         case 'time':
-          return applyDateTokens(arg && arg.length > 0 ? arg : DEFAULT_TIME_FORMAT, ctx.date)
+          return applyDateTokens(
+            arg && arg.length > 0 ? arg : DEFAULT_TIME_FORMAT,
+            ctx.date,
+          )
         case 'datetime':
           return `${applyDateTokens(DEFAULT_DATE_FORMAT, ctx.date)}_${applyDateTokens(DEFAULT_TIME_FORMAT, ctx.date)}`
         case 'timestamp':
@@ -143,9 +142,7 @@ export function buildExportFileBaseName(
 
   if (uniqueNoteFormat) {
     const datePart = applyDateTokens(uniqueNoteFormat, date)
-    const raw = appendTitleWhenFollowing
-      ? `${datePart}_${title}`
-      : datePart
+    const raw = appendTitleWhenFollowing ? `${datePart}_${title}` : datePart
     return sanitizeExportFileBaseName(raw)
   }
 
@@ -720,7 +717,7 @@ export async function exportChatConversationToVault(
   const cfg = settings?.chatExport
   const followUnique = cfg?.followUniqueNote === true
   const uniqueFormat = followUnique
-    ? readUniqueNoteConfig(app)?.format ?? null
+    ? (readUniqueNoteConfig(app)?.format ?? null)
     : null
 
   const baseName = buildExportFileBaseName(conversation.title, new Date(), {

--- a/src/utils/obsidian/unique-note.ts
+++ b/src/utils/obsidian/unique-note.ts
@@ -1,0 +1,34 @@
+import type { App } from 'obsidian'
+
+export type UniqueNoteConfig = {
+  enabled: boolean
+  folder: string
+  format: string
+}
+
+const DEFAULT_UNIQUE_NOTE_FORMAT = 'YYYYMMDDHHmmss'
+
+export function readUniqueNoteConfig(app: App): UniqueNoteConfig | null {
+  const internalPlugins = app.internalPlugins
+  if (!internalPlugins) return null
+
+  const plugin =
+    internalPlugins.getPluginById?.('unique-note') ??
+    internalPlugins.plugins?.['unique-note']
+  if (!plugin) return null
+
+  const enabled = Boolean(plugin.enabled ?? plugin._loaded)
+  const options = plugin.instance?.options ?? {}
+
+  const folderValue = options.folder
+  const formatValue = options.format
+
+  return {
+    enabled,
+    folder: typeof folderValue === 'string' ? folderValue : '',
+    format:
+      typeof formatValue === 'string' && formatValue.length > 0
+        ? formatValue
+        : DEFAULT_UNIQUE_NOTE_FORMAT,
+  }
+}


### PR DESCRIPTION
为聊天记录导出引入可配置的输出文件夹、文件名模板、跟随官方
unique-note 插件等字段；默认值保持现有行为兼容老用户。