### PR TITLE
fix(js_eval): 解决部分外部脚本加载失败，简化部分实现

### DIFF
--- a/src/components/common/ObsidianToggle.tsx
+++ b/src/components/common/ObsidianToggle.tsx
@@ -6,9 +6,14 @@ import { useObsidianSetting } from './ObsidianSetting'
 type ObsidianToggleProps = {
   value: boolean
   onChange: (value: boolean) => void
+  disabled?: boolean
 }
 
-export function ObsidianToggle({ value, onChange }: ObsidianToggleProps) {
+export function ObsidianToggle({
+  value,
+  onChange,
+  disabled,
+}: ObsidianToggleProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const { setting } = useObsidianSetting()
   const [toggleComponent, setToggleComponent] =
@@ -68,6 +73,15 @@ export function ObsidianToggle({ value, onChange }: ObsidianToggleProps) {
       isSyncingRef.current = false
     })
   })
+
+  useEffect(() => {
+    if (!toggleComponent) return
+    toggleComponent.setDisabled(!!disabled)
+    // setDisabled only sets the flag; visually nothing changes unless the
+    // theme has a rule. Toggle .is-disabled so styles/chat/input.css
+    // (.yolo-checkbox-container.is-disabled) can dim and block clicks.
+    toggleComponent.toggleEl.toggleClass('is-disabled', !!disabled)
+  }, [toggleComponent, disabled])
 
   return <div ref={containerRef} className="yolo-display-contents" />
 }

--- a/src/components/settings/modals/JsSandboxConfigModal.tsx
+++ b/src/components/settings/modals/JsSandboxConfigModal.tsx
@@ -10,7 +10,10 @@ import { App } from 'obsidian'
 import { type ReactNode, useState } from 'react'
 
 import { useLanguage } from '../../../contexts/language-context'
-import type { JsSandboxSettings } from '../../../core/mcp/jsSandboxSettings'
+import {
+  type JsSandboxSettings,
+  normalizeJsSandboxConfig,
+} from '../../../core/mcp/jsSandboxSettings'
 import {
   JS_SANDBOX_DEFAULT_OUTPUT_MAX_BYTES,
   JS_SANDBOX_DEFAULT_TIMEOUT_MS,
@@ -68,11 +71,14 @@ function JsSandboxConfigModalContent({
   onChange,
 }: JsSandboxConfigModalProps & { onClose: () => void }) {
   const { t } = useLanguage()
-  const [config, setConfig] = useState<JsSandboxSettings>(value ?? {})
+  const [config, setConfig] = useState<JsSandboxSettings>(() =>
+    normalizeJsSandboxConfig(value ?? {}),
+  )
 
   const update = (next: JsSandboxSettings) => {
-    setConfig(next)
-    onChange(next)
+    const normalized = normalizeJsSandboxConfig(next)
+    setConfig(normalized)
+    onChange(normalized)
   }
 
   const handleCapToggle = (
@@ -81,6 +87,10 @@ function JsSandboxConfigModalContent({
     confirmMessage: string,
   ) => {
     if (!requested) {
+      if (cap === 'allowFetch' && config.allowExternalScripts) {
+        update({ ...config, allowFetch: true })
+        return
+      }
       update({ ...config, [cap]: false })
       return
     }
@@ -94,7 +104,10 @@ function JsSandboxConfigModalContent({
       ctaText: t('common.confirm', 'Confirm'),
       cancelText: t('common.cancel', 'Cancel'),
       onConfirm: () => update({ ...snapshot, [cap]: true }),
-      onCancel: () => setConfig((current) => ({ ...current, [cap]: false })),
+      onCancel: () =>
+        setConfig((current) =>
+          normalizeJsSandboxConfig({ ...current, [cap]: false }),
+        ),
     }).open()
   }
 
@@ -238,13 +251,14 @@ function JsSandboxConfigModalContent({
             )}
             description={t(
               'settings.agent.jsSandboxAllowFetchDesc',
-              'Allow browser network requests, plus a separate $fetch helper for requests that need YOLO to bypass cross-origin limits.',
+              'Allow browser network requests, plus a separate $fetch helper for requests that need YOLO to bypass cross-origin limits. Also enabled automatically when external scripts are enabled.',
             )}
             riskWarning={t(
               'settings.agent.jsSandboxAllowFetchRisk',
               'Risk: scripts can reach any URL the browser can — public APIs, your local network, internal services, and the LLM provider itself. Data in the script (including vault contents you pass in) can be exfiltrated. Only enable for agents you fully trust.',
             )}
-            enabled={Boolean(config.allowFetch)}
+            enabled={Boolean(config.allowFetch || config.allowExternalScripts)}
+            disabled={Boolean(config.allowExternalScripts)}
             onToggle={(v) =>
               handleCapToggle(
                 'allowFetch',
@@ -387,6 +401,7 @@ function CapabilityCard({
   riskWarning,
   enabled,
   onToggle,
+  disabled,
   children,
 }: {
   icon: ReactNode
@@ -395,6 +410,7 @@ function CapabilityCard({
   riskWarning?: string
   enabled: boolean
   onToggle: (value: boolean) => void
+  disabled?: boolean
   children?: ReactNode
 }) {
   return (
@@ -408,7 +424,11 @@ function CapabilityCard({
           name={title}
           desc={description}
         >
-          <ObsidianToggle value={enabled} onChange={onToggle} />
+          <ObsidianToggle
+            value={enabled}
+            onChange={onToggle}
+            disabled={disabled}
+          />
         </ObsidianSetting>
         {riskWarning ? (
           <div className="yolo-js-exec-cap-risk" role="note">

--- a/src/core/mcp/jsSandboxSettings.ts
+++ b/src/core/mcp/jsSandboxSettings.ts
@@ -24,11 +24,33 @@ export type { JsSandboxSettings } from '../../settings/schema/setting.types'
  * consumer (LLM-facing description, capability gate, proxy handler, approval
  * mode resolver) reads through this helper so the model's view of `js_eval`
  * cannot drift from what the host actually executes.
+ *
+ * Always returns a normalized view (see normalizeJsSandboxConfig) so any
+ * legacy persisted state — e.g. `allowExternalScripts=true` saved before
+ * fetch was implicit — is reconciled before downstream code reads it.
  */
 export function getJsSandboxSettings(
   settings: Pick<YoloSettings, 'jsSandbox'> | null | undefined,
 ): JsSandboxSettings {
-  return settings?.jsSandbox ?? {}
+  return normalizeJsSandboxConfig(settings?.jsSandbox ?? {})
+}
+
+/**
+ * Reconcile cross-capability invariants so every read path sees the same
+ * shape: enabling external scripts implicitly enables network fetch, since
+ * any remote script can call `fetch` itself the moment it is loaded.
+ * Keeping the two flags coupled at the data layer avoids UI/runtime drift.
+ */
+export function normalizeJsSandboxConfig(
+  config: JsSandboxSettings,
+): JsSandboxSettings {
+  if (!config.allowExternalScripts) {
+    return config
+  }
+  if (config.allowFetch) {
+    return config
+  }
+  return { ...config, allowFetch: true }
 }
 
 /**
@@ -81,7 +103,7 @@ export function buildJsSandboxToolDescription(s: JsSandboxSettings): string {
           )
         : JS_SANDBOX_FETCH_DEFAULT_MAX_CONCURRENT
     enabled.push(
-      `Network: fetch/XMLHttpRequest/WebSocket are browser-native and still obey CORS/CSP. For cross-origin reads use await $fetch(url,{method?,headers?,body?,contentType?}) -> Response; it uses Obsidian host networking, buffers the response, is capped at ${fetchCapKb} KB, and allows at most ${fetchMaxConcurrent} concurrent $fetch calls per execution (excess calls throw)`,
+      `Network: fetch/XMLHttpRequest/WebSocket are browser-native (CORS/CSP apply). For cross-origin reads: \`const data = await (await $fetch(url, {method?,headers?,body?,contentType?})).text()\`. Host-routed, ${fetchCapKb} KB cap, max ${fetchMaxConcurrent} concurrent calls per execution (excess throw)`,
     )
   }
 
@@ -101,8 +123,19 @@ export function buildJsSandboxToolDescription(s: JsSandboxSettings): string {
   }
 
   if (s.allowExternalScripts) {
+    // importScripts and nested Worker remain reachable at the JS API level
+    // when this capability is on — this is not a lockdown, it is guidance.
+    // We deliberately omit them from the model-facing description because
+    // their failures (network / CSP / parse / eval) all surface as a
+    // single opaque "Script error", which routinely misleads external
+    // models into reporting a network problem when the real cause is a
+    // CSP block or a syntax error in the fetched bundle. For remote
+    // source loading we point the model at `$fetch(url).text()` instead,
+    // which preserves status codes, response headers, and parse errors
+    // separately — the model can then decide whether to `eval` / `new
+    // Function` the source itself with useful diagnostics on failure.
     enabled.push(
-      'External scripts: `importScripts(url, ...)` loads AND executes remote classic scripts into the worker — synchronous (no await), registers globals (e.g. `Tesseract`, `tf`). `$loadScript(url)` only FETCHES source text; use it for inspection or patching, NOT to load libraries. Worker/SharedWorker unblocked. Network implicitly enabled',
+      'External scripts: classic Worker globals — `document`/`location` absent (shim on globalThis; canvas → OffscreenCanvas). Network implicitly enabled. Load remote source via indirect eval (so UMD/IIFE bundles attach to globalThis): `(0, eval)(await (await $fetch(url)).text())`',
     )
   }
 

--- a/src/core/mcp/jsSandboxTool.ts
+++ b/src/core/mcp/jsSandboxTool.ts
@@ -83,7 +83,6 @@ export type JsSandboxProxyHandlers = {
     method: 'search' | 'find' | 'get',
     params: Record<string, unknown>,
   ) => Promise<unknown>
-  externalScript?: (url: string) => Promise<string>
 }
 
 type JsSandboxCaps = {
@@ -467,7 +466,13 @@ const SANDBOX_UTILS = createSandboxUtils()
 function disableAmbientCapabilities(allowScripts, allowFetch) {
   // allowScripts is the "full power" switch: once the model can pull in and
   // execute arbitrary remote code, any extra restriction we keep is theatre.
-  // Skip the lockdown entirely so imported scripts can use standard idioms.
+  // Skip the lockdown entirely — every ambient capability stays unlocked
+  // (fetch, XMLHttpRequest, WebSocket, EventSource, sendBeacon,
+  // importScripts, Worker, SharedWorker, indexedDB, caches), because real
+  // libraries depend on them. This pairs with skipping
+  // freezeBuiltinPrototypes() below: external-script mode is the explicit
+  // high-risk compatibility tradeoff, not partial isolation. The host
+  // already forces approval for any agent that enables this flag.
   if (allowScripts) {
     return
   }
@@ -597,10 +602,7 @@ function buildScope(rawVars) {
       find: (keyword, limit) => proxyCall('db_query', { method: 'find', keyword, limit }),
       get: (path) => proxyCall('db_query', { method: 'get', path })
     } : undefined,
-    $fetch: hostFetchAllowed ? hostFetch : undefined,
-    $loadScript: caps.allowExternalScripts
-      ? (url) => proxyCall('external_script', { url })
-      : undefined
+    $fetch: hostFetchAllowed ? hostFetch : undefined
   }
   // Network fetch: when network or external scripts are allowed, do NOT
   // shadow the global so user code resolves to browser-native fetch. When
@@ -822,6 +824,9 @@ function errorPayload(error) {
 // (e.g. Object.prototype.toJSON = () => 'fake') cannot corrupt serializeResult
 // or fool the host/LLM with falsified output. Only built-in prototypes are
 // frozen — user-defined classes and own properties remain fully mutable.
+// External script mode deliberately skips this: many UMD/browser libraries
+// patch prototypes during startup, and enabling that mode is already the
+// explicit high-risk compatibility tradeoff.
 function freezeBuiltinPrototypes() {
   const protos = [
     Object.prototype,
@@ -866,11 +871,25 @@ self.addEventListener('message', async (event) => {
 
   const caps = (data.vars && data.vars._caps) || {}
   if (!lockdownApplied) {
+    const allowExternalScripts = Boolean(caps.allowExternalScripts)
     disableAmbientCapabilities(
-      Boolean(caps.allowExternalScripts),
+      allowExternalScripts,
       Boolean(caps.allowFetch),
     )
-    freezeBuiltinPrototypes()
+    if (!allowExternalScripts) {
+      freezeBuiltinPrototypes()
+    } else {
+      // UMD/browser bundles probe typeof window !== "undefined" to decide
+      // where to attach exports. In a classic Worker, window is absent, so
+      // the probe fails and the bundle silently drops its exports — caller
+      // code then sees a ReferenceError when reaching for e.g. Algebrite.
+      // Aliasing window to self lets the probe succeed without exposing
+      // any new capability (self.fetch / self.document etc. are unchanged).
+      // Libraries that actually touch DOM still fail, but with a precise
+      // TypeError on window.document.* instead of an opaque importScripts
+      // load error.
+      self.window = self
+    }
     lockdownApplied = true
   }
 
@@ -1671,22 +1690,6 @@ class JsSandboxRunner {
         const method = payload.method as 'search' | 'find' | 'get'
         const result = await handlers.dbQuery(method, payload)
         this.sendProxyResponse(reqId, proxyId, result)
-        return
-      }
-
-      if (cap === 'external_script') {
-        if (!handlers?.externalScript) {
-          this.sendProxyResponse(
-            reqId,
-            proxyId,
-            undefined,
-            'external scripts are not enabled',
-          )
-          return
-        }
-        const url = typeof payload.url === 'string' ? payload.url : ''
-        const scriptText = await handlers.externalScript(url)
-        this.sendProxyResponse(reqId, proxyId, scriptText)
         return
       }
 

--- a/src/core/mcp/localFileTools.ts
+++ b/src/core/mcp/localFileTools.ts
@@ -4855,15 +4855,5 @@ function buildJsSandboxProxyHandlers(
     }
   }
 
-  if (config.allowExternalScripts) {
-    handlers.externalScript = async (url: string) => {
-      const response = await requestUrl({ url, throw: false })
-      if (response.status < 200 || response.status >= 300) {
-        throw new Error(`failed to fetch script: ${response.status}`)
-      }
-      return response.text
-    }
-  }
-
   return handlers
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -592,7 +592,7 @@ export const en: TranslationKeys = {
       jsSandboxExtTitle: 'Extension capabilities',
       jsSandboxAllowFetch: 'Allow Network Fetch',
       jsSandboxAllowFetchDesc:
-        'Allow browser network requests, plus a separate $fetch helper for requests that need YOLO to bypass cross-origin limits.',
+        'Allow browser network requests, plus a separate $fetch helper for requests that need YOLO to bypass cross-origin limits. Also enabled automatically when external scripts are enabled.',
       jsSandboxAllowFetchRisk:
         'Risk: scripts can reach any URL the browser can — public APIs, your local network, internal services, and the LLM provider itself. Data in the script (including vault contents you pass in) can be exfiltrated. Only enable for agents you fully trust.',
       jsSandboxAllowFetchConfirm:

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -543,7 +543,7 @@ export const zh: TranslationKeys = {
       jsSandboxExtTitle: '扩展能力',
       jsSandboxAllowFetch: '允许网络请求',
       jsSandboxAllowFetchDesc:
-        '允许脚本发起浏览器网络请求；遇到浏览器跨域限制时，可使用单独的 $fetch 宿主请求。',
+        '允许脚本发起浏览器网络请求；遇到浏览器跨域限制时，可使用单独的 $fetch 宿主请求。开启外部脚本时会自动启用此能力。',
       jsSandboxAllowFetchRisk:
         '风险：脚本可访问浏览器能到达的任何 URL —— 公开 API、你的本地网络、内网服务，乃至 LLM 服务本身。脚本中持有的任何数据（包括你传进来的 vault 内容）都可能被外发。仅在你完全信任此 Agent 时开启。',
       jsSandboxAllowFetchConfirm:

--- a/src/styles/chat/input.css
+++ b/src/styles/chat/input.css
@@ -1051,6 +1051,12 @@
   gap: var(--size-2-2);
 }
 
+.yolo-checkbox-container.is-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 /* 优先参考目录样式优化 */
 .yolo-composer-hint {
   margin-top: var(--size-4-3);

--- a/styles.css
+++ b/styles.css
@@ -227,10 +227,10 @@
 }
 
 .yolo-settings-actions svg {
-  height: var(--icon-l);
-  width: var(--icon-l);
-  stroke-width: var(--icon-stroke);
-}
+    height: var(--icon-l);
+    width: var(--icon-l);
+    stroke-width: var(--icon-stroke);
+  }
 
 .yolo-settings-kv-entry.setting-item .setting-item-info {
   display: none;
@@ -626,8 +626,8 @@
 }
 
 .yolo-assistant-message-metadata-toggle:hover {
-  background-color: transparent;
-}
+    background-color: transparent;
+  }
 
 .yolo-assistant-message-metadata-toggle.is-static {
   cursor: default;
@@ -727,94 +727,92 @@
 /* Overrides default .markdown-rendered class styles from Obsidian */
 
 .yolo-markdown-rendered.markdown-rendered {
-  --render-scale: 1;
-  font-size: calc(var(--render-scale) * 1rem);
-  line-height: 1.5;
-}
+    --render-scale: 1;
+    font-size: calc(var(--render-scale) * 1rem);
+    line-height: 1.5;
+  }
 
 .yolo-markdown-rendered.markdown-rendered.yolo-scale-xs {
-  --render-scale: 0.8;
-}
+      --render-scale: 0.8;
+    }
 
 .yolo-markdown-rendered.markdown-rendered.yolo-scale-sm {
-  --render-scale: 0.85;
-}
+      --render-scale: 0.85;
+    }
 
 .yolo-markdown-rendered.markdown-rendered.yolo-scale-base {
-  --render-scale: 1;
-}
+      --render-scale: 1;
+    }
 
 .yolo-markdown-rendered.markdown-rendered {
-  /* override default variables */
-  --p-spacing: calc(var(--render-scale) * 1rem);
-  --heading-spacing: calc(var(--p-spacing) * 1.75);
-  --checkbox-size: calc(var(--render-scale) * 1rem);
-  --checkbox-radius: calc(var(--render-scale) * var(--radius-s));
-  --icon-size: calc(var(--render-scale) * var(--icon-m));
 
-  /* adjust list indent */
-  --list-indent: 1.5em;
-}
+    /* override default variables */
+    --p-spacing: calc(var(--render-scale) * 1rem);
+    --heading-spacing: calc(var(--p-spacing) * 1.75);
+    --checkbox-size: calc(var(--render-scale) * 1rem);
+    --checkbox-radius: calc(var(--render-scale) * var(--radius-s));
+    --icon-size: calc(var(--render-scale) * var(--icon-m));
+
+    /* adjust list indent */
+    --list-indent: 1.5em;
+  }
 
 .yolo-markdown-rendered.markdown-rendered blockquote {
-  padding-inline-start: calc(var(--render-scale) * 1.5rem);
-}
+      padding-inline-start: calc(var(--render-scale) * 1.5rem);
+    }
 
 .yolo-markdown-rendered.markdown-rendered pre {
-  padding: calc(var(--render-scale) * 0.75rem) calc(var(--render-scale) * 1rem);
-}
+      padding: calc(var(--render-scale) * 0.75rem)
+        calc(var(--render-scale) * 1rem);
+    }
 
 .yolo-markdown-rendered.markdown-rendered :not(pre) > code {
-  word-break: break-all;
-}
+      word-break: break-all;
+    }
 
 .yolo-markdown-rendered.markdown-rendered hr {
-  margin: calc(var(--render-scale) * 2rem) 0;
-}
+      margin: calc(var(--render-scale) * 2rem) 0;
+    }
 
-.yolo-markdown-rendered.markdown-rendered th,
-.yolo-markdown-rendered.markdown-rendered td {
-  font-size: calc(var(--render-scale) * 1rem);
-  padding: calc(var(--render-scale) * 0.25rem)
-    calc(var(--render-scale) * 0.5rem);
-}
+.yolo-markdown-rendered.markdown-rendered th,.yolo-markdown-rendered.markdown-rendered td {
+      font-size: calc(var(--render-scale) * 1rem);
+      padding: calc(var(--render-scale) * 0.25rem)
+        calc(var(--render-scale) * 0.5rem);
+    }
 
 .yolo-markdown-rendered.markdown-rendered .callout {
-  padding: calc(var(--render-scale) * 0.75rem)
-    calc(var(--render-scale) * 0.75rem) calc(var(--render-scale) * 0.75rem)
-    calc(var(--render-scale) * 1.5rem);
-}
+      padding: calc(var(--render-scale) * 0.75rem)
+        calc(var(--render-scale) * 0.75rem) calc(var(--render-scale) * 0.75rem)
+        calc(var(--render-scale) * 1.5rem);
+    }
 
 .yolo-markdown-rendered.markdown-rendered .callout-icon {
-  height: calc(var(--render-scale) * 1rem);
-  width: calc(var(--render-scale) * 1rem);
-}
+      height: calc(var(--render-scale) * 1rem);
+      width: calc(var(--render-scale) * 1rem);
+    }
 
 .yolo-markdown-rendered.markdown-rendered .math {
-  user-select: text;
-  cursor: text;
-}
+      user-select: text;
+      cursor: text;
+    }
 
-:is(.yolo-markdown-rendered.markdown-rendered .math)::selection,
-:is(.yolo-markdown-rendered.markdown-rendered .math) *::selection {
-  background: var(--text-selection);
-}
+:is(.yolo-markdown-rendered.markdown-rendered .math)::selection,:is(.yolo-markdown-rendered.markdown-rendered .math) *::selection {
+        background: var(--text-selection);
+      }
 
-:is(.yolo-markdown-rendered.markdown-rendered .math)
-  mjx-math.yolo-latex-selected,
-.yolo-latex-selected:is(.yolo-markdown-rendered.markdown-rendered .math) {
-  background: var(--text-selection);
-  border-radius: 0;
-}
+:is(.yolo-markdown-rendered.markdown-rendered .math) mjx-math.yolo-latex-selected,.yolo-latex-selected:is(.yolo-markdown-rendered.markdown-rendered .math) {
+        background: var(--text-selection);
+        border-radius: 0;
+      }
 
 /* Show frontmatter which is hidden by default */
 
 .yolo-markdown-rendered .frontmatter {
-  display: block !important;
-  background-color: transparent;
-  border-top: 1px solid var(--background-modifier-border);
-  border-bottom: 1px solid var(--background-modifier-border);
-}
+    display: block !important;
+    background-color: transparent;
+    border-top: 1px solid var(--background-modifier-border);
+    border-bottom: 1px solid var(--background-modifier-border);
+  }
 
 .yolo-stream-fresh-text {
   display: inline;
@@ -851,17 +849,17 @@
 }
 
 .yolo-settings-description-preserve-whitespace .setting-item-description {
-  white-space: pre-wrap;
-}
+    white-space: pre-wrap;
+  }
 
 .yolo-settings-desc-copyable .setting-item-description {
-  user-select: text;
-  cursor: text;
-}
+    user-select: text;
+    cursor: text;
+  }
 
 .yolo-obsidian-code-block pre {
-  margin: 0;
-}
+    margin: 0;
+  }
 
 .yolo-syntax-highlighter {
   margin: 0;
@@ -1170,8 +1168,8 @@
 }
 
 .yolo-toolcall-container .yolo-toolcall-border-top {
-  border-top: none;
-}
+    border-top: none;
+  }
 
 .yolo-toolcall {
   display: flex;
@@ -1204,85 +1202,84 @@
 }
 
 .yolo-toolcall-header:focus-visible {
-  outline: 2px solid
-    color-mix(in srgb, var(--interactive-accent) 55%, transparent);
-  outline-offset: 1px;
-  box-shadow: none !important;
-  background: transparent !important;
-}
+    outline: 2px solid
+      color-mix(in srgb, var(--interactive-accent) 55%, transparent);
+    outline-offset: 1px;
+    box-shadow: none !important;
+    background: transparent !important;
+  }
 
 .yolo-toolcall-header:hover {
-  background-color: transparent;
-  color: var(--text-normal);
-}
+    background-color: transparent;
+    color: var(--text-normal);
+  }
 
 .yolo-toolcall-header .yolo-toolcall-header-content {
-  min-width: 0;
-  flex: 1 1 auto;
-}
+    min-width: 0;
+    flex: 1 1 auto;
+  }
 
 .yolo-toolcall-header .yolo-toolcall-header-icon {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  color: var(--text-faint);
-}
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    color: var(--text-faint);
+  }
 
 .yolo-toolcall-header .yolo-toolcall-header-icon--status-inline {
-  color: var(--text-muted);
-}
+    color: var(--text-muted);
+  }
 
 .yolo-toolcall-header .yolo-toolcall-header-icon--expand {
-  margin-left: auto;
-  color: var(--text-faint);
-  opacity: 0.9;
-}
+    margin-left: auto;
+    color: var(--text-faint);
+    opacity: 0.9;
+  }
 
 .yolo-toolcall-header .yolo-toolcall-header-tool-name {
-  display: flex;
-  align-items: baseline;
-  gap: 2px;
-  min-width: 0;
-  font-family: var(--font-ui);
-  font-weight: var(--font-normal);
-  font-size: var(--font-ui-smaller);
-  line-height: 1.35;
-}
+    display: flex;
+    align-items: baseline;
+    gap: 2px;
+    min-width: 0;
+    font-family: var(--font-ui);
+    font-weight: var(--font-normal);
+    font-size: var(--font-ui-smaller);
+    line-height: 1.35;
+  }
 
