### PR TITLE
[auto-triage] fix: "跟随当前选择"助手在 Cursor Chat Quick Ask 中不生效 (#350)

### DIFF
--- a/src/features/editor/selection-chat/selectionChatController.ts
+++ b/src/features/editor/selection-chat/selectionChatController.ts
@@ -413,12 +413,18 @@ export class SelectionChatController {
     rewriteBehavior?: SelectionActionRewriteBehavior,
     assistantId?: string,
   ) {
+    // undefined = "follow current selection" → use the sidebar's active assistant
+    const resolvedAssistantId =
+      assistantId !== undefined
+        ? assistantId
+        : this.getSettings().currentAssistantId
+
     if (mode === 'rewrite') {
       await this.rewriteSelection(
         editor,
         instruction,
         rewriteBehavior,
-        assistantId,
+        resolvedAssistantId,
       )
       return
     }
@@ -428,21 +434,21 @@ export class SelectionChatController {
         await this.addToSidebar(editor)
         return
       }
-      await this.addToChatInput(editor, instruction, assistantId)
+      await this.addToChatInput(editor, instruction, resolvedAssistantId)
       return
     }
 
     if (mode === 'chat-send') {
-      await this.addToChatAndSend(editor, instruction, assistantId)
+      await this.addToChatAndSend(editor, instruction, resolvedAssistantId)
       return
     }
 
     const prompt = instruction.trim()
     if (!prompt) {
-      await this.openCustomAsk(editor, assistantId)
+      await this.openCustomAsk(editor, resolvedAssistantId)
       return
     }
-    await this.explainSelection(editor, prompt, assistantId)
+    await this.explainSelection(editor, prompt, resolvedAssistantId)
   }
 
   private async openCustomAsk(editor: Editor, assistantId?: string) {

--- a/src/features/editor/selection-chat/selectionChatController.ts
+++ b/src/features/editor/selection-chat/selectionChatController.ts
@@ -762,6 +762,12 @@ export class SelectionChatController {
     pdfPageContextPromise: Promise<PdfPageContextResult | null>,
     assistantId?: string,
   ): Promise<void> {
+    // undefined = "follow current selection" → use the sidebar's active assistant
+    const resolvedAssistantId =
+      assistantId !== undefined
+        ? assistantId
+        : this.getSettings().currentAssistantId
+
     // rewrite is filtered out at the menu level — this branch is unreachable
     if (mode === 'rewrite') {
       return
@@ -803,7 +809,7 @@ export class SelectionChatController {
       await this.openChatWithSelectionAndPrefill(
         pinned,
         instruction.trim(),
-        assistantId,
+        resolvedAssistantId,
       )
       return
     }
@@ -812,7 +818,7 @@ export class SelectionChatController {
       await this.openChatWithSelectionAndSend(
         buildPinnedBlock(),
         instruction.trim(),
-        assistantId,
+        resolvedAssistantId,
       )
       return
     }
@@ -842,7 +848,7 @@ export class SelectionChatController {
       file: pdfData.file,
       pageNumber: pdfData.pageNumber,
       contextText,
-      initialAssistantId: assistantId,
+      initialAssistantId: resolvedAssistantId,
       initialMentionables: [mentionable],
       initialPrompt: prompt || undefined,
       initialMode: 'chat',


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要

当 Cursor Chat 快捷指令的"使用助手"设为"跟随当前选择"（`assistantId === undefined`）时，`executeAction` 和 `handlePdfSelectionAction` 直接将 `undefined` 作为 `initialAssistantId` 传给 Quick Ask panel。Quick Ask panel 收到 `undefined` 后回退到 `settings.quickAskAssistantId`（Quick Ask 自己的持久化偏好），而非 `settings.currentAssistantId`（侧边栏当前激活的助手）。

修复：在两个入口方法顶部将 `undefined` 解析为 `this.getSettings().currentAssistantId`，随后使用 `resolvedAssistantId` 贯穿后续所有调用（rewrite / chat-input / chat-send / ask / PDF ask）。

## 根因分析

- `SelectionChatActionsSettings.tsx` 中 `FOLLOW_CURRENT_ASSISTANT_VALUE = '__follow_current__'`，存储时映射为 `assistantId === undefined`，语义是"使用侧边栏当前激活的助手"
- `settings.currentAssistantId` = 侧边栏当前助手；`settings.quickAskAssistantId` = Quick Ask 自己的持久化偏好——两者不同
- 两处修改：`executeAction`（Markdown 编辑器快捷指令路径）+ `handlePdfSelectionAction`（PDF 选区弹窗路径）

## Codex 二审反馈

> patch 对 issue #350 的 Markdown/Cursor Chat 快捷指令路径是有效的，没有发现阻断问题。
> 低风险遗漏：PDF selection action 仍然直接把 `assistantId` 传给 Quick Ask，PDF Quick Ask 仍会落回 `quickAskAssistantId`。

→ 已在第二个 commit 补齐 PDF 路径，消除行为不一致。

## 校验

- [x] `npm run type:check` 通过（仅有 pre-existing TS6 `baseUrl` 弃用警告）
- [x] 改动仅影响 `selectionChatController.ts`，不触碰 schema / settings / i18n

## 关联

Closes #350

---

*执行令落笔，助手已在侧；*  
*跟随两字轻，选择不落空。*  
*— Claude 维护助手*

---
_Generated by [Claude Code](https://claude.ai/code/session_011JwjwbyUpEkjyRtyJ24cvP)_