### PR TITLE
[auto-triage] fix: remove auto title fallback in ContextUsageRing to prevent double tooltip (#366)

### DIFF
--- a/src/components/chat-view/ContextUsageRing.tsx
+++ b/src/components/chat-view/ContextUsageRing.tsx
@@ -86,7 +86,10 @@ const ContextUsageRing = forwardRef<HTMLButtonElement, ContextUsageRingProps>(
         data-tone={tone}
         data-has-max={hasMax ? 'true' : 'false'}
         aria-label={titleLabel}
-        title={title ?? titleLabel}
+        // Don't fall back to titleLabel: Obsidian already shows its own
+        // tooltip from aria-label; adding title on top stacks a second
+        // native browser tooltip (same issue as LLMDebugButton).
+        title={title}
       >
         <svg
           className="yolo-context-usage-ring__svg"


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要

将 `ContextUsageRing.tsx` 中的 `title={title ?? titleLabel}` 改为 `title={title}`，移除了自动回落到 `titleLabel` 的逻辑。

## Claude 分析要点

**根因**：`ContextUsageRing` 同时设置了两个属性：
- `aria-label={titleLabel}` — Obsidian 从这里读取并显示自己的样式化 tooltip
- `title={title ?? titleLabel}` — 浏览器原生 tooltip 也在 hover 时显示

两套 tooltip 系统都响应 hover，导致出现两个弹窗（issue #366 现象）。

**证据**：`LLMDebugButton.tsx` 里已有明确的注释记录了这个陷阱：
```
// Intentionally omit the `title` attribute here: Obsidian renders its own
// tooltip from `aria-label`, and adding `title` causes the native browser
// tooltip to stack on top of it (more visible on disabled buttons).
```

**影响范围**：两处调用（`ContextUsagePopover` 作为 Trigger 时，以及 `ChatUserInput` 无 breakdown 时直接渲染），均无传入 `title` prop，因此 `?? titleLabel` 在两处都无条件触发了双 tooltip。修改组件本身，两处同时修复。

## Codex 二审反馈

Codex 确认分析正确，无异议。补充：
- 修改不损害无障碍名称，`aria-label={titleLabel}` 仍在
- `title={title}` 保留了调用方显式传入的能力（调用方选择）
- 类型检查通过（仅预存在的 `baseUrl` 废弃警告，与本 PR 无关）

## 校验清单

- [x] `npm run type:check` — 通过（预存在警告，本 PR 不引入新错误）
- [x] 改动量最小（1 行实质变更 + 3 行注释）
- [x] 不违反 CLAUDE.md 规范

## 关联

Fixes #366

---

> *The browser whispered twice the same old line,*
> *"Here's what you're hovering — token count, fine."*
> *But Obsidian too had something to say,*
> *so both of them shouted — what a display.*
>
> *One `title` removed, the echo is gone;*
> *`aria-label` alone now carries the song.*

— auto-triage by Claude + Codex gpt-5.5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJhmCureNZkL1HB5ArSQij)_