-.yolo-toolcall-header .yolo-toolcall-header-title,
-.yolo-toolcall-header .yolo-toolcall-header-separator {
-  flex: 0 0 auto;
-  white-space: nowrap;
-}
+.yolo-toolcall-header .yolo-toolcall-header-title,.yolo-toolcall-header .yolo-toolcall-header-separator {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
 
 .yolo-toolcall-header .yolo-toolcall-header-summary {
-  min-width: 0;
-  flex: 0 1 auto;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+    min-width: 0;
+    flex: 0 1 auto;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
 .yolo-toolcall-header .yolo-toolcall-header-edit-deltas {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: baseline;
-  gap: 4px;
-  margin-left: 6px;
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-}
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    margin-left: 6px;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
 
 .yolo-toolcall-header .yolo-toolcall-header-edit-added {
-  color: var(--text-success);
-}
+    color: var(--text-success);
+  }
 
 .yolo-toolcall-header .yolo-toolcall-header-edit-removed {
-  color: var(--text-error);
-}
+    color: var(--text-error);
+  }
 
 .yolo-toolcall-content {
   display: flex;
@@ -1299,10 +1296,10 @@
 }
 
 .yolo-toolcall-content .yolo-toolcall-content-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--size-2-3);
-}
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-2-3);
+  }
 
 .yolo-toolcall-compaction-pending {
   display: inline-flex;
@@ -1369,22 +1366,22 @@
 }
 
 .yolo-toolcall-footer .yolo-toolcall-footer-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--size-4-1);
-}
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-1);
+  }
 
 :is(.yolo-toolcall-footer .yolo-toolcall-footer-actions) button {
-  background-color: var(--background-primary-alt);
-  border: 1px solid var(--background-modifier-border);
-  box-shadow: none;
-}
+      background-color: var(--background-primary-alt);
+      border: 1px solid var(--background-modifier-border);
+      box-shadow: none;
+    }
 
 :is(:is(.yolo-toolcall-footer .yolo-toolcall-footer-actions) button):hover {
-  background-color: var(--background-modifier-hover);
-  border: 1px solid var(--background-modifier-border-hover);
-  box-shadow: none;
-}
+        background-color: var(--background-modifier-hover);
+        border: 1px solid var(--background-modifier-border-hover);
+        box-shadow: none;
+      }
 
 @media (prefers-reduced-motion: reduce) {
   .yolo-toolcall-compaction-pending {
@@ -1398,14 +1395,14 @@
 }
 
 .yolo-split-button .yolo-split-button-primary {
-  border-radius: var(--button-radius) 0 0 var(--button-radius) !important;
-}
+    border-radius: var(--button-radius) 0 0 var(--button-radius) !important;
+  }
 
 .yolo-split-button .yolo-split-button-toggle {
-  padding: var(--size-4-1);
-  border-radius: 0 var(--button-radius) var(--button-radius) 0 !important;
-  border-left: none !important;
-}
+    padding: var(--size-4-1);
+    border-radius: 0 var(--button-radius) var(--button-radius) 0 !important;
+    border-left: none !important;
+  }
 
 /* Providers and Models Section Styles */
 
