### PR TITLE
[auto-triage] restore persistSelectionHighlight toggle (#373)

### DIFF
--- a/src/components/settings/tabs/OthersTab.tsx
+++ b/src/components/settings/tabs/OthersTab.tsx
@@ -2,10 +2,12 @@ import { App, Platform } from 'obsidian'
 
 import { useLanguage } from '../../../contexts/language-context'
 import { useSettings } from '../../../contexts/settings-context'
+import { selectionHighlightController } from '../../../features/editor/selection-highlight/selectionHighlightController'
 import YoloPlugin from '../../../main'
 import { ObsidianButton } from '../../common/ObsidianButton'
 import { ObsidianDropdown } from '../../common/ObsidianDropdown'
 import { ObsidianSetting } from '../../common/ObsidianSetting'
+import { ObsidianToggle } from '../../common/ObsidianToggle'
 import { ChatPreferencesSection } from '../sections/ChatPreferencesSection'
 import { EtcSection } from '../sections/EtcSection'
 
@@ -65,6 +67,25 @@ export function OthersTab({ app, plugin }: OthersTabProps) {
         })
       } catch (error: unknown) {
         console.error('Failed to update chat apply mode', error)
+      }
+    })()
+  }
+
+  const handlePersistSelectionHighlightChange = (value: boolean) => {
+    void (async () => {
+      try {
+        await setSettings({
+          ...settings,
+          continuationOptions: {
+            ...settings.continuationOptions,
+            persistSelectionHighlight: value,
+          },
+        })
+        if (!value) {
+          selectionHighlightController.clearAll()
+        }
+      } catch (error: unknown) {
+        console.error('Failed to update selection highlight setting', error)
       }
     })()
   }
@@ -216,6 +237,24 @@ export function OthersTab({ app, plugin }: OthersTabProps) {
                   ),
                 }}
                 onChange={handleChatApplyModeChange}
+              />
+            </ObsidianSetting>
+            <ObsidianSetting
+              name={t(
+                'settings.etc.persistSelectionHighlight',
+                '保留选区块高亮',
+              )}
+              desc={t(
+                'settings.etc.persistSelectionHighlightDesc',
+                '在侧边栏 Chat 或 Quick Ask 交互时，持续显示编辑器中已选内容的块级高亮。',
+              )}
+              className="yolo-settings-card"
+            >
+              <ObsidianToggle
+                value={
+                  settings.continuationOptions.persistSelectionHighlight ?? true
+                }
+                onChange={handlePersistSelectionHighlightChange}
               />
             </ObsidianSetting>
 

