### PR TITLE
fix: 改善调试捕获错误链路提示不明确的问题

### DIFF
--- a/src/core/agent/llm-turn-executor.test.ts
+++ b/src/core/agent/llm-turn-executor.test.ts
@@ -80,6 +80,12 @@ const TEST_MODEL: ChatModel = {
   model: 'gpt-4.1',
 }
 
+const createMockMcpManager = (tools: unknown[] = []): McpManager =>
+  ({
+    listAvailableTools: jest.fn().mockResolvedValue(tools),
+    getJsSandboxSettings: jest.fn(() => ({})),
+  }) as unknown as McpManager
+
 describe('AgentLlmTurnExecutor', () => {
   beforeEach(() => {
     mockExecuteSingleTurn.mockReset()
@@ -102,9 +108,7 @@ describe('AgentLlmTurnExecutor', () => {
         .mockResolvedValue([{ role: 'user', content: 'hello' }]),
     } as unknown as RequestContextBuilder
 
-    const mcpManager = {
-      listAvailableTools: jest.fn().mockResolvedValue([]),
-    } as unknown as McpManager
+    const mcpManager = createMockMcpManager()
 
     const executor = new AgentLlmTurnExecutor({
       providerClient: provider,
@@ -202,18 +206,16 @@ describe('AgentLlmTurnExecutor', () => {
         .mockResolvedValue([{ role: 'user', content: 'hello' }]),
     } as unknown as RequestContextBuilder
 
-    const mcpManager = {
-      listAvailableTools: jest.fn().mockResolvedValue([
-        {
-          name: 'yolo_local__fs_move',
-          description: 'Move path',
-          inputSchema: {
-            type: 'object',
-            properties: {},
-          },
+    const mcpManager = createMockMcpManager([
+      {
+        name: 'yolo_local__fs_move',
+        description: 'Move path',
+        inputSchema: {
+          type: 'object',
+          properties: {},
         },
-      ]),
-    } as unknown as McpManager
+      },
+    ])
 
     const observedAssistantMessages: ChatAssistantMessage[] = []
     const executor = new AgentLlmTurnExecutor({
@@ -279,9 +281,7 @@ describe('AgentLlmTurnExecutor', () => {
         .mockResolvedValue([{ role: 'user', content: 'hello' }]),
     } as unknown as RequestContextBuilder
 
-    const mcpManager = {
-      listAvailableTools: jest.fn().mockResolvedValue([]),
-    } as unknown as McpManager
+    const mcpManager = createMockMcpManager()
 
     mockExecuteSingleTurn.mockRejectedValue(new Error('network exploded'))
 
@@ -325,6 +325,59 @@ describe('AgentLlmTurnExecutor', () => {
     )
   })
 
+  it('includes nested cause details in assistant error messages', async () => {
+    const provider = new MockProvider()
+    const requestContextBuilder = {
+      generateRequestMessages: jest
+        .fn()
+        .mockResolvedValue([{ role: 'user', content: 'hello' }]),
+    } as unknown as RequestContextBuilder
+
+    const mcpManager = createMockMcpManager()
+
+    const wrappedError = new Error('Connection error.') as Error & {
+      cause?: unknown
+    }
+    wrappedError.cause = new Error(
+      'LLM debug capture failed while reading request body.',
+    )
+    mockExecuteSingleTurn.mockRejectedValue(wrappedError)
+
+    const observedAssistantMessages: ChatAssistantMessage[] = []
+    const executor = new AgentLlmTurnExecutor({
+      providerClient: provider,
+      model: TEST_MODEL,
+      requestContextBuilder,
+      mcpManager,
+      conversationId: 'conv-1',
+      messages: [],
+      enableTools: false,
+      includeBuiltinTools: false,
+      requestParams: {
+        stream: true,
+      },
+      onAssistantMessage: (message) => {
+        observedAssistantMessages.push({
+          ...message,
+          metadata: message.metadata
+            ? {
+                ...message.metadata,
+              }
+            : undefined,
+        })
+      },
+    })
+
+    await expect(executor.run()).rejects.toThrow('Connection error.')
+
+    expect(observedAssistantMessages.at(-1)?.metadata?.errorMessage).toBe(
+      [
+        'Connection error.',
+        'Caused by: LLM debug capture failed while reading request body.',
+      ].join('\n'),
+    )
+  })
+
   it('marks assistant message aborted on abort errors', async () => {
     const provider = new MockProvider()
     const requestContextBuilder = {
@@ -333,9 +386,7 @@ describe('AgentLlmTurnExecutor', () => {
         .mockResolvedValue([{ role: 'user', content: 'hello' }]),
     } as unknown as RequestContextBuilder
 
-    const mcpManager = {
-      listAvailableTools: jest.fn().mockResolvedValue([]),
-    } as unknown as McpManager
+    const mcpManager = createMockMcpManager()
     const abortController = new AbortController()
     abortController.abort()
 
@@ -387,9 +438,7 @@ describe('AgentLlmTurnExecutor', () => {
         .mockResolvedValue([{ role: 'user', content: 'hello' }]),
     } as unknown as RequestContextBuilder
 
-    const mcpManager = {
-      listAvailableTools: jest.fn().mockResolvedValue([]),
-    } as unknown as McpManager
+    const mcpManager = createMockMcpManager()
 
     mockExecuteSingleTurn.mockImplementation(async ({ onStreamDelta }) => {
       onStreamDelta?.({
@@ -448,18 +497,16 @@ describe('AgentLlmTurnExecutor', () => {
         .mockResolvedValue([{ role: 'user', content: 'hello' }]),
     } as unknown as RequestContextBuilder
 
-    const mcpManager = {
-      listAvailableTools: jest.fn().mockResolvedValue([
-        {
-          name: 'yolo_local__memory_add',
-          description: 'Add memory',
-          inputSchema: {
-            type: 'object',
-            properties: {},
-          },
+    const mcpManager = createMockMcpManager([
+      {
+        name: 'yolo_local__memory_add',
+        description: 'Add memory',
+        inputSchema: {
+          type: 'object',
+          properties: {},
         },
-      ]),
-    } as unknown as McpManager
+      },
+    ])
 
     mockExecuteSingleTurn.mockResolvedValue({
       content: 'done',
@@ -505,18 +552,16 @@ describe('AgentLlmTurnExecutor', () => {
         .mockResolvedValue([{ role: 'user', content: 'hello' }]),
     } as unknown as RequestContextBuilder
 
-    const mcpManager = {
-      listAvailableTools: jest.fn().mockResolvedValue([
-        {
-          name: 'yolo_local__fs_read',
-          description: 'Read file',
-          inputSchema: {
-            type: 'object',
-            properties: {},
-          },
+    const mcpManager = createMockMcpManager([
+      {
+        name: 'yolo_local__fs_read',
+        description: 'Read file',
+        inputSchema: {
+          type: 'object',
+          properties: {},
         },
-      ]),
-    } as unknown as McpManager
+      },
+    ])
 
     mockExecuteSingleTurn.mockResolvedValue({
       content: 'done',

--- a/src/core/agent/llm-turn-executor.ts
+++ b/src/core/agent/llm-turn-executor.ts
@@ -15,6 +15,7 @@ import {
 import { ToolCallRequest } from '../../types/tool-call.types'
 import type { ContextualInjection } from '../../utils/chat/contextual-injections'
 import { RequestContextBuilder } from '../../utils/chat/requestContextBuilder'
+import { formatErrorMessageWithCauses } from '../../utils/error-message'
 import { executeSingleTurn } from '../ai/single-turn'
 import { BaseLLMProvider } from '../llm/base'
 import {
@@ -241,9 +242,7 @@ export class AgentLlmTurnExecutor {
         (error instanceof Error && error.name === 'AbortError')
       const errorMessage = isAborted
         ? undefined
-        : error instanceof Error
-          ? error.message
-          : String(error ?? 'Unknown error')
+        : formatErrorMessageWithCauses(error)
 
       assistantMessage.metadata = {
         ...assistantMessage.metadata,

--- a/src/core/agent/service.ts
+++ b/src/core/agent/service.ts
@@ -15,6 +15,7 @@ import {
   ToolCallResponseStatus,
   getToolCallArgumentsObject,
 } from '../../types/tool-call.types'
+import { formatErrorMessageWithCauses } from '../../utils/error-message'
 import { captureLLMDebugOperation } from '../llm/debugCapture'
 
 import { DEFAULT_BRANCH_ID } from './branch'
@@ -1307,10 +1308,7 @@ export class AgentService {
         ...currentRunEntry.state,
         status: aborted ? 'aborted' : 'error',
         pendingCompactionAnchorMessageId: null,
-        errorMessage:
-          aborted || !(error instanceof Error)
-            ? undefined
-            : (error.message ?? 'Unknown error'),
+        errorMessage: aborted ? undefined : formatErrorMessageWithCauses(error),
       }
       this.recomputeConversationState(conversationId)
       if (!aborted) {

--- a/src/core/llm/debugCapture.test.ts
+++ b/src/core/llm/debugCapture.test.ts
@@ -1,5 +1,6 @@
 import {
   bindLLMDebugTraceToSignal,
+  captureLLMDebugOperation,
   createLLMDebugFetch,
   createLLMDebugTrace,
   flushLLMDebugTraceReads,
@@ -140,6 +141,61 @@ describe('debugCapture', () => {
 
     expect(omitted).toMatch(/\[OMITTED long JSON string: \d+ chars\]/)
     expect(omitted).not.toContain('Truncated long JSON string')
+  })
+
+  it('omits base64 data from captured operation responses before storage', async () => {
+    setLLMDebugCaptureEnabled(true)
+    const trace = createLLMDebugTrace({ requestKind: 'streaming' })
+    const base64 = 'A'.repeat(1024)
+
+    await runWithLLMDebugTrace(trace.id, async () => {
+      await expect(
+        captureLLMDebugOperation({
+          traceId: trace.id,
+          transportMode: 'mcp',
+          url: 'mcp://yolo_local/fs_read',
+          method: 'callTool',
+          requestBody: { name: 'fs_read' },
+          responseContentType: 'application/json',
+          run: async () => ({
+            status: 'success',
+            content: [{ type: 'text', data: base64 }],
+          }),
+        }),
+      ).resolves.toEqual({
+        status: 'success',
+        content: [{ type: 'text', data: base64 }],
+      })
+    })
+
+    const responseBody = getLLMDebugTrace(trace.id)?.exchanges[0]?.response
+      ?.body
+    expect(responseBody).toContain('[OMITTED base64 data: 1024 chars]')
+    expect(responseBody).not.toContain(base64)
+  })
+
+  it('adds debug capture context to serialization failures', async () => {
+    setLLMDebugCaptureEnabled(true)
+    const trace = createLLMDebugTrace({ requestKind: 'streaming' })
+
+    await runWithLLMDebugTrace(trace.id, async () => {
+      await expect(
+        captureLLMDebugOperation({
+          traceId: trace.id,
+          transportMode: 'mcp',
+          url: 'mcp://yolo_local/fs_read',
+          method: 'callTool',
+          requestBody: { name: 'fs_read' },
+          responseContentType: 'application/json',
+          run: async () => ({ ok: true }),
+          getResponseBody: () => {
+            throw new RangeError('Maximum call stack size exceeded')
+          },
+        }),
+      ).rejects.toThrow(
+        'LLM debug capture failed while serializing response body.',
+      )
+    })
   })
 
   it('redacts sensitive params in form-urlencoded request bodies', async () => {

--- a/src/core/llm/debugCapture.ts
+++ b/src/core/llm/debugCapture.ts
@@ -844,7 +844,8 @@ function unknownToDebugBody(value: unknown): string | undefined {
     return prepareBodyForStorage(value)
   }
   try {
-    return prepareBodyForStorage(JSON.stringify(value))
+    const compacted = JSON.stringify(omitBase64DebugData(redactJsonLike(value)))
+    return truncateDebugText(compacted ?? '')
   } catch {
     if (value === null) {
       return 'null'
@@ -866,6 +867,16 @@ function unknownToDebugBody(value: unknown): string | undefined {
     }
     return '[Unserializable debug value]'
   }
+}
+
+function wrapDebugCaptureError(action: string, error: unknown): Error {
+  const wrapped = new Error(
+    `LLM debug capture failed while ${action}.`,
+  ) as Error & {
+    cause?: unknown
+  }
+  wrapped.cause = error
+  return wrapped
 }
 
 async function readResponseBodyForDebug(response: Response): Promise<{
@@ -969,6 +980,13 @@ export async function captureLLMDebugOperation<T>({
   }
 
   const exchangeId = createExchangeId()
+  let requestBodyForDebug: string | undefined
+  try {
+    requestBodyForDebug = unknownToDebugBody(requestBody)
+  } catch (error) {
+    throw wrapDebugCaptureError('serializing request body', error)
+  }
+
   const exchange: LLMDebugHttpExchange = {
     id: exchangeId,
     traceId,
@@ -978,7 +996,7 @@ export async function captureLLMDebugOperation<T>({
       url: redactUrl(url),
       method,
       headers: headersToRecord(requestHeaders),
-      body: unknownToDebugBody(requestBody),
+      body: requestBodyForDebug,
     },
   }
   trace.exchanges.push(exchange)
@@ -987,6 +1005,14 @@ export async function captureLLMDebugOperation<T>({
   try {
     const result = await run()
     const responseHeaders = getResponseHeaders?.(result)
+    let responseBodyForDebug: string | undefined
+    try {
+      responseBodyForDebug = unknownToDebugBody(
+        getResponseBody ? getResponseBody(result) : result,
+      )
+    } catch (error) {
+      throw wrapDebugCaptureError('serializing response body', error)
+    }
     completeExchange(exchangeId, {
       completedAt: Date.now(),
       response: {
@@ -996,9 +1022,7 @@ export async function captureLLMDebugOperation<T>({
           ? headersToRecord(responseHeaders as HeadersInit)
           : {},
         contentType: responseContentType,
-        body: unknownToDebugBody(
-          getResponseBody ? getResponseBody(result) : result,
-        ),
+        body: responseBodyForDebug,
       },
     })
     return result
@@ -1021,7 +1045,11 @@ export function createLLMDebugFetch(
     })
     let debugRequest: LLMDebugHttpExchange['request'] | null = null
     if (llmDebugCaptureEnabled && !traceId) {
-      debugRequest = await buildDebugRequest(input, init)
+      try {
+        debugRequest = await buildDebugRequest(input, init)
+      } catch (error) {
+        throw wrapDebugCaptureError('reading request body', error)
+      }
       traceId = resolveLLMDebugTraceIdForRequest(debugRequest)
     }
 
@@ -1040,7 +1068,11 @@ export function createLLMDebugFetch(
       traceId,
       transportMode,
       startedAt: Date.now(),
-      request: debugRequest ?? (await buildDebugRequest(input, init)),
+      request:
+        debugRequest ??
+        (await buildDebugRequest(input, init).catch((error) => {
+          throw wrapDebugCaptureError('reading request body', error)
+        })),
     }
     trace.exchanges.push(exchange)
     enforceMemoryBudget()

--- a/src/utils/error-message.test.ts
+++ b/src/utils/error-message.test.ts
@@ -1,0 +1,24 @@
+import { formatErrorMessageWithCauses } from './error-message'
+
+describe('formatErrorMessageWithCauses', () => {
+  it('includes nested causes behind generic wrapper errors', () => {
+    const error = new Error('Connection error.') as Error & { cause?: unknown }
+    error.cause = new TypeError(
+      'LLM debug capture failed while reading request body.',
+    )
+
+    expect(formatErrorMessageWithCauses(error)).toBe(
+      [
+        'Connection error.',
+        'Caused by: LLM debug capture failed while reading request body.',
+      ].join('\n'),
+    )
+  })
+
+  it('deduplicates repeated wrapper and cause messages', () => {
+    const error = new Error('Failed') as Error & { cause?: unknown }
+    error.cause = new Error('Failed')
+
+    expect(formatErrorMessageWithCauses(error)).toBe('Failed')
+  })
+})

--- a/src/utils/error-message.ts
+++ b/src/utils/error-message.ts
@@ -1,0 +1,90 @@
+const MAX_ERROR_CAUSE_DEPTH = 6
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object'
+
+const readMessage = (error: unknown): string | null => {
+  if (typeof error === 'string') {
+    return error.trim() || null
+  }
+
+  if (error instanceof Error) {
+    return error.message.trim() || error.name || null
+  }
+
+  if (isRecord(error) && typeof error.message === 'string') {
+    return error.message.trim() || null
+  }
+
+  if (error === undefined || error === null) {
+    return null
+  }
+
+  return String(error).trim() || null
+}
+
+const collectErrorMessages = (
+  error: unknown,
+  seen: Set<unknown>,
+  depth: number,
+): string[] => {
+  if (depth > MAX_ERROR_CAUSE_DEPTH || error === undefined || error === null) {
+    return []
+  }
+  if (
+    (typeof error === 'object' || typeof error === 'function') &&
+    seen.has(error)
+  ) {
+    return []
+  }
+  if (typeof error === 'object' || typeof error === 'function') {
+    seen.add(error)
+  }
+
+  const messages: string[] = []
+  const message = readMessage(error)
+  if (message) {
+    messages.push(message)
+  }
+
+  if (isRecord(error)) {
+    const nestedCandidates = [error.cause, error.rawError, error.error]
+    for (const nested of nestedCandidates) {
+      messages.push(...collectErrorMessages(nested, seen, depth + 1))
+    }
+  }
+
+  return messages
+}
+
+export function formatErrorMessageWithCauses(
+  error: unknown,
+  fallback = 'Unknown error',
+): string {
+  const seenMessages = new Set<string>()
+  const messages = collectErrorMessages(error, new Set<unknown>(), 0).filter(
+    (message) => {
+      if (seenMessages.has(message)) {
+        return false
+      }
+      seenMessages.add(message)
+      return true
+    },
+  )
+
+  if (messages.length === 0) {
+    return fallback
+  }
+
+  const [primary, ...causes] = messages
+  if (!primary) {
+    return fallback
+  }
+  if (causes.length === 0) {
+    return primary
+  }
+
+  return [primary, ...causes.map((message) => `Caused by: ${message}`)].join(
+    '\n',
+  )
+}


### PR DESCRIPTION
# fix: 改善调试捕获错误链路提示不明确的问题

## 问题

对于一些特殊案例，Debug 机制本身可能会出错。比如让 Agent 用 `fs_read` 读取一个约 14MB 的 PDF，选择“读全文”，并且把 modality 指定为 `pdf`：不开启调试模式时请求正常；开启调试模式后，会显示“本次回复生成失败 Connection error.”。控制台里能看到更具体的堆栈，但也不容易发现是 Debug 机制本身的问题。

<img width="400" src="https://github.com/user-attachments/assets/db12582a-a5fe-4637-8b0f-8ed3c3d74ab9" />


这个 PR 不尝试修复这个内部错误本身。因为这个场景比较边缘，还不确定是否存在其它触发方式，保留原始错误对于本 PR 的定位和测试更有价值。这个 PR 解决的问题是：外部用户界面只看到泛化的“连接错误”，很难意识到失败来自调试模式自身，而不是模型、网络或工具调用。

## 方案

让错误链完整透传，并在 Debug 捕获模块自身出错时补充明确上下文。这样用户仍然能看到底层错误，例如 `Maximum call stack size exceeded`，同时也能看到它来自 `LLM debug capture` 的序列化或请求体读取阶段。


具体做法：

- 新增通用错误格式化工具，读取 `cause` / `rawError` / `error` 链并去重。
- 主助手回复失败和 Agent run 状态错误改为保存完整错误链，不只保存最外层 `error.message`。
- Debug capture 在序列化请求/响应体或读取请求体失败时，只包一层“LLM debug capture failed while ...”上下文，然后继续抛出原始错误链，不做进一步格式化以免节外生枝。
- Debug trace 存储对象时先脱敏和省略 base64 / 长字符串，再序列化和截断，避免大 PDF / 图片内容先被完整 stringify。
- 补充测试覆盖：错误链展示、Debug capture 上下文提示，以及 debug 响应中 base64 省略。

<img width="400" src="https://github.com/user-attachments/assets/3796beae-b477-4af0-a046-93b533da6e79" />