@@ -2717,24 +2714,24 @@ body.theme-dark .yolo-pp-badge--mute {
 }
 
 .yolo-mcp-servers-header > div {
-  padding: var(--size-4-1);
-}
+    padding: var(--size-4-1);
+  }
 
 .yolo-mcp-servers-header > div:nth-child(1) {
-  text-align: left;
-}
+    text-align: left;
+  }
 
 .yolo-mcp-servers-header > div:nth-child(2) {
-  text-align: left;
-}
+    text-align: left;
+  }
 
 .yolo-mcp-servers-header > div:nth-child(3) {
-  text-align: center;
-}
+    text-align: center;
+  }
 
 .yolo-mcp-servers-header > div:nth-child(4) {
-  text-align: center;
-}
+    text-align: center;
+  }
 
 .yolo-mcp-servers-empty {
   padding: var(--size-4-4) 0;
@@ -2757,8 +2754,8 @@ body.theme-dark .yolo-pp-badge--mute {
 }
 
 .yolo-mcp-server-row > div {
-  padding: var(--size-4-1);
-}
+    padding: var(--size-4-1);
+  }
 
 .yolo-mcp-server-name {
   overflow: hidden;
@@ -2783,10 +2780,10 @@ body.theme-dark .yolo-pp-badge--mute {
 }
 
 .yolo-mcp-server-actions svg {
-  height: var(--icon-l);
-  width: var(--icon-l);
-  stroke-width: var(--icon-stroke);
-}
+    height: var(--icon-l);
+    width: var(--icon-l);
+    stroke-width: var(--icon-stroke);
+  }
 
 .yolo-server-expanded-info {
   margin-bottom: var(--size-4-4);
@@ -2970,14 +2967,14 @@ button.yolo-mcp-tool-description-toggle.is-expanded {
 }
 
 .yolo-mcp-parameters-info-icon:hover {
-  color: var(--text-normal);
-  background: transparent !important;
-}
+    color: var(--text-normal);
+    background: transparent !important;
+  }
 
 .yolo-mcp-parameters-info-icon:focus-visible {
-  outline: 2px solid var(--interactive-accent);
-  outline-offset: 1px;
-}
+    outline: 2px solid var(--interactive-accent);
+    outline-offset: 1px;
+  }
 
 .yolo-mcp-sr-only {
   position: absolute;
@@ -3051,12 +3048,12 @@ button.yolo-mcp-tool-description-toggle.is-expanded {
 }
 
 .yolo-mcp-server-modal-validation.yolo-mcp-server-modal-validation--error {
-  color: var(--text-error);
-}
+    color: var(--text-error);
+  }
 
 .yolo-mcp-server-modal-validation.yolo-mcp-server-modal-validation--success {
-  color: var(--text-success);
-}
+    color: var(--text-success);
+  }
 
 .yolo-rag-layout {
   display: flex;
@@ -3427,16 +3424,16 @@ button.yolo-mcp-tool-description-toggle.is-expanded {
 }
 
 .yolo-templates-header > div {
-  padding: var(--size-4-1);
-}
+    padding: var(--size-4-1);
+  }
 
 .yolo-templates-header > div:nth-child(1) {
-  text-align: left;
-}
+    text-align: left;
+  }
 
 .yolo-templates-header > div:nth-child(2) {
-  text-align: center;
-}
+    text-align: center;
+  }
 
 .yolo-templates-empty {
   padding: var(--size-4-4) 0;
@@ -3459,8 +3456,8 @@ button.yolo-mcp-tool-description-toggle.is-expanded {
 }
 
 .yolo-template-row > div {
-  padding: var(--size-4-1);
-}
+    padding: var(--size-4-1);
+  }
 
 .yolo-template-name {
   overflow: hidden;
@@ -3475,10 +3472,10 @@ button.yolo-mcp-tool-description-toggle.is-expanded {
 }
 
 .yolo-template-actions svg {
-  height: var(--icon-l);
-  width: var(--icon-l);
-  stroke-width: var(--icon-stroke);
-}
+    height: var(--icon-l);
+    width: var(--icon-l);
+    stroke-width: var(--icon-stroke);
+  }
 
 .yolo-continue-response-button-container {
   display: flex;
@@ -7511,10 +7508,10 @@ button.yolo-agent-chip--more:hover {
 }
 
 .yolo-chat-header-buttons svg {
-  height: var(--icon-l);
-  width: var(--icon-l);
-  stroke-width: var(--icon-stroke);
-}
+    height: var(--icon-l);
+    width: var(--icon-l);
+    stroke-width: var(--icon-stroke);
+  }
 
 .yolo-markdown {
   line-height: var(--line-height-normal);
@@ -7522,90 +7519,90 @@ button.yolo-agent-chip--more:hover {
 }
 
 .yolo-markdown h1 {
-  font-size: var(--font-ui-large);
-}
+    font-size: var(--font-ui-large);
+  }
 
 .yolo-markdown h2 {
-  font-size: var(--font-ui-medium);
-}
+    font-size: var(--font-ui-medium);
+  }
 
 .yolo-markdown h3 {
-  font-size: var(--font-ui-small);
-}
+    font-size: var(--font-ui-small);
+  }
 
 .yolo-markdown h4 {
-  font-size: var(--font-ui-smaller);
-}
+    font-size: var(--font-ui-smaller);
+  }
 
 .yolo-markdown h5 {
-  font-size: var(--font-ui-smallest);
-}
+    font-size: var(--font-ui-smallest);
+  }
 
 .yolo-markdown h6 {
-  font-size: var(--font-ui-smallest);
-}
+    font-size: var(--font-ui-smallest);
+  }
 
 .yolo-markdown p {
-  font-size: var(--font-ui-small);
-}
+    font-size: var(--font-ui-small);
+  }
 
 .yolo-markdown ul {
-  font-size: var(--font-ui-small);
-  padding-left: var(--size-4-4);
-}
+    font-size: var(--font-ui-small);
+    padding-left: var(--size-4-4);
+  }
 
 .yolo-markdown ol {
-  font-size: var(--font-ui-small);
-  padding-left: var(--size-4-4);
-}
+    font-size: var(--font-ui-small);
+    padding-left: var(--size-4-4);
+  }
 
 .yolo-markdown li {
-  font-size: var(--font-ui-small);
-}
+    font-size: var(--font-ui-small);
+  }
 
 .yolo-markdown blockquote {
-  font-size: var(--font-ui-small);
-  font-style: var(--blockquote-style);
-  background-color: var(--blockquote-background-color);
-  margin: 0;
-  padding-left: var(--size-4-2);
-  border-left: var(--blockquote-border-thickness) solid
-    var(--blockquote-border-color);
-}
+    font-size: var(--font-ui-small);
+    font-style: var(--blockquote-style);
+    background-color: var(--blockquote-background-color);
+    margin: 0;
+    padding-left: var(--size-4-2);
+    border-left: var(--blockquote-border-thickness) solid
+      var(--blockquote-border-color);
+  }
 
 .yolo-markdown code {
-  font-size: var(--font-ui-small);
-  border-radius: var(--code-radius);
-  padding: 0.1em 0.25em;
-  color: var(--code-normal);
-  font-size: var(--code-size);
-  background-color: var(--code-background);
-  vertical-align: baseline;
-}
+    font-size: var(--font-ui-small);
+    border-radius: var(--code-radius);
+    padding: 0.1em 0.25em;
+    color: var(--code-normal);
+    font-size: var(--code-size);
+    background-color: var(--code-background);
+    vertical-align: baseline;
+  }
 
 .yolo-markdown table {
-  font-size: var(--font-ui-small);
-}
+    font-size: var(--font-ui-small);
+  }
 
 .yolo-markdown thead {
-  font-size: var(--font-ui-small);
-}
+    font-size: var(--font-ui-small);
+  }
 
 .yolo-markdown tbody {
-  font-size: var(--font-ui-small);
-}
+    font-size: var(--font-ui-small);
+  }
 
 .yolo-markdown tr {
-  font-size: var(--font-ui-small);
-}
+    font-size: var(--font-ui-small);
+  }
 
 .yolo-markdown td {
-  font-size: var(--font-ui-small);
-}
+    font-size: var(--font-ui-small);
+  }
 
 .yolo-markdown th {
-  font-size: var(--font-ui-small);
-}
+    font-size: var(--font-ui-small);
+  }
 
 .yolo-chat-container {
   display: flex;
@@ -8424,29 +8421,29 @@ button.yolo-agent-chip--more:hover {
    * collapse the spacer back to 0 and re-introduce the occlusion bug. */
 }
 
-.yolo-chat-messages > .yolo-chat-timeline-bottom-spacer {
-  flex: 0 0 auto;
-}
+.yolo-chat-messages  > .yolo-chat-timeline-bottom-spacer {
+    flex: 0 0 auto;
+  }
 
 .yolo-chat-messages .yolo-chat-messages-user {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  align-items: flex-end;
-}
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    align-items: flex-end;
+  }
 
 .yolo-chat-messages .yolo-chat-messages-assistant {
-  display: flex;
-  flex-direction: column;
-}
+    display: flex;
+    flex-direction: column;
+  }
 
 .yolo-chat-messages .yolo-assistant-tool-message-group {
-  padding-bottom: var(--size-4-2);
-  display: flex;
-  flex-direction: column;
-  gap: var(--size-4-1);
-}
+    padding-bottom: var(--size-4-2);
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-4-1);
+  }
 
 .yolo-chat-timeline-row {
   display: flex;
@@ -8514,10 +8511,10 @@ button.yolo-agent-chip--more:hover {
 }
 
 .yolo-chat-compaction-divider.is-entering .yolo-chat-compaction-divider__line {
-  transform-origin: center;
-  animation: yolo-chat-compaction-divider-line-enter 220ms
-    cubic-bezier(0.2, 0.8, 0.2, 1) both;
-}
+    transform-origin: center;
+    animation: yolo-chat-compaction-divider-line-enter 220ms
+      cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  }
 
 .yolo-chat-compaction-divider__title {
   font-size: var(--font-ui-small);
@@ -9048,13 +9045,10 @@ button.yolo-agent-chip--more:hover {
   --yolo-mention-badge-max-width: 180px;
 }
 
-.yolo-chat-user-input-container:focus-within,
-.yolo-chat-user-input-container:focus,
-.yolo-chat-user-input-container:focus-visible,
-.yolo-chat-user-input-container:active {
-  box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
-  transition: box-shadow 0.15s ease-in-out;
-}
+.yolo-chat-user-input-container:focus-within,.yolo-chat-user-input-container:focus,.yolo-chat-user-input-container:focus-visible,.yolo-chat-user-input-container:active {
+    box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
+    transition: box-shadow 0.15s ease-in-out;
+  }
 
 .yolo-chat-user-input-container[data-resizable='true'] .yolo-obsidian-textarea,
 .yolo-chat-user-input-container[data-resizable='true'] .yolo-content-editable {
@@ -9281,21 +9275,21 @@ button.yolo-agent-chip--more:hover {
 }
 
 .yolo-chat-user-input-placeholder .yolo-placeholder-trigger {
-  pointer-events: auto;
-  display: inline-block;
-  min-width: 1.4em;
-  text-align: center;
-  padding: 0 3px;
-  border-radius: 3px;
-  background-color: var(--tag-background);
-  color: var(--tag-color);
-  cursor: pointer;
-  transition: opacity 80ms ease;
-}
+    pointer-events: auto;
+    display: inline-block;
+    min-width: 1.4em;
+    text-align: center;
+    padding: 0 3px;
+    border-radius: 3px;
+    background-color: var(--tag-background);
+    color: var(--tag-color);
+    cursor: pointer;
+    transition: opacity 80ms ease;
+  }
 
 :is(.yolo-chat-user-input-placeholder .yolo-placeholder-trigger):hover {
-  opacity: 0.75;
-}
+      opacity: 0.75;
+    }
 
 .yolo-chat-user-input-controls {
   display: flex;
@@ -9309,36 +9303,35 @@ button.yolo-agent-chip--more:hover {
 }
 
 .yolo-chat-user-input-controls .yolo-chat-user-input-controls__left {
-  display: flex;
-  align-items: center;
-  gap: var(--size-4-3);
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-}
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-3);
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+  }
 
 .yolo-chat-user-input-controls .yolo-chat-user-input-controls__right {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--size-4-2);
-  flex: 0 1 auto;
-  min-width: 0;
-}
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--size-4-2);
+    flex: 0 1 auto;
+    min-width: 0;
+  }
 
-.yolo-chat-user-input-controls
-  .yolo-chat-user-input-controls__model-select-container {
-  flex: 1 1 180px;
-  min-width: 0;
-  overflow: hidden;
-}
+.yolo-chat-user-input-controls .yolo-chat-user-input-controls__model-select-container {
+    flex: 1 1 180px;
+    min-width: 0;
+    overflow: hidden;
+  }
 
 .yolo-chat-user-input-controls .yolo-chat-user-input-controls__buttons {
-  flex-shrink: 0;
-  display: flex;
-  gap: var(--size-4-2);
-  align-items: center;
-}
+    flex-shrink: 0;
+    display: flex;
+    gap: var(--size-4-2);
+    align-items: center;
+  }
 
 .yolo-chat-user-input-controls__left .yolo-chat-input-model-select {
   max-width: 160px;
@@ -9379,16 +9372,15 @@ button.yolo-agent-chip--more:hover {
 }
 
 :is(.yolo-chat-user-input-controls .yolo-chat-user-input-submit-button):hover {
-  color: var(--text-normal);
-}
+    color: var(--text-normal);
+  }
 
-:is(.yolo-chat-user-input-controls .yolo-chat-user-input-submit-button)
-  .yolo-chat-user-input-submit-button-icons {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-shrink: 0;
-}
+:is(.yolo-chat-user-input-controls .yolo-chat-user-input-submit-button) .yolo-chat-user-input-submit-button-icons {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-shrink: 0;
+  }
 
 .yolo-chat-user-input-submit-button-label {
   min-width: 0;
@@ -9409,12 +9401,10 @@ button.yolo-agent-chip--more:hover {
   color: var(--text-muted);
 }
 
-:is(
-    .yolo-chat-user-input-controls__left .yolo-chat-user-input-upload-button
-  ):hover {
-  color: var(--text-normal);
-  background: var(--background-modifier-hover);
-}
+:is(.yolo-chat-user-input-controls__left .yolo-chat-user-input-upload-button):hover {
+    color: var(--text-normal);
+    background: var(--background-modifier-hover);
+  }
 
 .yolo-chat-input-model-select__label {
   min-width: 0;
@@ -9814,17 +9804,17 @@ button.yolo-chat-user-input-submit-button-circle.is-stop:hover:not(:disabled) {
 }
 
 .yolo-chat-user-input-file-badge.yolo-chat-user-input-file-badge-focused {
-  border: 1px solid var(--interactive-accent);
-}
+    border: 1px solid var(--interactive-accent);
+  }
 
 .yolo-chat-user-input-file-badge .yolo-excluded-content {
-  text-decoration: line-through;
-  font-style: italic;
-}
+    text-decoration: line-through;
+    font-style: italic;
+  }
 
 .yolo-chat-user-input-file-badge svg {
-  flex-shrink: 0;
-}
+    flex-shrink: 0;
+  }
 
 .yolo-chat-user-input-file-badge:hover {
   background-color: var(--background-modifier-hover);
@@ -9933,9 +9923,9 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-chat-user-input-file-content-preview img {
-  max-width: 100%;
-  max-height: 350px;
-}
+    max-width: 100%;
+    max-height: 350px;
+  }
 
 .yolo-agent-mode-warning-modal {
   display: flex;
@@ -10192,18 +10182,18 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-settings-textarea .yolo-item-control {
-  width: 100%;
-}
+    width: 100%;
+  }
 
 .yolo-settings-textarea .setting-item-control {
-  padding-bottom: 0;
-}
+    padding-bottom: 0;
+  }
 
 .yolo-settings-textarea textarea {
-  width: 100%;
-  min-height: 100px;
-  resize: none;
-}
+    width: 100%;
+    min-height: 100px;
+    resize: none;
+  }
 
 /* prevent setting-item:first-child overwriting padding-top and border-top */
 
@@ -10222,12 +10212,12 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-settings-model-container .setting-item {
-  border-top: none;
-}
+    border-top: none;
+  }
 
 :is(.yolo-settings-model-container .setting-item):first-child {
-  margin-top: var(--size-4-2);
-}
+      margin-top: var(--size-4-2);
+    }
 
 .yolo-settings-plain.setting-item {
   padding: 0;
@@ -10264,51 +10254,51 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-dialog-content .yolo-dialog-header {
-  margin-bottom: var(--size-4-2);
-  display: grid;
-  gap: var(--size-2-3);
-}
+    margin-bottom: var(--size-4-2);
+    display: grid;
+    gap: var(--size-2-3);
+  }
 
 .yolo-dialog-content .yolo-dialog-title {
-  font-size: var(--font-ui-medium);
-  font-weight: var(--font-semibold);
-  line-height: var(--line-height-tight);
-  margin: 0;
-}
+    font-size: var(--font-ui-medium);
+    font-weight: var(--font-semibold);
+    line-height: var(--line-height-tight);
+    margin: 0;
+  }
 
 .yolo-dialog-content .yolo-dialog-input {
-  display: grid;
-  gap: var(--size-4-1);
-}
+    display: grid;
+    gap: var(--size-4-1);
+  }
 
 :is(.yolo-dialog-content .yolo-dialog-input) label {
-  font-size: var(--font-ui-smaller);
-}
+      font-size: var(--font-ui-smaller);
+    }
 
 .yolo-dialog-content .yolo-dialog-description {
-  font-size: var(--font-ui-small);
-  color: var(--text-muted);
-  margin: 0;
-}
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+    margin: 0;
+  }
 
 .yolo-dialog-content .yolo-dialog-footer {
-  margin-top: var(--size-4-2);
-  display: flex;
-  justify-content: flex-end;
-}
+    margin-top: var(--size-4-2);
+    display: flex;
+    justify-content: flex-end;
+  }
 
 .yolo-dialog-content .yolo-dialog-close {
-  position: absolute;
-  right: var(--size-4-4);
-  top: var(--size-4-4);
-  cursor: var(--cursor);
-  opacity: 0.7;
-  transition: opacity 0.2s;
-}
+    position: absolute;
+    right: var(--size-4-4);
+    top: var(--size-4-4);
+    cursor: var(--cursor);
+    opacity: 0.7;
+    transition: opacity 0.2s;
+  }
 
 :is(.yolo-dialog-content .yolo-dialog-close):hover {
-  opacity: 1;
-}
+      opacity: 1;
+    }
 
 .yolo-template-menu-item {
   display: flex;
@@ -10319,17 +10309,17 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-template-menu-item .yolo-template-menu-item-delete {
-  display: flex;
-  align-items: center;
-  padding: var(--size-4-1);
-  margin: calc(var(--size-4-1) * -1);
-  opacity: 0.7;
-  transition: opacity 0.2s;
-}
+    display: flex;
+    align-items: center;
+    padding: var(--size-4-1);
+    margin: calc(var(--size-4-1) * -1);
+    opacity: 0.7;
+    transition: opacity 0.2s;
+  }
 
 :is(.yolo-template-menu-item .yolo-template-menu-item-delete):hover {
-  opacity: 1;
-}
+      opacity: 1;
+    }
 
 .yolo-assistant-message-actions {
   display: flex;
@@ -11861,56 +11851,51 @@ button.yolo-llm-debug-modal-button:focus-visible {
 }
 
 .yolo-similarity-search-results .yolo-similarity-search-results__trigger {
-  display: flex;
-  align-items: center;
-  gap: var(--size-4-1);
-  padding: var(--size-4-1);
-  border-radius: var(--radius-s);
-  cursor: pointer;
-}
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-1);
+    padding: var(--size-4-1);
+    border-radius: var(--radius-s);
+    cursor: pointer;
+  }
 
-:is(
-    .yolo-similarity-search-results .yolo-similarity-search-results__trigger
-  ):hover {
-  background-color: var(--background-modifier-hover);
-}
+:is(.yolo-similarity-search-results .yolo-similarity-search-results__trigger):hover {
+      background-color: var(--background-modifier-hover);
+    }
 
 .yolo-similarity-search-results .yolo-similarity-search-item {
-  display: flex;
-  align-items: center;
-  justify-content: start;
-  gap: var(--size-4-2);
-  padding: var(--size-4-1);
-  border-radius: var(--radius-s);
-  cursor: pointer;
-}
+    display: flex;
+    align-items: center;
+    justify-content: start;
+    gap: var(--size-4-2);
+    padding: var(--size-4-1);
+    border-radius: var(--radius-s);
+    cursor: pointer;
+  }
 
 :is(.yolo-similarity-search-results .yolo-similarity-search-item):hover {
-  background-color: var(--background-modifier-hover);
-}
+      background-color: var(--background-modifier-hover);
+    }
 