--- a/src/features/editor/quick-ask/quickAskController.ts
+++ b/src/features/editor/quick-ask/quickAskController.ts
@@ -384,16 +384,22 @@ export class QuickAskController {
     overlay.mount()
 
     // Mirror Markdown's persistence: register a 'sync' highlight on the PDF
-    // leaf so the selected range stays visually highlighted while Quick Ask floats.
-    const id = `quickask:${crypto.randomUUID()}`
-    this.currentPdfHighlightId = id
-    pdfSelectionHighlightController.addHighlight(
-      args.leaf,
-      id,
-      { range: args.range, pageNumber: args.pageNumber, file: args.file },
-      'sync',
-      'quickask',
-    )
+    // leaf so the selected range stays visually highlighted while the Quick
+    // Ask floats. Cleared in close()/onClose. Gated by the same setting.
+    if (
+      this.deps.getSettings().continuationOptions.persistSelectionHighlight ??
+      true
+    ) {
+      const id = `quickask:${crypto.randomUUID()}`
+      this.currentPdfHighlightId = id
+      pdfSelectionHighlightController.addHighlight(
+        args.leaf,
+        id,
+        { range: args.range, pageNumber: args.pageNumber, file: args.file },
+        'sync',
+        'quickask',
+      )
+    }
   }
 
   /**
@@ -411,6 +417,15 @@ export class QuickAskController {
   }
 
   private deferSelectionHighlightTakeover(view: EditorView, token: number) {
+    if (
+      !(
+        this.deps.getSettings().continuationOptions.persistSelectionHighlight ??
+        true
+      )
+    ) {
+      return
+    }
+
     window.requestAnimationFrame(() => {
       window.requestAnimationFrame(() => {
         if (token !== this.highlightTakeoverToken) {

--- a/src/features/editor/selection-chat/selectionChatController.ts
+++ b/src/features/editor/selection-chat/selectionChatController.ts
@@ -537,7 +537,7 @@ export class SelectionChatController {
     // Stamp a highlightId and pin the sync highlight immediately.
     const highlightId = crypto.randomUUID()
     const editorView = this.getEditorView(editor)
-    if (editorView) {
+    if (editorView && this.shouldPersistSelectionHighlight()) {
       const selection = editorView.state.selection.main
       if (!selection.empty) {
         selectionHighlightController.addHighlight(
@@ -602,17 +602,19 @@ export class SelectionChatController {
     // selections.
     const highlightId = crypto.randomUUID()
 
-    pdfSelectionHighlightController.addHighlight(
-      result.leaf,
-      highlightId,
-      {
-        range: result.range,
-        pageNumber: result.pageNumber,
-        file: result.file,
-      },
-      'sync',
-      'chat',
-    )
+    if (this.shouldPersistSelectionHighlight()) {
+      pdfSelectionHighlightController.addHighlight(
+        result.leaf,
+        highlightId,
+        {
+          range: result.range,
+          pageNumber: result.pageNumber,
+          file: result.file,
+        },
+        'sync',
+        'chat',
+      )
+    }
 
     const blockData: MentionableBlockData = {
       content: result.content,
@@ -776,23 +778,26 @@ export class SelectionChatController {
     // currently tracked in chat).  This way subsequent selections that sweep
     // 'sync' entries on the leaf cannot wipe the pinned highlight.
     const buildPinnedBlock = (): MentionableBlockData => {
-      const pinnedId = crypto.randomUUID()
-      pdfSelectionHighlightController.addHighlight(
-        pdfData.leaf,
-        pinnedId,
-        {
-          range: pdfData.range,
-          pageNumber: pdfData.pageNumber,
-          file: pdfData.file,
-        },
-        'pinned',
-        'chat',
-      )
-      return {
-        ...blockData,
-        source: 'selection-pinned',
-        highlightId: pinnedId,
+      if (this.shouldPersistSelectionHighlight()) {
+        const pinnedId = crypto.randomUUID()
+        pdfSelectionHighlightController.addHighlight(
+          pdfData.leaf,
+          pinnedId,
+          {
+            range: pdfData.range,
+            pageNumber: pdfData.pageNumber,
+            file: pdfData.file,
+          },
+          'pinned',
+          'chat',
+        )
+        return {
+          ...blockData,
+          source: 'selection-pinned',
+          highlightId: pinnedId,
+        }
       }
+      return { ...blockData, source: 'selection-pinned' }
     }
 
     if (mode === 'chat-input') {
@@ -954,7 +959,7 @@ export class SelectionChatController {
     const editorView = this.getEditorView(editor)
     const highlightId = crypto.randomUUID()
 
-    if (editorView) {
+    if (editorView && this.shouldPersistSelectionHighlight()) {
       const sel = editorView.state.selection.main
       if (!sel.empty) {
         selectionHighlightController.addHighlight(
@@ -991,7 +996,7 @@ export class SelectionChatController {
     const editorView = this.getEditorView(editor)
     const highlightId = crypto.randomUUID()
 
-    if (editorView) {
+    if (editorView && this.shouldPersistSelectionHighlight()) {
       const sel = editorView.state.selection.main
       if (!sel.empty) {
         selectionHighlightController.addHighlight(
@@ -1031,7 +1036,7 @@ export class SelectionChatController {
     const editorView = this.getEditorView(editor)
     const highlightId = crypto.randomUUID()
 
-    if (editorView) {
+    if (editorView && this.shouldPersistSelectionHighlight()) {
       const sel = editorView.state.selection.main
       if (!sel.empty) {
         selectionHighlightController.addHighlight(
@@ -1048,6 +1053,12 @@ export class SelectionChatController {
       { ...data, source: 'selection-pinned', highlightId },
       prompt?.trim() ?? '',
       assistantId,
+    )
+  }
+
+  private shouldPersistSelectionHighlight(): boolean {
+    return (
+      this.getSettings().continuationOptions.persistSelectionHighlight ?? true
     )
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1368,6 +1368,9 @@ export const en: TranslationKeys = {
         'Only affects Apply in the sidebar Chat. Choose whether edits open inline review first or write directly to the file. Turning review off skips the second confirmation step.',
       chatApplyModeReviewRequired: 'Review before apply',
       chatApplyModeDirectApply: 'Write directly to file',
+      persistSelectionHighlight: 'Keep selection block highlight',
+      persistSelectionHighlightDesc:
+        'Keep showing the block highlight for selected editor content while interacting with sidebar Chat or Quick Ask.',
       notifications: 'Notifications',
       notificationsDesc:
         'Configure alerts for Agent runs. System notifications automatically degrade when the environment does not support them.',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1268,6 +1268,9 @@ export const it: TranslationKeys = {
         'Controlla come i file con @ vengono iniettati nel modello. In modalita leggera vengono iniettati solo i percorsi dei file citati, le proprieta della nota e la struttura Markdown, incoraggiando l agent a leggere solo il contenuto necessario.',
       mentionContextModeLight: 'Modalita leggera',
       mentionContextModeFull: 'Modalita completa',
+      persistSelectionHighlight: 'Mantieni evidenziazione blocco selezione',
+      persistSelectionHighlightDesc:
+        "Mantiene visibile l'evidenziazione a blocco del contenuto selezionato nell'editor durante l'interazione con la Chat laterale o Quick Ask.",
       notifications: 'Notifiche',
       notificationsDesc:
         "Configura gli avvisi per Agent. Le notifiche di sistema degradano automaticamente se l'ambiente non le supporta.",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -1263,6 +1263,9 @@ export const zh: TranslationKeys = {
         '仅影响 Chat 侧边栏中的“应用”。可选择先进入内联审阅，或直接写入文件。关闭审阅后，点击应用将不再需要二次审批。',
       chatApplyModeReviewRequired: '先审阅后应用',
       chatApplyModeDirectApply: '直接写入文件',
+      persistSelectionHighlight: '保留选区块高亮',
+      persistSelectionHighlightDesc:
+        '在侧边栏 Chat 或 Quick Ask 交互时，持续显示编辑器中已选内容的块级高亮。',
       notifications: '通知提醒',
       notificationsDesc:
         '配置 Agent 的提醒方式。若当前环境不支持系统通知，会自动降级，不影响主流程。',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1068,6 +1068,8 @@ export type TranslationKeys = {
       chatApplyModeDesc?: string
       chatApplyModeReviewRequired?: string
       chatApplyModeDirectApply?: string
+      persistSelectionHighlight?: string
+      persistSelectionHighlightDesc?: string
       notifications?: string
       notificationsDesc?: string
       notificationsEnabled?: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -2655,7 +2655,10 @@ ${validationResult.error.issues.map((v) => v.message).join('\n')}`)
     if (!data) return
 
     const highlightId = crypto.randomUUID()
-    if (editorView) {
+    if (
+      editorView &&
+      (this.settings.continuationOptions.persistSelectionHighlight ?? true)
+    ) {
       const sel = editorView.state.selection.main
       if (!sel.empty) {
         selectionHighlightController.addHighlight(

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -460,6 +460,8 @@ export const yoloSettingsSchema = z.object({
       enableSmartSpace: z.boolean().optional(),
       // enable selection chat (Cursor-like text selection actions)
       enableSelectionChat: z.boolean().optional(),
+      // persist selected editor block highlight while chatting in sidebar
+      persistSelectionHighlight: z.boolean().optional(),
       // enable manual context selection for continuation
       manualContextEnabled: z.boolean().optional(),
       // manual context folders picked by user from the vault
@@ -559,6 +561,7 @@ export const yoloSettingsSchema = z.object({
           ?.id ?? '',
       enableSmartSpace: true,
       enableSelectionChat: true,
+      persistSelectionHighlight: true,
       manualContextEnabled: false,
       manualContextFolders: [],
       referenceRuleFolders: [],


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要

恢复 commit 8f8bbaf 删除的 `persistSelectionHighlight` 设置项，让用户可以关闭 YOLO 的选区块高亮层，避免与第三方主题产生双层叠加冲突。

改动文件：
- `src/settings/schema/setting.types.ts` — 重新加回字段和默认值 `true`
- `src/i18n/types.ts` / `locales/en.ts` / `locales/zh.ts` / `locales/it.ts` — 恢复三语翻译
- `src/components/settings/tabs/OthersTab.tsx` — 恢复设置页 Toggle UI 和 handler
- `src/features/editor/selection-chat/selectionChatController.ts` — 恢复 `shouldPersistSelectionHighlight()` 方法及 6 处 guard
- `src/features/editor/quick-ask/quickAskController.ts` — 恢复 2 处 guard
- `src/main.ts` — 恢复 1 处 guard

## Claude 分析要点

- 当前 schema 版本为 v67（62→63 之后又有 4 个迁移），所有现存用户处于 v67 且字段已被删除；Zod `.catch()` 和 `?? true` 默认值可正确处理 `undefined`，无需新增迁移。
- `shouldPersistSelectionHighlight()` 在 selectionChatController，`?? true` inline 在 quickAskController 和 main.ts——与原始实现一致。

## Codex 二审反馈

gpt-5.5 审查：

1. **High（实际影响极低）**：62→63 迁移仍会删除从 v62 升级用户的 `false` 偏好 → 以 `true` 默认重新开始，可手动关闭。历史迁移不应修改，受影响用户极少。
2. **Medium**：关闭开关时只清 Markdown 高亮，未清 PDF 高亮 → 原始实现的既有行为，忠实恢复原状。
3. **Low**：`clearAll()` 会清 transient 高亮 → 原始实现既有行为。

整体确认：核心逻辑正确，TS 风格符合 CLAUDE.md，`git diff --check` 通过。

## 校验清单

- [x] `npm run type:check` — 仅有预存的 `baseUrl` 弃用警告（main 分支同样存在）
- [x] Codex gpt-5.5 独立二审 diff
- [x] 逻辑全链路推演：schema → runtime defaults → gate 各路径 → UI toggle

## 关联

Closes #373

---

*I'm Claude (lapis0x0-bot). May your themes never double-highlight again.*

*"There once was a toggle named `persist`,*
*Deleted by commit — it was missed.*
*Now restored with a guard,*
*Theme conflicts are barred,*
*And third-party themes can coexist."*