-:is(.yolo-similarity-search-results .yolo-similarity-search-item)
-  .yolo-similarity-search-item__similarity {
-  flex-shrink: 0;
-  font-size: var(--font-smallest);
-  color: var(--text-muted);
-}
+:is(.yolo-similarity-search-results .yolo-similarity-search-item) .yolo-similarity-search-item__similarity {
+      flex-shrink: 0;
+      font-size: var(--font-smallest);
+      color: var(--text-muted);
+    }
 
-:is(.yolo-similarity-search-results .yolo-similarity-search-item)
-  .yolo-similarity-search-item__path {
-  flex-shrink: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: var(--font-smallest);
-}
+:is(.yolo-similarity-search-results .yolo-similarity-search-item) .yolo-similarity-search-item__path {
+      flex-shrink: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: var(--font-smallest);
+    }
 
-:is(.yolo-similarity-search-results .yolo-similarity-search-item)
-  .yolo-similarity-search-item__line-numbers {
-  flex-shrink: 0;
-  margin-left: auto;
-  font-size: var(--font-smallest);
-}
+:is(.yolo-similarity-search-results .yolo-similarity-search-item) .yolo-similarity-search-item__line-numbers {
+      flex-shrink: 0;
+      margin-left: auto;
+      font-size: var(--font-smallest);
+    }
 
 .yolo-llm-info-content {
   width: 320px;
@@ -12939,10 +12924,10 @@ button.yolo-chat-list-dropdown-archive-toggle:focus-visible
 }
 
 .yolo-chat-list-dropdown-item-actions svg {
-  height: var(--icon-xs);
-  width: var(--icon-xs);
-  stroke-width: var(--icon-stroke);
-}
+    height: var(--icon-xs);
+    width: var(--icon-xs);
+    stroke-width: var(--icon-stroke);
+  }
 
 .yolo-chat-list-inline-actions {
   display: grid;
@@ -13092,8 +13077,8 @@ button.yolo-chat-list-dropdown-archive-toggle:focus-visible
 }
 
 .yolo-code-block-header-filename:hover {
-  text-decoration: underline;
-}
+    text-decoration: underline;
+  }
 
 .yolo-code-block-header-button-container {
   margin-left: auto;
@@ -13105,19 +13090,18 @@ button.yolo-chat-list-dropdown-archive-toggle:focus-visible
 }
 
 .yolo-code-block-header-button-container .yolo-code-block-header-button {
-  height: 100%;
-  padding: 0 var(--size-4-2);
-  display: flex;
-  gap: var(--size-4-1);
-  font-size: var(--font-small);
-}
+    height: 100%;
+    padding: 0 var(--size-4-2);
+    display: flex;
+    gap: var(--size-4-1);
+    font-size: var(--font-small);
+  }
 
 /* Override clickable-icon color */
 
-.yolo-code-block-header-button-container
-  .yolo-code-block-header-button.clickable-icon {
-  color: var(--text-color) !important;
-}
+.yolo-code-block-header-button-container .yolo-code-block-header-button.clickable-icon {
+    color: var(--text-color) !important;
+  }
 
 .yolo-code-block-content {
   margin: 0;
@@ -13516,394 +13500,378 @@ button.yolo-chat-list-dropdown-archive-toggle:focus-visible
   );
 }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .view-content {
-  padding: 0;
-  flex: 1 1 auto;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .view-content {
+    padding: 0;
+    flex: 1 1 auto;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .markdown-source-view.mod-cm6 {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .markdown-source-view.mod-cm6 {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .cm-editor {
-  flex: 1 1 0;
-  min-height: 0;
-  position: relative !important;
-  box-sizing: border-box;
-  display: flex !important;
-  flex-direction: column;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .cm-editor {
+    flex: 1 1 0;
+    min-height: 0;
+    position: relative !important;
+    box-sizing: border-box;
+    display: flex !important;
+    flex-direction: column;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .cm-scroller {
-  padding: var(--file-margins);
-  display: flex !important;
-  align-items: flex-start !important;
-  line-height: 1.4;
-  height: 100%;
-  overflow-x: auto;
-  position: relative;
-  z-index: 0;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .cm-scroller {
+    padding: var(--file-margins);
+    display: flex !important;
+    align-items: flex-start !important;
+    line-height: 1.4;
+    height: 100%;
+    overflow-x: auto;
+    position: relative;
+    z-index: 0;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .cm-sizer {
-  box-sizing: border-box;
-  max-width: 100%;
-  width: 100%;
-  margin-left: auto;
-  margin-right: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  padding-left: 0;
-  padding-right: 0;
-  padding-bottom: 488px;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .cm-sizer {
+    box-sizing: border-box;
+    max-width: 100%;
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    padding-left: 0;
+    padding-right: 0;
+    padding-bottom: 488px;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-content {
-  width: 100%;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-content {
+    width: 100%;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-decision-status {
-  width: min(100%, var(--file-line-width));
-  margin: 0 auto;
-  color: var(--text-muted);
-  font-size: var(--font-ui-smaller);
-  line-height: 1.5;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-decision-status {
+    width: min(100%, var(--file-line-width));
+    margin: 0 auto;
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+    line-height: 1.5;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-decision-status {
-  margin-bottom: var(--size-4-1);
-  font-weight: var(--font-medium);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-decision-status {
+    margin-bottom: var(--size-4-1);
+    font-weight: var(--font-medium);
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .view-header {
-  height: var(--header-height);
-  display: flex;
-  border-bottom: var(--file-header-border);
-  background-color: var(--background-primary);
-  z-index: 1;
-  position: relative;
-  gap: var(--size-4-2);
-  padding: 0 var(--size-4-3);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .view-header {
+    height: var(--header-height);
+    display: flex;
+    border-bottom: var(--file-header-border);
+    background-color: var(--background-primary);
+    z-index: 1;
+    position: relative;
+    gap: var(--size-4-2);
+    padding: 0 var(--size-4-3);
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .view-header-title-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex: 1;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .view-header-title-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex: 1;
+  }
 
-:is(:is(#yolo-apply-view, .yolo-apply-view-root) .view-actions) button {
-  color: var(--text-normal);
-  font-weight: var(--font-medium);
-  gap: 2px;
-}
+:is(:is(#yolo-apply-view,.yolo-apply-view-root) .view-actions) button {
+      color: var(--text-normal);
+      font-weight: var(--font-medium);
+      gap: 2px;
+    }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block {
-  display: block;
-  padding: var(--size-4-1) 0;
-  color: var(--yolo-apply-text-color);
-  line-height: var(--line-height-normal);
-  width: 100%;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block {
+    display: block;
+    padding: var(--size-4-1) 0;
+    color: var(--yolo-apply-text-color);
+    line-height: var(--line-height-normal);
+    width: 100%;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block--resolved {
-  animation: yolo-apply-resolve-in 180ms ease;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block--resolved {
+    animation: yolo-apply-resolve-in 180ms ease;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root)
-  .yolo-diff-block--resolved
-  .yolo-apply-markdown-preview {
-  animation: yolo-apply-resolve-in 180ms ease;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block--resolved .yolo-apply-markdown-preview {
+    animation: yolo-apply-resolve-in 180ms ease;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block.added {
-  background-color: rgba(var(--yolo-incoming-color-rgb), 0.12);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block.added {
+    background-color: rgba(var(--yolo-incoming-color-rgb), 0.12);
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block.removed {
-  background-color: rgba(var(--yolo-current-color-rgb), 0.12);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block.removed {
+    background-color: rgba(var(--yolo-current-color-rgb), 0.12);
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block-container {
-  position: relative;
-  scroll-margin-top: var(--size-4-8);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block-container {
+    position: relative;
+    scroll-margin-top: var(--size-4-8);
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block-actions {
-  position: absolute;
-  right: calc(
-    (100% - var(--file-line-width)) / 2 - var(--yolo-apply-actions-offset)
-  );
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.15s ease;
-  z-index: 1;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block-actions {
+    position: absolute;
+    right: calc(
+      (100% - var(--file-line-width)) / 2 - var(--yolo-apply-actions-offset)
+    );
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+    z-index: 1;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-paragraph {
-  pointer-events: auto;
-  position: relative;
-  width: 100%;
-  --yolo-apply-side-gap: calc((100% - var(--file-line-width)) / 2);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph {
+    pointer-events: auto;
+    position: relative;
+    width: 100%;
+    --yolo-apply-side-gap: calc((100% - var(--file-line-width)) / 2);
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-paragraph.has-changes {
-  padding-right: 0;
-  margin-right: 0;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.has-changes {
+    padding-right: 0;
+    margin-right: 0;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-paragraph-indicator {
-  position: absolute;
-  right: calc(var(--yolo-apply-side-gap) - var(--yolo-apply-rail-offset));
-  top: 4px;
-  bottom: 4px;
-  width: 2px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--interactive-accent) 28%, transparent);
-  opacity: 0.6;
-  transition:
-    background 0.15s ease,
-    opacity 0.15s ease;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph-indicator {
+    position: absolute;
+    right: calc(var(--yolo-apply-side-gap) - var(--yolo-apply-rail-offset));
+    top: 4px;
+    bottom: 4px;
+    width: 2px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--interactive-accent) 28%, transparent);
+    opacity: 0.6;
+    transition:
+      background 0.15s ease,
+      opacity 0.15s ease;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root)
-  .yolo-apply-paragraph.has-changes:hover
-  .yolo-apply-paragraph-indicator,
-:is(#yolo-apply-view, .yolo-apply-view-root)
-  .yolo-apply-paragraph.has-changes:focus-within
-  .yolo-apply-paragraph-indicator {
-  background: color-mix(in srgb, var(--interactive-accent) 65%, transparent);
-  opacity: 0.95;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.has-changes:hover .yolo-apply-paragraph-indicator,:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.has-changes:focus-within .yolo-apply-paragraph-indicator {
+    background: color-mix(in srgb, var(--interactive-accent) 65%, transparent);
+    opacity: 0.95;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root)
-  .yolo-apply-paragraph.has-changes.is-active
-  .yolo-apply-paragraph-indicator {
-  background: color-mix(in srgb, var(--interactive-accent) 65%, transparent);
-  opacity: 0.95;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.has-changes.is-active .yolo-apply-paragraph-indicator {
+    background: color-mix(in srgb, var(--interactive-accent) 65%, transparent);
+    opacity: 0.95;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-paragraph.is-empty {
-  min-height: 20px;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.is-empty {
+    min-height: 20px;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-empty-line {
-  height: 12px;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-empty-line {
+    height: 12px;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root)
-  .yolo-apply-paragraph:hover
-  .yolo-diff-block-actions,
-:is(#yolo-apply-view, .yolo-apply-view-root)
-  .yolo-apply-paragraph:focus-within
-  .yolo-diff-block-actions {
-  opacity: 1;
-  pointer-events: auto;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph:hover .yolo-diff-block-actions,:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph:focus-within .yolo-diff-block-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root)
-  .yolo-apply-paragraph.is-active
-  .yolo-diff-block-actions {
-  opacity: 1;
-  pointer-events: auto;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.is-active .yolo-diff-block-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action {
-  width: 26px;
-  height: 26px;
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--text-muted) 40%, transparent);
-  background: color-mix(in srgb, var(--background-primary) 92%, transparent);
-  color: var(--text-normal);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  box-shadow: none;
-  transition:
-    background 0.15s ease,
-    color 0.15s ease,
-    border-color 0.15s ease,
-    transform 0.15s ease;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action {
+    width: 26px;
+    height: 26px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--text-muted) 40%, transparent);
+    background: color-mix(in srgb, var(--background-primary) 92%, transparent);
+    color: var(--text-normal);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: none;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease,
+      border-color 0.15s ease,
+      transform 0.15s ease;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action svg {
-  width: 15px;
-  height: 15px;
-  stroke-width: 2.4;
-  stroke: currentColor;
-  fill: none;
-  opacity: 0.95;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action svg {
+    width: 15px;
+    height: 15px;
+    stroke-width: 2.4;
+    stroke: currentColor;
+    fill: none;
+    opacity: 0.95;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 15px;
-  line-height: 1;
-  font-weight: 600;
-  color: currentColor;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 15px;
+    line-height: 1;
+    font-weight: 600;
+    color: currentColor;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action-icon--merge {
-  font-size: 14px;
-  font-weight: 500;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action-icon--merge {
+    font-size: 14px;
+    font-weight: 500;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action:hover {
-  transform: translateY(-1px);
-  color: var(--text-normal);
-  background: color-mix(
-    in srgb,
-    var(--background-primary) 82%,
-    var(--background-secondary) 18%
-  );
-  border-color: color-mix(in srgb, var(--text-muted) 55%, transparent);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action:hover {
+    transform: translateY(-1px);
+    color: var(--text-normal);
+    background: color-mix(
+      in srgb,
+      var(--background-primary) 82%,
+      var(--background-secondary) 18%
+    );
+    border-color: color-mix(in srgb, var(--text-muted) 55%, transparent);
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action-accept {
-  color: rgb(var(--yolo-incoming-color-rgb));
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action-accept {
+    color: rgb(var(--yolo-incoming-color-rgb));
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action-reject {
-  color: rgb(var(--yolo-current-color-rgb));
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action-reject {
+    color: rgb(var(--yolo-current-color-rgb));
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-accept {
-  color: white;
-  background: rgba(var(--yolo-incoming-color-rgb), 0.8);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-accept {
+    color: white;
+    background: rgba(var(--yolo-incoming-color-rgb), 0.8);
+  }
 
-:is(:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-accept):hover {
-  background: rgba(var(--yolo-incoming-color-rgb), 1);
-}
+:is(:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-accept):hover {
+      background: rgba(var(--yolo-incoming-color-rgb), 1);
+    }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-exclude {
-  color: white;
-  background: rgba(var(--yolo-current-color-rgb), 0.8);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-exclude {
+    color: white;
+    background: rgba(var(--yolo-current-color-rgb), 0.8);
+  }
 
-:is(:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-exclude):hover {
-  background: rgba(var(--yolo-current-color-rgb), 1);
-}
+:is(:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-exclude):hover {
+      background: rgba(var(--yolo-current-color-rgb), 1);
+    }
 
 /* Toolbar styles */
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-toolbar {
-  position: absolute;
-  left: 50%;
-  bottom: var(--size-4-3);
-  transform: translateX(-50%);
-  display: flex;
-  justify-content: center;
-  width: 100%;
-  pointer-events: none;
-  z-index: 3;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-toolbar {
+    position: absolute;
+    left: 50%;
+    bottom: var(--size-4-3);
+    transform: translateX(-50%);
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    pointer-events: none;
+    z-index: 3;
+  }
 
 /* Lift the floating toolbar above Obsidian's mobile navbar (back / menu, etc.). */
 
-body.is-mobile
-  :is(#yolo-apply-view, .yolo-apply-view-root)
-  .yolo-apply-toolbar {
-  bottom: calc(
-    var(--size-4-3) + var(--yolo-apply-toolbar-mobile-offset, 48px) +
-      var(--safe-area-inset-bottom, 0px)
-  );
-}
+body.is-mobile :is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-toolbar {
+    bottom: calc(
+      var(--size-4-3) + var(--yolo-apply-toolbar-mobile-offset, 48px) +
+        var(--safe-area-inset-bottom, 0px)
+    );
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-toolbar-pill {
-  pointer-events: auto;
-  display: flex;
-  align-items: center;
-  gap: var(--size-4-3);
-  padding: var(--size-4-2) var(--size-4-3);
-  border-radius: 999px;
-  max-width: calc(100% - var(--size-4-6));
-  flex-wrap: wrap;
-  justify-content: center;
-  background: color-mix(in srgb, var(--background-secondary) 86%, transparent);
-  border: 1px solid
-    color-mix(in srgb, var(--background-modifier-border) 70%, transparent);
-  backdrop-filter: blur(12px);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-toolbar-pill {
+    pointer-events: auto;
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-3);
+    padding: var(--size-4-2) var(--size-4-3);
+    border-radius: 999px;
+    max-width: calc(100% - var(--size-4-6));
+    flex-wrap: wrap;
+    justify-content: center;
+    background: color-mix(
+      in srgb,
+      var(--background-secondary) 86%,
+      transparent
+    );
+    border: 1px solid
+      color-mix(in srgb, var(--background-modifier-border) 70%, transparent);
+    backdrop-filter: blur(12px);
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-toolbar-nav,
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-toolbar-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--size-4-2);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-toolbar-nav,:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-toolbar-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-2);
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-progress {
-  font-size: var(--font-ui-small);
-  color: var(--text-muted);
-  min-width: 52px;
-  text-align: center;
-  font-variant-numeric: tabular-nums;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-progress {
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+    min-width: 52px;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-btn {
-  padding: 6px var(--size-4-3);
-  font-size: var(--font-ui-small);
-  border-radius: 999px;
-  cursor: pointer;
-  border: 1px solid var(--background-modifier-border);
-  background: color-mix(in srgb, var(--background-primary) 88%, transparent);
-  color: var(--text-normal);
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-btn {
+    padding: 6px var(--size-4-3);
+    font-size: var(--font-ui-small);
+    border-radius: 999px;
+    cursor: pointer;
+    border: 1px solid var(--background-modifier-border);
+    background: color-mix(in srgb, var(--background-primary) 88%, transparent);
+    color: var(--text-normal);
+  }
 
-:is(:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-btn):hover {
-  background: color-mix(
-    in srgb,
-    var(--background-modifier-hover) 88%,
-    transparent
-  );
-}
+:is(:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-btn):hover {
+      background: color-mix(
+        in srgb,
+        var(--background-modifier-hover) 88%,
+        transparent
+      );
+    }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-btn:disabled,
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-icon-btn:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-btn:disabled,:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-icon-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-icon-btn {
-  width: 30px;
-  height: 30px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  border: 1px solid var(--background-modifier-border);
-  background: color-mix(in srgb, var(--background-primary) 88%, transparent);
-  color: var(--text-muted);
-  cursor: pointer;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-icon-btn {
+    width: 30px;
+    height: 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    border: 1px solid var(--background-modifier-border);
+    background: color-mix(in srgb, var(--background-primary) 88%, transparent);
+    color: var(--text-muted);
+    cursor: pointer;
+  }
 
-:is(:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-icon-btn):hover {
-  color: var(--text-normal);
-  background: color-mix(
-    in srgb,
-    var(--background-modifier-hover) 88%,
-    transparent
-  );
-}
+:is(:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-icon-btn):hover {
+      color: var(--text-normal);
+      background: color-mix(
+        in srgb,
+        var(--background-modifier-hover) 88%,
+        transparent
+      );
+    }
 
-:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-icon {
-  font-size: 14px;
-  line-height: 1;
-  font-weight: 600;
-}
+:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-icon {
+    font-size: 14px;
+    line-height: 1;
+    font-weight: 600;
+  }
 
 :is(#yolo-apply-view, .yolo-apply-view-root)
   .yolo-apply-markdown.markdown-rendered {
@@ -14046,22 +14014,22 @@ button.yolo-chat-input-model-select {
 }
 
 button.yolo-chat-input-model-select:hover {
-  color: var(--text-normal);
-}
+    color: var(--text-normal);
+  }
 
 button.yolo-chat-input-model-select .yolo-chat-input-model-select__model-name {
-  flex-shrink: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
 button.yolo-chat-input-model-select .yolo-chat-input-model-select__icon {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 
 .yolo-query-progress {
   font-size: var(--font-ui-smaller);

--- a/styles.css
+++ b/styles.css
@@ -227,10 +227,10 @@
 }
 
 .yolo-settings-actions svg {
-    height: var(--icon-l);
-    width: var(--icon-l);
-    stroke-width: var(--icon-stroke);
-  }
+  height: var(--icon-l);
+  width: var(--icon-l);
+  stroke-width: var(--icon-stroke);
+}
 
 .yolo-settings-kv-entry.setting-item .setting-item-info {
   display: none;
@@ -626,8 +626,8 @@
 }
 
 .yolo-assistant-message-metadata-toggle:hover {
-    background-color: transparent;
-  }
+  background-color: transparent;
+}
 
 .yolo-assistant-message-metadata-toggle.is-static {
   cursor: default;
@@ -727,92 +727,94 @@
 /* Overrides default .markdown-rendered class styles from Obsidian */
 
 .yolo-markdown-rendered.markdown-rendered {
-    --render-scale: 1;
-    font-size: calc(var(--render-scale) * 1rem);
-    line-height: 1.5;
-  }
+  --render-scale: 1;
+  font-size: calc(var(--render-scale) * 1rem);
+  line-height: 1.5;
+}
 
 .yolo-markdown-rendered.markdown-rendered.yolo-scale-xs {
-      --render-scale: 0.8;
-    }
+  --render-scale: 0.8;
+}
 
 .yolo-markdown-rendered.markdown-rendered.yolo-scale-sm {
-      --render-scale: 0.85;
-    }
+  --render-scale: 0.85;
+}
 
 .yolo-markdown-rendered.markdown-rendered.yolo-scale-base {
-      --render-scale: 1;
-    }
+  --render-scale: 1;
+}
 
 .yolo-markdown-rendered.markdown-rendered {
+  /* override default variables */
+  --p-spacing: calc(var(--render-scale) * 1rem);
+  --heading-spacing: calc(var(--p-spacing) * 1.75);
+  --checkbox-size: calc(var(--render-scale) * 1rem);
+  --checkbox-radius: calc(var(--render-scale) * var(--radius-s));
+  --icon-size: calc(var(--render-scale) * var(--icon-m));
 
-    /* override default variables */
-    --p-spacing: calc(var(--render-scale) * 1rem);
-    --heading-spacing: calc(var(--p-spacing) * 1.75);
-    --checkbox-size: calc(var(--render-scale) * 1rem);
-    --checkbox-radius: calc(var(--render-scale) * var(--radius-s));
-    --icon-size: calc(var(--render-scale) * var(--icon-m));
-
-    /* adjust list indent */
-    --list-indent: 1.5em;
-  }
+  /* adjust list indent */
+  --list-indent: 1.5em;
+}
 
 .yolo-markdown-rendered.markdown-rendered blockquote {
-      padding-inline-start: calc(var(--render-scale) * 1.5rem);
-    }
+  padding-inline-start: calc(var(--render-scale) * 1.5rem);
+}
 
 .yolo-markdown-rendered.markdown-rendered pre {
-      padding: calc(var(--render-scale) * 0.75rem)
-        calc(var(--render-scale) * 1rem);
-    }
+  padding: calc(var(--render-scale) * 0.75rem) calc(var(--render-scale) * 1rem);
+}
 
 .yolo-markdown-rendered.markdown-rendered :not(pre) > code {
-      word-break: break-all;
-    }
+  word-break: break-all;
+}
 
 .yolo-markdown-rendered.markdown-rendered hr {
-      margin: calc(var(--render-scale) * 2rem) 0;
-    }
+  margin: calc(var(--render-scale) * 2rem) 0;
+}
 
-.yolo-markdown-rendered.markdown-rendered th,.yolo-markdown-rendered.markdown-rendered td {
-      font-size: calc(var(--render-scale) * 1rem);
-      padding: calc(var(--render-scale) * 0.25rem)
-        calc(var(--render-scale) * 0.5rem);
-    }
+.yolo-markdown-rendered.markdown-rendered th,
+.yolo-markdown-rendered.markdown-rendered td {
+  font-size: calc(var(--render-scale) * 1rem);
+  padding: calc(var(--render-scale) * 0.25rem)
+    calc(var(--render-scale) * 0.5rem);
+}
 
 .yolo-markdown-rendered.markdown-rendered .callout {
-      padding: calc(var(--render-scale) * 0.75rem)
-        calc(var(--render-scale) * 0.75rem) calc(var(--render-scale) * 0.75rem)
-        calc(var(--render-scale) * 1.5rem);
-    }
+  padding: calc(var(--render-scale) * 0.75rem)
+    calc(var(--render-scale) * 0.75rem) calc(var(--render-scale) * 0.75rem)
+    calc(var(--render-scale) * 1.5rem);
+}
 
 .yolo-markdown-rendered.markdown-rendered .callout-icon {
-      height: calc(var(--render-scale) * 1rem);
-      width: calc(var(--render-scale) * 1rem);
-    }
+  height: calc(var(--render-scale) * 1rem);
+  width: calc(var(--render-scale) * 1rem);
+}
 
 .yolo-markdown-rendered.markdown-rendered .math {
-      user-select: text;
-      cursor: text;
-    }
+  user-select: text;
+  cursor: text;
+}
 
-:is(.yolo-markdown-rendered.markdown-rendered .math)::selection,:is(.yolo-markdown-rendered.markdown-rendered .math) *::selection {
-        background: var(--text-selection);
-      }
+:is(.yolo-markdown-rendered.markdown-rendered .math)::selection,
+:is(.yolo-markdown-rendered.markdown-rendered .math) *::selection {
+  background: var(--text-selection);
+}
 
-:is(.yolo-markdown-rendered.markdown-rendered .math) mjx-math.yolo-latex-selected,.yolo-latex-selected:is(.yolo-markdown-rendered.markdown-rendered .math) {
-        background: var(--text-selection);
-        border-radius: 0;
-      }
+:is(.yolo-markdown-rendered.markdown-rendered .math)
+  mjx-math.yolo-latex-selected,
+.yolo-latex-selected:is(.yolo-markdown-rendered.markdown-rendered .math) {
+  background: var(--text-selection);
+  border-radius: 0;
+}
 
 /* Show frontmatter which is hidden by default */
 
 .yolo-markdown-rendered .frontmatter {
-    display: block !important;
-    background-color: transparent;
-    border-top: 1px solid var(--background-modifier-border);
-    border-bottom: 1px solid var(--background-modifier-border);
-  }
+  display: block !important;
+  background-color: transparent;
+  border-top: 1px solid var(--background-modifier-border);
+  border-bottom: 1px solid var(--background-modifier-border);
+}
 
 .yolo-stream-fresh-text {
   display: inline;
@@ -849,17 +851,17 @@
 }
 
 .yolo-settings-description-preserve-whitespace .setting-item-description {
-    white-space: pre-wrap;
-  }
+  white-space: pre-wrap;
+}
 
 .yolo-settings-desc-copyable .setting-item-description {
-    user-select: text;
-    cursor: text;
-  }
+  user-select: text;
+  cursor: text;
+}
 
 .yolo-obsidian-code-block pre {
-    margin: 0;
-  }
+  margin: 0;
+}
 
 .yolo-syntax-highlighter {
   margin: 0;
@@ -1168,8 +1170,8 @@
 }
 
 .yolo-toolcall-container .yolo-toolcall-border-top {
-    border-top: none;
-  }
+  border-top: none;
+}
 
 .yolo-toolcall {
   display: flex;
@@ -1202,84 +1204,85 @@
 }
 
 .yolo-toolcall-header:focus-visible {
-    outline: 2px solid
-      color-mix(in srgb, var(--interactive-accent) 55%, transparent);
-    outline-offset: 1px;
-    box-shadow: none !important;
-    background: transparent !important;
-  }
+  outline: 2px solid
+    color-mix(in srgb, var(--interactive-accent) 55%, transparent);
+  outline-offset: 1px;
+  box-shadow: none !important;
+  background: transparent !important;
+}
 
 .yolo-toolcall-header:hover {
-    background-color: transparent;
-    color: var(--text-normal);
-  }
+  background-color: transparent;
+  color: var(--text-normal);
+}
 
 .yolo-toolcall-header .yolo-toolcall-header-content {
-    min-width: 0;
-    flex: 1 1 auto;
-  }
+  min-width: 0;
+  flex: 1 1 auto;
+}
 
 .yolo-toolcall-header .yolo-toolcall-header-icon {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 16px;
-    height: 16px;
-    color: var(--text-faint);
-  }
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--text-faint);
+}
 
 .yolo-toolcall-header .yolo-toolcall-header-icon--status-inline {
-    color: var(--text-muted);
-  }
+  color: var(--text-muted);
+}
 
 .yolo-toolcall-header .yolo-toolcall-header-icon--expand {
-    margin-left: auto;
-    color: var(--text-faint);
-    opacity: 0.9;
-  }
+  margin-left: auto;
+  color: var(--text-faint);
+  opacity: 0.9;
+}
 
 .yolo-toolcall-header .yolo-toolcall-header-tool-name {
-    display: flex;
-    align-items: baseline;
-    gap: 2px;
-    min-width: 0;
-    font-family: var(--font-ui);
-    font-weight: var(--font-normal);
-    font-size: var(--font-ui-smaller);
-    line-height: 1.35;
-  }
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+  min-width: 0;
+  font-family: var(--font-ui);
+  font-weight: var(--font-normal);
+  font-size: var(--font-ui-smaller);
+  line-height: 1.35;
+}
 
-.yolo-toolcall-header .yolo-toolcall-header-title,.yolo-toolcall-header .yolo-toolcall-header-separator {
-    flex: 0 0 auto;
-    white-space: nowrap;
-  }
+.yolo-toolcall-header .yolo-toolcall-header-title,
+.yolo-toolcall-header .yolo-toolcall-header-separator {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
 
 .yolo-toolcall-header .yolo-toolcall-header-summary {
-    min-width: 0;
-    flex: 0 1 auto;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+  min-width: 0;
+  flex: 0 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 .yolo-toolcall-header .yolo-toolcall-header-edit-deltas {
-    flex: 0 0 auto;
-    display: inline-flex;
-    align-items: baseline;
-    gap: 4px;
-    margin-left: 6px;
-    white-space: nowrap;
-    font-variant-numeric: tabular-nums;
-  }
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  margin-left: 6px;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
 
 .yolo-toolcall-header .yolo-toolcall-header-edit-added {
-    color: var(--text-success);
-  }
+  color: var(--text-success);
+}
 
 .yolo-toolcall-header .yolo-toolcall-header-edit-removed {
-    color: var(--text-error);
-  }
+  color: var(--text-error);
+}
 
 .yolo-toolcall-content {
   display: flex;
@@ -1296,10 +1299,10 @@
 }
 
 .yolo-toolcall-content .yolo-toolcall-content-section {
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-2-3);
-  }
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-2-3);
+}
 
 .yolo-toolcall-compaction-pending {
   display: inline-flex;
@@ -1366,22 +1369,22 @@
 }
 
 .yolo-toolcall-footer .yolo-toolcall-footer-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--size-4-1);
-  }
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-1);
+}
 
 :is(.yolo-toolcall-footer .yolo-toolcall-footer-actions) button {
-      background-color: var(--background-primary-alt);
-      border: 1px solid var(--background-modifier-border);
-      box-shadow: none;
-    }
+  background-color: var(--background-primary-alt);
+  border: 1px solid var(--background-modifier-border);
+  box-shadow: none;
+}
 
 :is(:is(.yolo-toolcall-footer .yolo-toolcall-footer-actions) button):hover {
-        background-color: var(--background-modifier-hover);
-        border: 1px solid var(--background-modifier-border-hover);
-        box-shadow: none;
-      }
+  background-color: var(--background-modifier-hover);
+  border: 1px solid var(--background-modifier-border-hover);
+  box-shadow: none;
+}
 
 @media (prefers-reduced-motion: reduce) {
   .yolo-toolcall-compaction-pending {
@@ -1395,14 +1398,14 @@
 }
 
 .yolo-split-button .yolo-split-button-primary {
-    border-radius: var(--button-radius) 0 0 var(--button-radius) !important;
-  }
+  border-radius: var(--button-radius) 0 0 var(--button-radius) !important;
+}
 
 .yolo-split-button .yolo-split-button-toggle {
-    padding: var(--size-4-1);
-    border-radius: 0 var(--button-radius) var(--button-radius) 0 !important;
-    border-left: none !important;
-  }
+  padding: var(--size-4-1);
+  border-radius: 0 var(--button-radius) var(--button-radius) 0 !important;
+  border-left: none !important;
+}
 
 /* Providers and Models Section Styles */
 
@@ -2714,24 +2717,24 @@ body.theme-dark .yolo-pp-badge--mute {
 }
 
 .yolo-mcp-servers-header > div {
-    padding: var(--size-4-1);
-  }
+  padding: var(--size-4-1);
+}
 
 .yolo-mcp-servers-header > div:nth-child(1) {
-    text-align: left;
-  }
+  text-align: left;
+}
 
 .yolo-mcp-servers-header > div:nth-child(2) {
-    text-align: left;
-  }
+  text-align: left;
+}
 
 .yolo-mcp-servers-header > div:nth-child(3) {
-    text-align: center;
-  }
+  text-align: center;
+}
 
 .yolo-mcp-servers-header > div:nth-child(4) {
-    text-align: center;
-  }
+  text-align: center;
+}
 
 .yolo-mcp-servers-empty {
   padding: var(--size-4-4) 0;
@@ -2754,8 +2757,8 @@ body.theme-dark .yolo-pp-badge--mute {
 }
 
 .yolo-mcp-server-row > div {
-    padding: var(--size-4-1);
-  }
+  padding: var(--size-4-1);
+}
 
 .yolo-mcp-server-name {
   overflow: hidden;
@@ -2780,10 +2783,10 @@ body.theme-dark .yolo-pp-badge--mute {
 }
 
 .yolo-mcp-server-actions svg {
-    height: var(--icon-l);
-    width: var(--icon-l);
-    stroke-width: var(--icon-stroke);
-  }
+  height: var(--icon-l);
+  width: var(--icon-l);
+  stroke-width: var(--icon-stroke);
+}
 
 .yolo-server-expanded-info {
   margin-bottom: var(--size-4-4);
@@ -2967,14 +2970,14 @@ button.yolo-mcp-tool-description-toggle.is-expanded {
 }
 
 .yolo-mcp-parameters-info-icon:hover {
-    color: var(--text-normal);
-    background: transparent !important;
-  }
+  color: var(--text-normal);
+  background: transparent !important;
+}
 
 .yolo-mcp-parameters-info-icon:focus-visible {
-    outline: 2px solid var(--interactive-accent);
-    outline-offset: 1px;
-  }
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 1px;
+}
 
 .yolo-mcp-sr-only {
   position: absolute;
@@ -3048,12 +3051,12 @@ button.yolo-mcp-tool-description-toggle.is-expanded {
 }
 
 .yolo-mcp-server-modal-validation.yolo-mcp-server-modal-validation--error {
-    color: var(--text-error);
-  }
+  color: var(--text-error);
+}
 
 .yolo-mcp-server-modal-validation.yolo-mcp-server-modal-validation--success {
-    color: var(--text-success);
-  }
+  color: var(--text-success);
+}
 
 .yolo-rag-layout {
   display: flex;
@@ -3424,16 +3427,16 @@ button.yolo-mcp-tool-description-toggle.is-expanded {
 }
 
 .yolo-templates-header > div {
-    padding: var(--size-4-1);
-  }
+  padding: var(--size-4-1);
+}
 
 .yolo-templates-header > div:nth-child(1) {
-    text-align: left;
-  }
+  text-align: left;
+}
 
 .yolo-templates-header > div:nth-child(2) {
-    text-align: center;
-  }
+  text-align: center;
+}
 
 .yolo-templates-empty {
   padding: var(--size-4-4) 0;
@@ -3456,8 +3459,8 @@ button.yolo-mcp-tool-description-toggle.is-expanded {
 }
 
 .yolo-template-row > div {
-    padding: var(--size-4-1);
-  }
+  padding: var(--size-4-1);
+}
 
 .yolo-template-name {
   overflow: hidden;
@@ -3472,10 +3475,10 @@ button.yolo-mcp-tool-description-toggle.is-expanded {
 }
 
 .yolo-template-actions svg {
-    height: var(--icon-l);
-    width: var(--icon-l);
-    stroke-width: var(--icon-stroke);
-  }
+  height: var(--icon-l);
+  width: var(--icon-l);
+  stroke-width: var(--icon-stroke);
+}
 
 .yolo-continue-response-button-container {
   display: flex;
@@ -7508,10 +7511,10 @@ button.yolo-agent-chip--more:hover {
 }
 
 .yolo-chat-header-buttons svg {
-    height: var(--icon-l);
-    width: var(--icon-l);
-    stroke-width: var(--icon-stroke);
-  }
+  height: var(--icon-l);
+  width: var(--icon-l);
+  stroke-width: var(--icon-stroke);
+}
 
 .yolo-markdown {
   line-height: var(--line-height-normal);
@@ -7519,90 +7522,90 @@ button.yolo-agent-chip--more:hover {
 }
 
 .yolo-markdown h1 {
-    font-size: var(--font-ui-large);
-  }
+  font-size: var(--font-ui-large);
+}
 
 .yolo-markdown h2 {
-    font-size: var(--font-ui-medium);
-  }
+  font-size: var(--font-ui-medium);
+}
 
 .yolo-markdown h3 {
-    font-size: var(--font-ui-small);
-  }
+  font-size: var(--font-ui-small);
+}
 
 .yolo-markdown h4 {
-    font-size: var(--font-ui-smaller);
-  }
+  font-size: var(--font-ui-smaller);
+}
 
 .yolo-markdown h5 {
-    font-size: var(--font-ui-smallest);
-  }
+  font-size: var(--font-ui-smallest);
+}
 
 .yolo-markdown h6 {
-    font-size: var(--font-ui-smallest);
-  }
+  font-size: var(--font-ui-smallest);
+}
 
 .yolo-markdown p {
-    font-size: var(--font-ui-small);
-  }
+  font-size: var(--font-ui-small);
+}
 
 .yolo-markdown ul {
-    font-size: var(--font-ui-small);
-    padding-left: var(--size-4-4);
-  }
+  font-size: var(--font-ui-small);
+  padding-left: var(--size-4-4);
+}
 
 .yolo-markdown ol {
-    font-size: var(--font-ui-small);
-    padding-left: var(--size-4-4);
-  }
+  font-size: var(--font-ui-small);
+  padding-left: var(--size-4-4);
+}
 
 .yolo-markdown li {
-    font-size: var(--font-ui-small);
-  }
+  font-size: var(--font-ui-small);
+}
 
 .yolo-markdown blockquote {
-    font-size: var(--font-ui-small);
-    font-style: var(--blockquote-style);
-    background-color: var(--blockquote-background-color);
-    margin: 0;
-    padding-left: var(--size-4-2);
-    border-left: var(--blockquote-border-thickness) solid
-      var(--blockquote-border-color);
-  }
+  font-size: var(--font-ui-small);
+  font-style: var(--blockquote-style);
+  background-color: var(--blockquote-background-color);
+  margin: 0;
+  padding-left: var(--size-4-2);
+  border-left: var(--blockquote-border-thickness) solid
+    var(--blockquote-border-color);
+}
 
 .yolo-markdown code {
-    font-size: var(--font-ui-small);
-    border-radius: var(--code-radius);
-    padding: 0.1em 0.25em;
-    color: var(--code-normal);
-    font-size: var(--code-size);
-    background-color: var(--code-background);
-    vertical-align: baseline;
-  }
+  font-size: var(--font-ui-small);
+  border-radius: var(--code-radius);
+  padding: 0.1em 0.25em;
+  color: var(--code-normal);
+  font-size: var(--code-size);
+  background-color: var(--code-background);
+  vertical-align: baseline;
+}
 
 .yolo-markdown table {
-    font-size: var(--font-ui-small);
-  }
+  font-size: var(--font-ui-small);
+}
 
 .yolo-markdown thead {
-    font-size: var(--font-ui-small);
-  }
+  font-size: var(--font-ui-small);
+}
 
 .yolo-markdown tbody {
-    font-size: var(--font-ui-small);
-  }
+  font-size: var(--font-ui-small);
+}
 
 .yolo-markdown tr {
-    font-size: var(--font-ui-small);
-  }
+  font-size: var(--font-ui-small);
+}
 
 .yolo-markdown td {
-    font-size: var(--font-ui-small);
-  }
+  font-size: var(--font-ui-small);
+}
 
 .yolo-markdown th {
-    font-size: var(--font-ui-small);
-  }
+  font-size: var(--font-ui-small);
+}
 
 .yolo-chat-container {
   display: flex;
@@ -8355,6 +8358,12 @@ button.yolo-agent-chip--more:hover {
   gap: var(--size-2-2);
 }
 
+.yolo-checkbox-container.is-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 /* 优先参考目录样式优化 */
 
 .yolo-composer-hint {
@@ -8415,29 +8424,29 @@ button.yolo-agent-chip--more:hover {
    * collapse the spacer back to 0 and re-introduce the occlusion bug. */
 }
 
-.yolo-chat-messages  > .yolo-chat-timeline-bottom-spacer {
-    flex: 0 0 auto;
-  }
+.yolo-chat-messages > .yolo-chat-timeline-bottom-spacer {
+  flex: 0 0 auto;
+}
 
 .yolo-chat-messages .yolo-chat-messages-user {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-    align-items: flex-end;
-  }
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  align-items: flex-end;
+}
 
 .yolo-chat-messages .yolo-chat-messages-assistant {
-    display: flex;
-    flex-direction: column;
-  }
+  display: flex;
+  flex-direction: column;
+}
 
 .yolo-chat-messages .yolo-assistant-tool-message-group {
-    padding-bottom: var(--size-4-2);
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-4-1);
-  }
+  padding-bottom: var(--size-4-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-4-1);
+}
 
 .yolo-chat-timeline-row {
   display: flex;
@@ -8505,10 +8514,10 @@ button.yolo-agent-chip--more:hover {
 }
 
 .yolo-chat-compaction-divider.is-entering .yolo-chat-compaction-divider__line {
-    transform-origin: center;
-    animation: yolo-chat-compaction-divider-line-enter 220ms
-      cubic-bezier(0.2, 0.8, 0.2, 1) both;
-  }
+  transform-origin: center;
+  animation: yolo-chat-compaction-divider-line-enter 220ms
+    cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
 
 .yolo-chat-compaction-divider__title {
   font-size: var(--font-ui-small);
@@ -9039,10 +9048,13 @@ button.yolo-agent-chip--more:hover {
   --yolo-mention-badge-max-width: 180px;
 }
 
-.yolo-chat-user-input-container:focus-within,.yolo-chat-user-input-container:focus,.yolo-chat-user-input-container:focus-visible,.yolo-chat-user-input-container:active {
-    box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
-    transition: box-shadow 0.15s ease-in-out;
-  }
+.yolo-chat-user-input-container:focus-within,
+.yolo-chat-user-input-container:focus,
+.yolo-chat-user-input-container:focus-visible,
+.yolo-chat-user-input-container:active {
+  box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
+  transition: box-shadow 0.15s ease-in-out;
+}
 
 .yolo-chat-user-input-container[data-resizable='true'] .yolo-obsidian-textarea,
 .yolo-chat-user-input-container[data-resizable='true'] .yolo-content-editable {
@@ -9269,21 +9281,21 @@ button.yolo-agent-chip--more:hover {
 }
 
 .yolo-chat-user-input-placeholder .yolo-placeholder-trigger {
-    pointer-events: auto;
-    display: inline-block;
-    min-width: 1.4em;
-    text-align: center;
-    padding: 0 3px;
-    border-radius: 3px;
-    background-color: var(--tag-background);
-    color: var(--tag-color);
-    cursor: pointer;
-    transition: opacity 80ms ease;
-  }
+  pointer-events: auto;
+  display: inline-block;
+  min-width: 1.4em;
+  text-align: center;
+  padding: 0 3px;
+  border-radius: 3px;
+  background-color: var(--tag-background);
+  color: var(--tag-color);
+  cursor: pointer;
+  transition: opacity 80ms ease;
+}
 
 :is(.yolo-chat-user-input-placeholder .yolo-placeholder-trigger):hover {
-      opacity: 0.75;
-    }
+  opacity: 0.75;
+}
 
 .yolo-chat-user-input-controls {
   display: flex;
@@ -9297,35 +9309,36 @@ button.yolo-agent-chip--more:hover {
 }
 
 .yolo-chat-user-input-controls .yolo-chat-user-input-controls__left {
-    display: flex;
-    align-items: center;
-    gap: var(--size-4-3);
-    flex: 1 1 auto;
-    min-width: 0;
-    overflow: hidden;
-  }
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-3);
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
 
 .yolo-chat-user-input-controls .yolo-chat-user-input-controls__right {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: var(--size-4-2);
-    flex: 0 1 auto;
-    min-width: 0;
-  }
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--size-4-2);
+  flex: 0 1 auto;
+  min-width: 0;
+}
 
-.yolo-chat-user-input-controls .yolo-chat-user-input-controls__model-select-container {
-    flex: 1 1 180px;
-    min-width: 0;
-    overflow: hidden;
-  }
+.yolo-chat-user-input-controls
+  .yolo-chat-user-input-controls__model-select-container {
+  flex: 1 1 180px;
+  min-width: 0;
+  overflow: hidden;
+}
 
 .yolo-chat-user-input-controls .yolo-chat-user-input-controls__buttons {
-    flex-shrink: 0;
-    display: flex;
-    gap: var(--size-4-2);
-    align-items: center;
-  }
+  flex-shrink: 0;
+  display: flex;
+  gap: var(--size-4-2);
+  align-items: center;
+}
 
 .yolo-chat-user-input-controls__left .yolo-chat-input-model-select {
   max-width: 160px;
@@ -9366,15 +9379,16 @@ button.yolo-agent-chip--more:hover {
 }
 
 :is(.yolo-chat-user-input-controls .yolo-chat-user-input-submit-button):hover {
-    color: var(--text-normal);
-  }
+  color: var(--text-normal);
+}
 
-:is(.yolo-chat-user-input-controls .yolo-chat-user-input-submit-button) .yolo-chat-user-input-submit-button-icons {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-shrink: 0;
-  }
+:is(.yolo-chat-user-input-controls .yolo-chat-user-input-submit-button)
+  .yolo-chat-user-input-submit-button-icons {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+}
 
 .yolo-chat-user-input-submit-button-label {
   min-width: 0;
@@ -9395,10 +9409,12 @@ button.yolo-agent-chip--more:hover {
   color: var(--text-muted);
 }
 
-:is(.yolo-chat-user-input-controls__left .yolo-chat-user-input-upload-button):hover {
-    color: var(--text-normal);
-    background: var(--background-modifier-hover);
-  }
+:is(
+    .yolo-chat-user-input-controls__left .yolo-chat-user-input-upload-button
+  ):hover {
+  color: var(--text-normal);
+  background: var(--background-modifier-hover);
+}
 
 .yolo-chat-input-model-select__label {
   min-width: 0;
@@ -9798,17 +9814,17 @@ button.yolo-chat-user-input-submit-button-circle.is-stop:hover:not(:disabled) {
 }
 
 .yolo-chat-user-input-file-badge.yolo-chat-user-input-file-badge-focused {
-    border: 1px solid var(--interactive-accent);
-  }
+  border: 1px solid var(--interactive-accent);
+}
 
 .yolo-chat-user-input-file-badge .yolo-excluded-content {
-    text-decoration: line-through;
-    font-style: italic;
-  }
+  text-decoration: line-through;
+  font-style: italic;
+}
 
 .yolo-chat-user-input-file-badge svg {
-    flex-shrink: 0;
-  }
+  flex-shrink: 0;
+}
 
 .yolo-chat-user-input-file-badge:hover {
   background-color: var(--background-modifier-hover);
@@ -9917,9 +9933,9 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-chat-user-input-file-content-preview img {
-    max-width: 100%;
-    max-height: 350px;
-  }
+  max-width: 100%;
+  max-height: 350px;
+}
 
 .yolo-agent-mode-warning-modal {
   display: flex;
@@ -10176,18 +10192,18 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-settings-textarea .yolo-item-control {
-    width: 100%;
-  }
+  width: 100%;
+}
 
 .yolo-settings-textarea .setting-item-control {
-    padding-bottom: 0;
-  }
+  padding-bottom: 0;
+}
 
 .yolo-settings-textarea textarea {
-    width: 100%;
-    min-height: 100px;
-    resize: none;
-  }
+  width: 100%;
+  min-height: 100px;
+  resize: none;
+}
 
 /* prevent setting-item:first-child overwriting padding-top and border-top */
 
@@ -10206,12 +10222,12 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-settings-model-container .setting-item {
-    border-top: none;
-  }
+  border-top: none;
+}
 
 :is(.yolo-settings-model-container .setting-item):first-child {
-      margin-top: var(--size-4-2);
-    }
+  margin-top: var(--size-4-2);
+}
 
 .yolo-settings-plain.setting-item {
   padding: 0;
@@ -10248,51 +10264,51 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-dialog-content .yolo-dialog-header {
-    margin-bottom: var(--size-4-2);
-    display: grid;
-    gap: var(--size-2-3);
-  }
+  margin-bottom: var(--size-4-2);
+  display: grid;
+  gap: var(--size-2-3);
+}
 
 .yolo-dialog-content .yolo-dialog-title {
-    font-size: var(--font-ui-medium);
-    font-weight: var(--font-semibold);
-    line-height: var(--line-height-tight);
-    margin: 0;
-  }
+  font-size: var(--font-ui-medium);
+  font-weight: var(--font-semibold);
+  line-height: var(--line-height-tight);
+  margin: 0;
+}
 
 .yolo-dialog-content .yolo-dialog-input {
-    display: grid;
-    gap: var(--size-4-1);
-  }
+  display: grid;
+  gap: var(--size-4-1);
+}
 
 :is(.yolo-dialog-content .yolo-dialog-input) label {
-      font-size: var(--font-ui-smaller);
-    }
+  font-size: var(--font-ui-smaller);
+}
 
 .yolo-dialog-content .yolo-dialog-description {
-    font-size: var(--font-ui-small);
-    color: var(--text-muted);
-    margin: 0;
-  }
+  font-size: var(--font-ui-small);
+  color: var(--text-muted);
+  margin: 0;
+}
 
 .yolo-dialog-content .yolo-dialog-footer {
-    margin-top: var(--size-4-2);
-    display: flex;
-    justify-content: flex-end;
-  }
+  margin-top: var(--size-4-2);
+  display: flex;
+  justify-content: flex-end;
+}
 
 .yolo-dialog-content .yolo-dialog-close {
-    position: absolute;
-    right: var(--size-4-4);
-    top: var(--size-4-4);
-    cursor: var(--cursor);
-    opacity: 0.7;
-    transition: opacity 0.2s;
-  }
+  position: absolute;
+  right: var(--size-4-4);
+  top: var(--size-4-4);
+  cursor: var(--cursor);
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
 
 :is(.yolo-dialog-content .yolo-dialog-close):hover {
-      opacity: 1;
-    }
+  opacity: 1;
+}
 
 .yolo-template-menu-item {
   display: flex;
@@ -10303,17 +10319,17 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 }
 
 .yolo-template-menu-item .yolo-template-menu-item-delete {
-    display: flex;
-    align-items: center;
-    padding: var(--size-4-1);
-    margin: calc(var(--size-4-1) * -1);
-    opacity: 0.7;
-    transition: opacity 0.2s;
-  }
+  display: flex;
+  align-items: center;
+  padding: var(--size-4-1);
+  margin: calc(var(--size-4-1) * -1);
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
 
 :is(.yolo-template-menu-item .yolo-template-menu-item-delete):hover {
-      opacity: 1;
-    }
+  opacity: 1;
+}
 
 .yolo-assistant-message-actions {
   display: flex;
@@ -11845,51 +11861,56 @@ button.yolo-llm-debug-modal-button:focus-visible {
 }
 
 .yolo-similarity-search-results .yolo-similarity-search-results__trigger {
-    display: flex;
-    align-items: center;
-    gap: var(--size-4-1);
-    padding: var(--size-4-1);
-    border-radius: var(--radius-s);
-    cursor: pointer;
-  }
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-1);
+  padding: var(--size-4-1);
+  border-radius: var(--radius-s);
+  cursor: pointer;
+}
 
-:is(.yolo-similarity-search-results .yolo-similarity-search-results__trigger):hover {
-      background-color: var(--background-modifier-hover);
-    }
+:is(
+    .yolo-similarity-search-results .yolo-similarity-search-results__trigger
+  ):hover {
+  background-color: var(--background-modifier-hover);
+}
 
 .yolo-similarity-search-results .yolo-similarity-search-item {
-    display: flex;
-    align-items: center;
-    justify-content: start;
-    gap: var(--size-4-2);
-    padding: var(--size-4-1);
-    border-radius: var(--radius-s);
-    cursor: pointer;
-  }
+  display: flex;
+  align-items: center;
+  justify-content: start;
+  gap: var(--size-4-2);
+  padding: var(--size-4-1);
+  border-radius: var(--radius-s);
+  cursor: pointer;
+}
 
 :is(.yolo-similarity-search-results .yolo-similarity-search-item):hover {
-      background-color: var(--background-modifier-hover);
-    }
+  background-color: var(--background-modifier-hover);
+}
 
-:is(.yolo-similarity-search-results .yolo-similarity-search-item) .yolo-similarity-search-item__similarity {
-      flex-shrink: 0;
-      font-size: var(--font-smallest);
-      color: var(--text-muted);
-    }
+:is(.yolo-similarity-search-results .yolo-similarity-search-item)
+  .yolo-similarity-search-item__similarity {
+  flex-shrink: 0;
+  font-size: var(--font-smallest);
+  color: var(--text-muted);
+}
 
-:is(.yolo-similarity-search-results .yolo-similarity-search-item) .yolo-similarity-search-item__path {
-      flex-shrink: 1;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      font-size: var(--font-smallest);
-    }
+:is(.yolo-similarity-search-results .yolo-similarity-search-item)
+  .yolo-similarity-search-item__path {
+  flex-shrink: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: var(--font-smallest);
+}
 
-:is(.yolo-similarity-search-results .yolo-similarity-search-item) .yolo-similarity-search-item__line-numbers {
-      flex-shrink: 0;
-      margin-left: auto;
-      font-size: var(--font-smallest);
-    }
+:is(.yolo-similarity-search-results .yolo-similarity-search-item)
+  .yolo-similarity-search-item__line-numbers {
+  flex-shrink: 0;
+  margin-left: auto;
+  font-size: var(--font-smallest);
+}
 
 .yolo-llm-info-content {
   width: 320px;
@@ -12918,10 +12939,10 @@ button.yolo-chat-list-dropdown-archive-toggle:focus-visible
 }
 
 .yolo-chat-list-dropdown-item-actions svg {
-    height: var(--icon-xs);
-    width: var(--icon-xs);
-    stroke-width: var(--icon-stroke);
-  }
+  height: var(--icon-xs);
+  width: var(--icon-xs);
+  stroke-width: var(--icon-stroke);
+}
 
 .yolo-chat-list-inline-actions {
   display: grid;
@@ -13071,8 +13092,8 @@ button.yolo-chat-list-dropdown-archive-toggle:focus-visible
 }
 
 .yolo-code-block-header-filename:hover {
-    text-decoration: underline;
-  }
+  text-decoration: underline;
+}
 
 .yolo-code-block-header-button-container {
   margin-left: auto;
@@ -13084,18 +13105,19 @@ button.yolo-chat-list-dropdown-archive-toggle:focus-visible
 }
 
 .yolo-code-block-header-button-container .yolo-code-block-header-button {
-    height: 100%;
-    padding: 0 var(--size-4-2);
-    display: flex;
-    gap: var(--size-4-1);
-    font-size: var(--font-small);
-  }
+  height: 100%;
+  padding: 0 var(--size-4-2);
+  display: flex;
+  gap: var(--size-4-1);
+  font-size: var(--font-small);
+}
 
 /* Override clickable-icon color */
 
-.yolo-code-block-header-button-container .yolo-code-block-header-button.clickable-icon {
-    color: var(--text-color) !important;
-  }
+.yolo-code-block-header-button-container
+  .yolo-code-block-header-button.clickable-icon {
+  color: var(--text-color) !important;
+}
 
 .yolo-code-block-content {
   margin: 0;
@@ -13494,378 +13516,394 @@ button.yolo-chat-list-dropdown-archive-toggle:focus-visible
   );
 }
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .view-content {
-    padding: 0;
-    flex: 1 1 auto;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .view-content {
+  padding: 0;
+  flex: 1 1 auto;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .markdown-source-view.mod-cm6 {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .markdown-source-view.mod-cm6 {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .cm-editor {
-    flex: 1 1 0;
-    min-height: 0;
-    position: relative !important;
-    box-sizing: border-box;
-    display: flex !important;
-    flex-direction: column;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .cm-editor {
+  flex: 1 1 0;
+  min-height: 0;
+  position: relative !important;
+  box-sizing: border-box;
+  display: flex !important;
+  flex-direction: column;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .cm-scroller {
-    padding: var(--file-margins);
-    display: flex !important;
-    align-items: flex-start !important;
-    line-height: 1.4;
-    height: 100%;
-    overflow-x: auto;
-    position: relative;
-    z-index: 0;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .cm-scroller {
+  padding: var(--file-margins);
+  display: flex !important;
+  align-items: flex-start !important;
+  line-height: 1.4;
+  height: 100%;
+  overflow-x: auto;
+  position: relative;
+  z-index: 0;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .cm-sizer {
-    box-sizing: border-box;
-    max-width: 100%;
-    width: 100%;
-    margin-left: auto;
-    margin-right: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    padding-left: 0;
-    padding-right: 0;
-    padding-bottom: 488px;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .cm-sizer {
+  box-sizing: border-box;
+  max-width: 100%;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding-left: 0;
+  padding-right: 0;
+  padding-bottom: 488px;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-content {
-    width: 100%;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-content {
+  width: 100%;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-decision-status {
-    width: min(100%, var(--file-line-width));
-    margin: 0 auto;
-    color: var(--text-muted);
-    font-size: var(--font-ui-smaller);
-    line-height: 1.5;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-decision-status {
+  width: min(100%, var(--file-line-width));
+  margin: 0 auto;
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+  line-height: 1.5;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-decision-status {
-    margin-bottom: var(--size-4-1);
-    font-weight: var(--font-medium);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-decision-status {
+  margin-bottom: var(--size-4-1);
+  font-weight: var(--font-medium);
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .view-header {
-    height: var(--header-height);
-    display: flex;
-    border-bottom: var(--file-header-border);
-    background-color: var(--background-primary);
-    z-index: 1;
-    position: relative;
-    gap: var(--size-4-2);
-    padding: 0 var(--size-4-3);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .view-header {
+  height: var(--header-height);
+  display: flex;
+  border-bottom: var(--file-header-border);
+  background-color: var(--background-primary);
+  z-index: 1;
+  position: relative;
+  gap: var(--size-4-2);
+  padding: 0 var(--size-4-3);
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .view-header-title-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex: 1;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .view-header-title-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex: 1;
+}
 
-:is(:is(#yolo-apply-view,.yolo-apply-view-root) .view-actions) button {
-      color: var(--text-normal);
-      font-weight: var(--font-medium);
-      gap: 2px;
-    }
+:is(:is(#yolo-apply-view, .yolo-apply-view-root) .view-actions) button {
+  color: var(--text-normal);
+  font-weight: var(--font-medium);
+  gap: 2px;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block {
-    display: block;
-    padding: var(--size-4-1) 0;
-    color: var(--yolo-apply-text-color);
-    line-height: var(--line-height-normal);
-    width: 100%;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block {
+  display: block;
+  padding: var(--size-4-1) 0;
+  color: var(--yolo-apply-text-color);
+  line-height: var(--line-height-normal);
+  width: 100%;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block--resolved {
-    animation: yolo-apply-resolve-in 180ms ease;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block--resolved {
+  animation: yolo-apply-resolve-in 180ms ease;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block--resolved .yolo-apply-markdown-preview {
-    animation: yolo-apply-resolve-in 180ms ease;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root)
+  .yolo-diff-block--resolved
+  .yolo-apply-markdown-preview {
+  animation: yolo-apply-resolve-in 180ms ease;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block.added {
-    background-color: rgba(var(--yolo-incoming-color-rgb), 0.12);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block.added {
+  background-color: rgba(var(--yolo-incoming-color-rgb), 0.12);
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block.removed {
-    background-color: rgba(var(--yolo-current-color-rgb), 0.12);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block.removed {
+  background-color: rgba(var(--yolo-current-color-rgb), 0.12);
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block-container {
-    position: relative;
-    scroll-margin-top: var(--size-4-8);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block-container {
+  position: relative;
+  scroll-margin-top: var(--size-4-8);
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-diff-block-actions {
-    position: absolute;
-    right: calc(
-      (100% - var(--file-line-width)) / 2 - var(--yolo-apply-actions-offset)
-    );
-    top: 50%;
-    transform: translateY(-50%);
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.15s ease;
-    z-index: 1;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-diff-block-actions {
+  position: absolute;
+  right: calc(
+    (100% - var(--file-line-width)) / 2 - var(--yolo-apply-actions-offset)
+  );
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 1;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph {
-    pointer-events: auto;
-    position: relative;
-    width: 100%;
-    --yolo-apply-side-gap: calc((100% - var(--file-line-width)) / 2);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-paragraph {
+  pointer-events: auto;
+  position: relative;
+  width: 100%;
+  --yolo-apply-side-gap: calc((100% - var(--file-line-width)) / 2);
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.has-changes {
-    padding-right: 0;
-    margin-right: 0;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-paragraph.has-changes {
+  padding-right: 0;
+  margin-right: 0;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph-indicator {
-    position: absolute;
-    right: calc(var(--yolo-apply-side-gap) - var(--yolo-apply-rail-offset));
-    top: 4px;
-    bottom: 4px;
-    width: 2px;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--interactive-accent) 28%, transparent);
-    opacity: 0.6;
-    transition:
-      background 0.15s ease,
-      opacity 0.15s ease;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-paragraph-indicator {
+  position: absolute;
+  right: calc(var(--yolo-apply-side-gap) - var(--yolo-apply-rail-offset));
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--interactive-accent) 28%, transparent);
+  opacity: 0.6;
+  transition:
+    background 0.15s ease,
+    opacity 0.15s ease;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.has-changes:hover .yolo-apply-paragraph-indicator,:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.has-changes:focus-within .yolo-apply-paragraph-indicator {
-    background: color-mix(in srgb, var(--interactive-accent) 65%, transparent);
-    opacity: 0.95;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root)
+  .yolo-apply-paragraph.has-changes:hover
+  .yolo-apply-paragraph-indicator,
+:is(#yolo-apply-view, .yolo-apply-view-root)
+  .yolo-apply-paragraph.has-changes:focus-within
+  .yolo-apply-paragraph-indicator {
+  background: color-mix(in srgb, var(--interactive-accent) 65%, transparent);
+  opacity: 0.95;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.has-changes.is-active .yolo-apply-paragraph-indicator {
-    background: color-mix(in srgb, var(--interactive-accent) 65%, transparent);
-    opacity: 0.95;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root)
+  .yolo-apply-paragraph.has-changes.is-active
+  .yolo-apply-paragraph-indicator {
+  background: color-mix(in srgb, var(--interactive-accent) 65%, transparent);
+  opacity: 0.95;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.is-empty {
-    min-height: 20px;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-paragraph.is-empty {
+  min-height: 20px;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-empty-line {
-    height: 12px;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-empty-line {
+  height: 12px;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph:hover .yolo-diff-block-actions,:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph:focus-within .yolo-diff-block-actions {
-    opacity: 1;
-    pointer-events: auto;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root)
+  .yolo-apply-paragraph:hover
+  .yolo-diff-block-actions,
+:is(#yolo-apply-view, .yolo-apply-view-root)
+  .yolo-apply-paragraph:focus-within
+  .yolo-diff-block-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-paragraph.is-active .yolo-diff-block-actions {
-    opacity: 1;
-    pointer-events: auto;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root)
+  .yolo-apply-paragraph.is-active
+  .yolo-diff-block-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action {
-    width: 26px;
-    height: 26px;
-    border-radius: 999px;
-    border: 1px solid color-mix(in srgb, var(--text-muted) 40%, transparent);
-    background: color-mix(in srgb, var(--background-primary) 92%, transparent);
-    color: var(--text-normal);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    box-shadow: none;
-    transition:
-      background 0.15s ease,
-      color 0.15s ease,
-      border-color 0.15s ease,
-      transform 0.15s ease;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action {
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 40%, transparent);
+  background: color-mix(in srgb, var(--background-primary) 92%, transparent);
+  color: var(--text-normal);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: none;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease,
+    transform 0.15s ease;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action svg {
-    width: 15px;
-    height: 15px;
-    stroke-width: 2.4;
-    stroke: currentColor;
-    fill: none;
-    opacity: 0.95;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2.4;
+  stroke: currentColor;
+  fill: none;
+  opacity: 0.95;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 15px;
-    line-height: 1;
-    font-weight: 600;
-    color: currentColor;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  line-height: 1;
+  font-weight: 600;
+  color: currentColor;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action-icon--merge {
-    font-size: 14px;
-    font-weight: 500;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action-icon--merge {
+  font-size: 14px;
+  font-weight: 500;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action:hover {
-    transform: translateY(-1px);
-    color: var(--text-normal);
-    background: color-mix(
-      in srgb,
-      var(--background-primary) 82%,
-      var(--background-secondary) 18%
-    );
-    border-color: color-mix(in srgb, var(--text-muted) 55%, transparent);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action:hover {
+  transform: translateY(-1px);
+  color: var(--text-normal);
+  background: color-mix(
+    in srgb,
+    var(--background-primary) 82%,
+    var(--background-secondary) 18%
+  );
+  border-color: color-mix(in srgb, var(--text-muted) 55%, transparent);
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action-accept {
-    color: rgb(var(--yolo-incoming-color-rgb));
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action-accept {
+  color: rgb(var(--yolo-incoming-color-rgb));
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-action-reject {
-    color: rgb(var(--yolo-current-color-rgb));
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-action-reject {
+  color: rgb(var(--yolo-current-color-rgb));
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-accept {
-    color: white;
-    background: rgba(var(--yolo-incoming-color-rgb), 0.8);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-accept {
+  color: white;
+  background: rgba(var(--yolo-incoming-color-rgb), 0.8);
+}
 
-:is(:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-accept):hover {
-      background: rgba(var(--yolo-incoming-color-rgb), 1);
-    }
+:is(:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-accept):hover {
+  background: rgba(var(--yolo-incoming-color-rgb), 1);
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-exclude {
-    color: white;
-    background: rgba(var(--yolo-current-color-rgb), 0.8);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-exclude {
+  color: white;
+  background: rgba(var(--yolo-current-color-rgb), 0.8);
+}
 
-:is(:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-exclude):hover {
-      background: rgba(var(--yolo-current-color-rgb), 1);
-    }
+:is(:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-exclude):hover {
+  background: rgba(var(--yolo-current-color-rgb), 1);
+}
 
 /* Toolbar styles */
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-toolbar {
-    position: absolute;
-    left: 50%;
-    bottom: var(--size-4-3);
-    transform: translateX(-50%);
-    display: flex;
-    justify-content: center;
-    width: 100%;
-    pointer-events: none;
-    z-index: 3;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-toolbar {
+  position: absolute;
+  left: 50%;
+  bottom: var(--size-4-3);
+  transform: translateX(-50%);
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  pointer-events: none;
+  z-index: 3;
+}
 
 /* Lift the floating toolbar above Obsidian's mobile navbar (back / menu, etc.). */
 
-body.is-mobile :is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-toolbar {
-    bottom: calc(
-      var(--size-4-3) + var(--yolo-apply-toolbar-mobile-offset, 48px) +
-        var(--safe-area-inset-bottom, 0px)
-    );
-  }
+body.is-mobile
+  :is(#yolo-apply-view, .yolo-apply-view-root)
+  .yolo-apply-toolbar {
+  bottom: calc(
+    var(--size-4-3) + var(--yolo-apply-toolbar-mobile-offset, 48px) +
+      var(--safe-area-inset-bottom, 0px)
+  );
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-toolbar-pill {
-    pointer-events: auto;
-    display: flex;
-    align-items: center;
-    gap: var(--size-4-3);
-    padding: var(--size-4-2) var(--size-4-3);
-    border-radius: 999px;
-    max-width: calc(100% - var(--size-4-6));
-    flex-wrap: wrap;
-    justify-content: center;
-    background: color-mix(
-      in srgb,
-      var(--background-secondary) 86%,
-      transparent
-    );
-    border: 1px solid
-      color-mix(in srgb, var(--background-modifier-border) 70%, transparent);
-    backdrop-filter: blur(12px);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-toolbar-pill {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-3);
+  padding: var(--size-4-2) var(--size-4-3);
+  border-radius: 999px;
+  max-width: calc(100% - var(--size-4-6));
+  flex-wrap: wrap;
+  justify-content: center;
+  background: color-mix(in srgb, var(--background-secondary) 86%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--background-modifier-border) 70%, transparent);
+  backdrop-filter: blur(12px);
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-toolbar-nav,:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-toolbar-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--size-4-2);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-toolbar-nav,
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-2);
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-apply-progress {
-    font-size: var(--font-ui-small);
-    color: var(--text-muted);
-    min-width: 52px;
-    text-align: center;
-    font-variant-numeric: tabular-nums;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-apply-progress {
+  font-size: var(--font-ui-small);
+  color: var(--text-muted);
+  min-width: 52px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-btn {
-    padding: 6px var(--size-4-3);
-    font-size: var(--font-ui-small);
-    border-radius: 999px;
-    cursor: pointer;
-    border: 1px solid var(--background-modifier-border);
-    background: color-mix(in srgb, var(--background-primary) 88%, transparent);
-    color: var(--text-normal);
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-btn {
+  padding: 6px var(--size-4-3);
+  font-size: var(--font-ui-small);
+  border-radius: 999px;
+  cursor: pointer;
+  border: 1px solid var(--background-modifier-border);
+  background: color-mix(in srgb, var(--background-primary) 88%, transparent);
+  color: var(--text-normal);
+}
 
-:is(:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-btn):hover {
-      background: color-mix(
-        in srgb,
-        var(--background-modifier-hover) 88%,
-        transparent
-      );
-    }
+:is(:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-btn):hover {
+  background: color-mix(
+    in srgb,
+    var(--background-modifier-hover) 88%,
+    transparent
+  );
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-btn:disabled,:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-icon-btn:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-btn:disabled,
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-icon-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-icon-btn {
-    width: 30px;
-    height: 30px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 999px;
-    border: 1px solid var(--background-modifier-border);
-    background: color-mix(in srgb, var(--background-primary) 88%, transparent);
-    color: var(--text-muted);
-    cursor: pointer;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-icon-btn {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid var(--background-modifier-border);
+  background: color-mix(in srgb, var(--background-primary) 88%, transparent);
+  color: var(--text-muted);
+  cursor: pointer;
+}
 
-:is(:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-icon-btn):hover {
-      color: var(--text-normal);
-      background: color-mix(
-        in srgb,
-        var(--background-modifier-hover) 88%,
-        transparent
-      );
-    }
+:is(:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-icon-btn):hover {
+  color: var(--text-normal);
+  background: color-mix(
+    in srgb,
+    var(--background-modifier-hover) 88%,
+    transparent
+  );
+}
 
-:is(#yolo-apply-view,.yolo-apply-view-root) .yolo-toolbar-icon {
-    font-size: 14px;
-    line-height: 1;
-    font-weight: 600;
-  }
+:is(#yolo-apply-view, .yolo-apply-view-root) .yolo-toolbar-icon {
+  font-size: 14px;
+  line-height: 1;
+  font-weight: 600;
+}
 
 :is(#yolo-apply-view, .yolo-apply-view-root)
   .yolo-apply-markdown.markdown-rendered {
@@ -14008,22 +14046,22 @@ button.yolo-chat-input-model-select {
 }
 
 button.yolo-chat-input-model-select:hover {
-    color: var(--text-normal);
-  }
+  color: var(--text-normal);
+}
 
 button.yolo-chat-input-model-select .yolo-chat-input-model-select__model-name {
-    flex-shrink: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+  flex-shrink: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 button.yolo-chat-input-model-select .yolo-chat-input-model-select__icon {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 
 .yolo-query-progress {
   font-size: var(--font-ui-smaller);


### PR DESCRIPTION
## 问题

`js_eval` 在外部脚本模式（`allowExternalScripts=true`）下，模型用 `importScripts(url)` 加载一些库容易失败，且失败信号会误导模型。

示例提示词：
> 能不能调 js 里符号计算的库，为我随便做两道微分和积分

模型会调用 `importScripts('https://cdn.jsdelivr.net/npm/algebrite/...')`。脚本本身下载成功，但库的 UMD init 阶段会修改 `Object.prototype` 等 built-in，命中老版本无差别启用的 `freezeBuiltinPrototypes()`，抛 TypeError。浏览器把 Worker 内 eval 阶段的异常一律包装成 importScripts 的 NetworkError 形态返回：

```
NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope':
The script at '<url>' failed to load.
```

<img width="400" src="https://github.com/user-attachments/assets/a6b53cb2-1840-4262-a2e0-767c352d9aa6" />




模型只看到 "network failed to load"，往网络故障 / URL 错误方向猜，绕几次都修不好——真正的原因（prototype 被冻结）完全不可见。

顺带暴露的问题：
- `allowExternalScripts=true` 但 `allowFetch=false` 的配置组合在 UI / 运行时 `_caps` / iframe CSP / 模型描述里视角不一致。
- 原有的 `$loadScript(url)` 宿主接口仅取源文本、不执行，和`$fetch`过于接近，缺乏明确意义。

## 方案

### 1. 允许外部脚本时豁免 `freezeBuiltinPrototypes()`

UMD/IIFE 库启动期就要改 built-in 原型，冻结会让他们出问题。外部脚本模式下跳过冻结后，Algebrite 等库才能正常初始化。

攻击面权衡：原型污染本身被 Worker 隔离。Worker 是 single-use，与 iframe / 宿主 renderer 不共享全局，且 postMessage 用 structured clone 算法序列化，不会咨询 `toJSON`。攻击者唯一能做的"额外"事是污染 `serializeResult` 内宿主构造的 envelope（用户返回 `undefined` 时的兜底 hint 字段），把 prompt-injection 字符串注入到回给 LLM 的结果里。但用户代码本来就完全控制 `return` 的内容，能直接捏造同样的字符串，所以这个"加成"几乎为零。同时本 PR 删除了 `$loadScript` 宿主代理路径，攻击面综合看略减。


### 2. 把模型从 `importScripts` 引向 `$fetch` + 间接 `eval`

即使原型不再被冻结，`importScripts` 仍会把所有 eval 阶段的错误（解析失败、运行时 TypeError、CSP 拦截）一律包成 NetworkError。改为引导 `(0, eval)(await (await $fetch(url)).text())` 走宿主 `requestUrl`，把状态码、响应头与解析错误分开返回；模型可以根据 `response.status` 区分 404 / CSP / 网络，eval 阶段的失败也以原生错误抛出。

为什么用间接 `(0, eval)` 而不是 `eval` / `new Function`：

**直接 `eval(src)` 不行**：eval 继承调用方的严格模式。我们 wrap 时加了 `"use strict"`，于是 bundle 里的顶层 `var Algebrite = ...` 不会挂到 `globalThis`，只活在 eval 自己的临时作用域里；eval 一返回 `Algebrite` 就消失，下一行 `Algebrite.run(...)` 直接 `ReferenceError`。

**`new Function(src)()` 不行**：`src` 跑在匿名函数体里。函数级 `var` 提升有个很坑的副作用——哪怕 `if (false) { var foo = ... }` 这种永远不会执行的分支，`var foo` 也会被 hoist 到函数顶部、初始化为 `undefined`，**在函数作用域里盖住同名的 `globalThis.foo`**。

实测踩过：先 `new Function` 加载 nerdamer，`globalThis.nerdamer` 挂好；再 `new Function` 加载 Calculus.js，里面有一行 `if (false) { var nerdamer = require(...) }`。dead branch 不执行，但 hoisting 让 Calculus.js 的整个函数作用域里 `nerdamer === undefined`，下一行 `nerdamer.getCore()` 立刻报 `Cannot read properties of undefined`。

**`(0, eval)(src)` 才对**：间接 eval 跑在 Worker 全局作用域里，行为等同浏览器原生 `<script>`。在 script-global 上，`var foo` 只在 `foo` 还不存在时才会创建；如果 `globalThis.foo` 已经有值，这条声明就是 no-op，不会重置它。同样那行 dead-branch `var nerdamer = ...` 在间接 eval 里执行时，已经挂好的 `globalThis.nerdamer` 不受影响，Calculus.js 顺利扩展上去。

模型不需要学 `new Function('lib', code)(lib)` 之类参数注入 trick，选对执行上下文就够了。

注意这是引导而非禁用——Worker 内 `importScripts` 仍然可用，模型坚持用仍能跑。

里层 `await` 必须用括号包住：链式 `await $fetch(url).text()` 在 JS 优先级下等价于 `await (($fetch(url)).text())`，`.text()` 在 Promise 上调用直接 TypeError。模型实测里踩过这个坑，所以描述直接给可粘贴的工作样例，不留链式空间。

### 3. `allowExternalScripts` 时自动 `allowFetch`

新增 `normalizeJsSandboxConfig`：`allowExternalScripts=true` 时强制 `allowFetch=true`。`getJsSandboxSettings` 统一调用，所有下游（运行时 `_caps`、CSP key、模型描述、UI 状态）共用同一份归一化后配置。

独立关闭 `allowFetch` 本来就是 UX 上的安全幻觉——ambient API 全开后原生 `fetch` 一直能用，关掉那个开关只能影响宿主 `$fetch` 与 CSP/描述视角。归一化把这点显式化。

旧持久化配置（`allowExternalScripts=true` + `allowFetch=false`）在读取时自动归一化，无侵入式 migration。

<img width="700" src="https://github.com/user-attachments/assets/d172be17-7f85-4c8f-bf92-a6b6a7bd6370" />

### 4. 外部脚本模式自动注入 `self.window = self`

UMD bundle 普遍用 `typeof window !== 'undefined'` 探测环境并把 exports 挂到 `window` 上。Worker 默认没有 `window`，探测失败 bundle 静默丢 exports，调用方随后看到 `ReferenceError: Algebrite is not defined` 之类，与真正的加载/网络错误难以区分。

Worker bootstrap 在 `allowExternalScripts=true` 时执行一次 `self.window = self`。aliasing 本身不暴露新能力——`self.fetch` / `self.document` 仍是 Worker 原状；真正调用 DOM 的库仍会失败，但失败形态变成 `TypeError: Cannot read properties of undefined (reading 'createElement')` 之类可诊断的具体错误。

`document` 等如果注入可能有较多副作用，不做调整。

## 文件修改

**`src/core/mcp/jsSandboxSettings.ts`**
- 新增并导出 `normalizeJsSandboxConfig`。
- `getJsSandboxSettings` 调用归一化。
- 工具描述移除 `importScripts` / `$loadScript`，改为引导 `(0, eval)(await (await $fetch(url)).text())`，并提示外脚本 Worker 中 `document` / `location` 缺失。

**`src/core/mcp/jsSandboxTool.ts`**
- 删除 `external_script` proxy cap 与 `JsSandboxProxyHandlers.externalScript` 类型。
- `allowExternalScripts=true` 时跳过 `freezeBuiltinPrototypes()`。
- `allowExternalScripts=true` 时在 Worker bootstrap 注入 `self.window = self`，让 UMD 探测通过。

**`src/core/mcp/localFileTools.ts`**
- 删除 `buildJsSandboxProxyHandlers` 里的 `externalScript` 分支（`$loadScript` 的宿主实现）。

**`src/components/settings/modals/JsSandboxConfigModal.tsx`**
- 改用 `jsSandboxSettings.ts` 共享的 `normalizeJsSandboxConfig`，移除模态本地副本。
- "Allow Network Fetch" toggle 在 `allowExternalScripts` 开启时通过 `disabled` 置灰（Obsidian 原生 disabled 视觉），保持显示为已启用；底层 `handleCapToggle` 的静默忽略分支作为 belt-and-suspenders 保留。
- `onConfirm` / `onCancel` 都走归一化路径。
- `jsSandboxAllowFetchDesc` 描述补一句"开启外部脚本时会自动启用此能力"。

**`src/components/common/ObsidianToggle.tsx`**
- 新增 `disabled?: boolean` prop，透传到 Obsidian `ToggleComponent.setDisabled`，与 `ObsidianTextInput` / `ObsidianButton` 同模式。`setDisabled` 只设 flag 不带视觉，所以同步在 toggle 元素上加/去 `.is-disabled` class 让 CSS 有 hook 可用。

**`src/styles/chat/input.css` + `styles.css`**
- `.yolo-checkbox-container.is-disabled` 加 `opacity: 0.5` + `pointer-events: none` + `cursor: not-allowed`，实现 Toggle 置灰且阻挡点击；`styles.css` 重新构建。


**`src/i18n/locales/{en,zh}.ts`**
- 同步上面那条 fetch 描述文案。


## 测试

- `npm run type:check` 通过。
- `npm test`：1302 / 1319 通过。17 个失败全部位于 `src/core/agent/llm-turn-executor.test.ts` 与 `src/core/agent/tool-gateway.test.ts`，原因是这两个文件的 `mcpManager` mock 没有 `getJsSandboxSettings` 方法——这是 upstream 已存在的 mock 问题（在本分支起点 `fb14ae3e` 上一样失败），与本 PR 无关。
