### PR TITLE
[auto-triage] restore context_prune_tool_results tool (disabled by default) (#372)

### DIFF
--- a/src/core/agent/builtinToolUiMeta.ts
+++ b/src/core/agent/builtinToolUiMeta.ts
@@ -36,6 +36,13 @@ export const BUILTIN_TOOL_UI_META: Record<string, BuiltinToolUiMeta> = {
     descFallback:
       'Read vault files by path with either full-file or targeted line-range operations.',
   },
+  context_prune_tool_results: {
+    labelKey: 'settings.agent.builtinContextPruneToolResultsLabel',
+    descKey: 'settings.agent.builtinContextPruneToolResultsDesc',
+    labelFallback: 'Prune Tool Results',
+    descFallback:
+      'Exclude selected historical tool results, or prune all prunable tool results at once, from future model-visible context without deleting chat history.',
+  },
   context_compact: {
     labelKey: 'settings.agent.builtinContextCompactLabel',
     descKey: 'settings.agent.builtinContextCompactDesc',
@@ -164,6 +171,7 @@ const BUILTIN_TOOL_CATEGORY_MAP: Record<string, BuiltinToolCategory> = {
   fs_read: 'vault',
   fs_edit: 'vault',
   [FILE_OPS_GROUP_TOOL_NAME]: 'vault',
+  context_prune_tool_results: 'context',
   context_compact: 'context',
   load_tool_schemas: 'context',
   todo_write: 'context',

--- a/src/core/agent/tool-preferences.test.ts
+++ b/src/core/agent/tool-preferences.test.ts
@@ -27,6 +27,9 @@ describe('tool-preferences defaults', () => {
     })
 
     it('returns false for built-in tools in the deny-list', () => {
+      expect(
+        getDefaultEnabledForTool('yolo_local__context_prune_tool_results'),
+      ).toBe(false)
       expect(getDefaultEnabledForTool('yolo_local__context_compact')).toBe(
         false,
       )

--- a/src/core/agent/tool-preferences.ts
+++ b/src/core/agent/tool-preferences.ts
@@ -58,7 +58,11 @@ const FULL_ACCESS_LOCAL_TOOLS: ReadonlySet<string> = new Set([
  * and runtime read the same policy.
  */
 export const BUILTIN_DEFAULT_DISABLED_TOOL_SHORT_NAMES: ReadonlySet<string> =
-  new Set(['context_compact', JS_SANDBOX_TOOL_NAME])
+  new Set([
+    'context_prune_tool_results',
+    'context_compact',
+    JS_SANDBOX_TOOL_NAME,
+  ])
 
 /**
  * Full set of user-facing built-in tool FQNs that default to on. Used by the

--- a/src/core/mcp/localFileTools.test.ts
+++ b/src/core/mcp/localFileTools.test.ts
@@ -45,7 +45,10 @@ import { App, TFile, TFolder } from 'obsidian'
 import { PDFDocument } from 'pdf-lib'
 
 import type { YoloSettings } from '../../settings/schema/setting.types'
-import { ToolCallResponseStatus } from '../../types/tool-call.types'
+import {
+  ToolCallResponseStatus,
+  createCompleteToolCallArguments,
+} from '../../types/tool-call.types'
 import { editUndoSnapshotStore } from '../../utils/chat/editUndoSnapshotStore'
 import { extractMarkdownImages } from '../../utils/llm/extract-markdown-images'
 import { extractPdfText } from '../../utils/pdf/extractPdfText'
@@ -1197,6 +1200,345 @@ describe('local fs tool action helpers', () => {
         },
       ],
     })
+  })
+
+  it('supports context prune tool results for any successful text tool output', async () => {
+    const result = await callLocalFileTool({
+      app: {
+        vault: {},
+      } as unknown as App,
+      toolCallId: 'prune-1',
+      toolName: 'context_prune_tool_results',
+      conversationMessages: [
+        {
+          role: 'tool',
+          id: 'tool-message-1',
+          toolCalls: [
+            {
+              request: {
+                id: 'edit-1',
+                name: 'yolo_local__fs_edit',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: { type: 'text', text: '{}' },
+              },
+            },
+          ],
+        },
+      ],
+      args: {
+        toolCallIds: [' edit-1 ', 'read-2', 'edit-1'],
+        reason: 'superseded by newer reads',
+      },
+    })
+
+    expect(result.status).toBe(ToolCallResponseStatus.Success)
+    if (result.status !== ToolCallResponseStatus.Success) {
+      throw new Error('expected success')
+    }
+
+    expect(JSON.parse(result.text)).toEqual({
+      tool: 'context_prune_tool_results',
+      toolCallId: 'prune-1',
+      operation: 'prune_selected',
+      acceptedToolCallIds: ['edit-1'],
+      ignoredToolCallIds: ['read-2'],
+      reason: 'superseded by newer reads',
+    })
+  })
+
+  it('ignores tool results from the same tool message as prune', async () => {
+    const result = await callLocalFileTool({
+      app: {
+        vault: {},
+      } as unknown as App,
+      toolCallId: 'prune-1',
+      toolName: 'context_prune_tool_results',
+      conversationMessages: [
+        {
+          role: 'tool',
+          id: 'tool-message-history',
+          toolCalls: [
+            {
+              request: {
+                id: 'edit-history',
+                name: 'yolo_local__fs_edit',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: { type: 'text', text: '{}' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          id: 'tool-message-current',
+          toolCalls: [
+            {
+              request: {
+                id: 'edit-current',
+                name: 'server__tool_a',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: { type: 'text', text: '{}' },
+              },
+            },
+            {
+              request: {
+                id: 'prune-1',
+                name: 'yolo_local__context_prune_tool_results',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Running,
+              },
+            },
+          ],
+        },
+      ],
+      args: {
+        toolCallIds: ['edit-history', 'edit-current'],
+      },
+    })
+
+    expect(result.status).toBe(ToolCallResponseStatus.Success)
+    if (result.status !== ToolCallResponseStatus.Success) {
+      throw new Error('expected success')
+    }
+
+    expect(JSON.parse(result.text)).toEqual({
+      tool: 'context_prune_tool_results',
+      toolCallId: 'prune-1',
+      operation: 'prune_selected',
+      acceptedToolCallIds: ['edit-history'],
+      ignoredToolCallIds: ['edit-current'],
+      reason: null,
+    })
+  })
+
+  it('only accepts successful text non-control tool results for pruning', async () => {
+    const result = await callLocalFileTool({
+      app: {
+        vault: {},
+      } as unknown as App,
+      toolCallId: 'prune-1',
+      toolName: 'context_prune_tool_results',
+      conversationMessages: [
+        {
+          role: 'tool',
+          id: 'tool-message-1',
+          toolCalls: [
+            {
+              request: {
+                id: 'search-success',
+                name: 'yolo_local__fs_search',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: { type: 'text', text: '{}' },
+              },
+            },
+            {
+              request: {
+                id: 'edit-error',
+                name: 'yolo_local__fs_edit',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Error,
+                error: 'missing file',
+              },
+            },
+            {
+              request: {
+                id: 'remote-aborted',
+                name: 'server__tool_a',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Aborted,
+              },
+            },
+            {
+              request: {
+                id: 'compact-success',
+                name: 'yolo_local__context_compact',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: { type: 'text', text: '{}' },
+              },
+            },
+          ],
+        },
+      ],
+      args: {
+        toolCallIds: [
+          'search-success',
+          'edit-error',
+          'remote-aborted',
+          'compact-success',
+        ],
+      },
+    })
+
+    expect(result.status).toBe(ToolCallResponseStatus.Success)
+    if (result.status !== ToolCallResponseStatus.Success) {
+      throw new Error('expected success')
+    }
+
+    expect(JSON.parse(result.text)).toEqual({
+      tool: 'context_prune_tool_results',
+      toolCallId: 'prune-1',
+      operation: 'prune_selected',
+      acceptedToolCallIds: ['search-success'],
+      ignoredToolCallIds: ['edit-error', 'remote-aborted', 'compact-success'],
+      reason: null,
+    })
+  })
+
+  it('supports pruning all prunable tool results at once', async () => {
+    const result = await callLocalFileTool({
+      app: {
+        vault: {},
+      } as unknown as App,
+      toolCallId: 'prune-all-1',
+      toolName: 'context_prune_tool_results',
+      conversationMessages: [
+        {
+          role: 'tool',
+          id: 'tool-message-1',
+          toolCalls: [
+            {
+              request: {
+                id: 'search-1',
+                name: 'yolo_local__fs_search',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: { type: 'text', text: '{}' },
+              },
+            },
+            {
+              request: {
+                id: 'remote-1',
+                name: 'server__tool_a',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: { type: 'text', text: '{}' },
+              },
+            },
+            {
+              request: {
+                id: 'compact-1',
+                name: 'yolo_local__context_compact',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: { type: 'text', text: '{}' },
+              },
+            },
+          ],
+        },
+      ],
+      args: {
+        mode: 'all',
+        reason: 'reset working set',
+      },
+    })
+
+    expect(result.status).toBe(ToolCallResponseStatus.Success)
+    if (result.status !== ToolCallResponseStatus.Success) {
+      throw new Error('expected success')
+    }
+
+    expect(JSON.parse(result.text)).toEqual({
+      tool: 'context_prune_tool_results',
+      toolCallId: 'prune-all-1',
+      operation: 'prune_all',
+      acceptedToolCallIds: ['search-1', 'remote-1'],
+      ignoredToolCallIds: [],
+      reason: 'reset working set',
+    })
+  })
+
+  it('returns success with empty accepted ids when mode is all and nothing is prunable', async () => {
+    const result = await callLocalFileTool({
+      app: {
+        vault: {},
+      } as unknown as App,
+      toolCallId: 'prune-all-empty-1',
+      toolName: 'context_prune_tool_results',
+      conversationMessages: [
+        {
+          role: 'tool',
+          id: 'tool-message-1',
+          toolCalls: [
+            {
+              request: {
+                id: 'compact-1',
+                name: 'yolo_local__context_compact',
+                arguments: createCompleteToolCallArguments({ value: {} }),
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: { type: 'text', text: '{}' },
+              },
+            },
+          ],
+        },
+      ],
+      args: {
+        mode: 'all',
+      },
+    })
+
+    expect(result.status).toBe(ToolCallResponseStatus.Success)
+    if (result.status !== ToolCallResponseStatus.Success) {
+      throw new Error('expected success')
+    }
+
+    expect(JSON.parse(result.text)).toEqual({
+      tool: 'context_prune_tool_results',
+      toolCallId: 'prune-all-empty-1',
+      operation: 'prune_all',
+      acceptedToolCallIds: [],
+      ignoredToolCallIds: [],
+      reason: null,
+    })
+  })
+
+  it('requires toolCallIds when mode is selected', async () => {
+    const result = await callLocalFileTool({
+      app: {
+        vault: {},
+      } as unknown as App,
+      toolCallId: 'prune-selected-empty-1',
+      toolName: 'context_prune_tool_results',
+      args: {
+        mode: 'selected',
+        toolCallIds: [],
+      },
+    })
+
+    expect(result.status).toBe(ToolCallResponseStatus.Error)
+    if (result.status === ToolCallResponseStatus.Error) {
+      expect(result.error).toContain(
+        'toolCallIds cannot be empty when mode is selected.',
+      )
+    }
   })
 
   it('supports context compact control operation', async () => {

--- a/src/core/mcp/localFileTools.ts
+++ b/src/core/mcp/localFileTools.ts
@@ -27,6 +27,7 @@ import {
   deriveToolEditUndoStatus,
 } from '../../utils/chat/editSummary'
 import { editUndoSnapshotStore } from '../../utils/chat/editUndoSnapshotStore'
+import { isContextPrunableToolName } from '../../utils/chat/tool-context-pruning'
 import { collectWikilinkPaths } from '../../utils/llm/annotate-wikilinks'
 import { extractMarkdownImages } from '../../utils/llm/extract-markdown-images'
 import {
@@ -110,10 +111,46 @@ const MAX_READ_LINE_INDEX = 1_000_000
 const MAX_RAG_SNIPPET_CHARS = 500
 const RAG_FETCH_LIMIT_MAX = 300
 
+const getContextPrunableToolCallIds = (
+  messages: ChatMessage[] | undefined,
+  currentToolCallId?: string,
+): Set<string> => {
+  const acceptedToolCallIds = new Set<string>()
+
+  for (const message of messages ?? []) {
+    if (message.role !== 'tool') {
+      continue
+    }
+
+    if (
+      currentToolCallId &&
+      message.toolCalls.some(
+        (toolCall) => toolCall.request.id === currentToolCallId,
+      )
+    ) {
+      break
+    }
+
+    for (const toolCall of message.toolCalls) {
+      if (
+        isContextPrunableToolName(toolCall.request.name) &&
+        toolCall.response.status === ToolCallResponseStatus.Success &&
+        toolCall.response.data.type === 'text' &&
+        toolCall.request.id.trim().length > 0
+      ) {
+        acceptedToolCallIds.add(toolCall.request.id)
+      }
+    }
+  }
+
+  return acceptedToolCallIds
+}
+
 export const LOCAL_FILE_TOOL_SHORT_NAMES = [
   'fs_list',
   'fs_search',
   'fs_read',
+  'context_prune_tool_results',
   'context_compact',
   'fs_edit',
   'fs_write',
@@ -171,6 +208,7 @@ type FsReadOperation =
       maxLines: number
       modality?: FsReadModality
     }
+type ContextPruneMode = 'selected' | 'all'
 type FsFileOpAction = 'write' | 'delete' | 'create_dir' | 'move'
 
 type LocalToolCallResultMetadata = {
@@ -615,6 +653,34 @@ export function getLocalFileTools(options?: {
           },
         },
         required: ['paths', 'operation'],
+      },
+    },
+    {
+      name: 'context_prune_tool_results',
+      description:
+        'Exclude historical tool call results from future model-visible context without deleting chat history. Supports pruning selected calls or all prunable calls at once.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          mode: {
+            type: 'string',
+            enum: ['selected', 'all'],
+            description:
+              'Prune mode. Use selected to prune specific toolCallIds, or all to prune all historical prunable tool results.',
+          },
+          toolCallIds: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            description:
+              'Tool call ids to exclude from future prompt context when mode is selected.',
+          },
+          reason: {
+            type: 'string',
+            description: 'Optional short reason for pruning.',
+          },
+        },
       },
     },
     {
@@ -1691,6 +1757,19 @@ const getSemanticSearchUnavailableReason = ({
     return 'No embedding model configured. Fell back to keyword search.'
   }
   return null
+}
+
+const getContextPruneMode = (
+  args: Record<string, unknown>,
+): ContextPruneMode => {
+  const value = args.mode
+  if (value === undefined) {
+    return 'selected'
+  }
+  if (value !== 'selected' && value !== 'all') {
+    throw new Error('mode must be one of: selected, all.')
+  }
+  return value
 }
 
 const getFsListScope = (args: Record<string, unknown>): FsListScope => {
@@ -3319,6 +3398,47 @@ export async function callLocalFileTool({
           status: ToolCallResponseStatus.Success,
           text: textResult,
           contentParts,
+        }
+      }
+
+      case 'context_prune_tool_results': {
+        const mode = getContextPruneMode(args)
+
+        const prunableToolCallIds = getContextPrunableToolCallIds(
+          conversationMessages,
+          toolCallId,
+        )
+        const toolCallIds =
+          mode === 'all'
+            ? [...prunableToolCallIds]
+            : getStringArrayArg(args, 'toolCallIds')
+                .map((value) => value.trim())
+                .filter(
+                  (value, index, arr) =>
+                    value.length > 0 && arr.indexOf(value) === index,
+                )
+
+        if (mode === 'selected' && toolCallIds.length === 0) {
+          throw new Error('toolCallIds cannot be empty when mode is selected.')
+        }
+
+        const acceptedToolCallIds = toolCallIds.filter((value) =>
+          prunableToolCallIds.has(value),
+        )
+        const ignoredToolCallIds = toolCallIds.filter(
+          (value) => !prunableToolCallIds.has(value),
+        )
+
+        return {
+          status: ToolCallResponseStatus.Success,
+          text: formatJsonResult({
+            tool: 'context_prune_tool_results',
+            toolCallId: toolCallId ?? null,
+            operation: mode === 'all' ? 'prune_all' : 'prune_selected',
+            acceptedToolCallIds,
+            ignoredToolCallIds,
+            reason: getOptionalTextArg(args, 'reason')?.trim() || null,
+          }),
         }
       }
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -431,6 +431,9 @@ export const en: TranslationKeys = {
       builtinFsSearchDesc: 'Search vault files and content',
       builtinFsReadLabel: 'Read',
       builtinFsReadDesc: 'Read vault files',
+      builtinContextPruneToolResultsLabel: 'Prune Tool Results',
+      builtinContextPruneToolResultsDesc:
+        'Exclude past tool results from future context',
       builtinContextCompactLabel: 'Compact Context',
       builtinContextCompactDesc: 'Compress earlier conversation into a summary',
       builtinToolSearchLabel: 'Load Tool',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -419,6 +419,9 @@ export const it: TranslationKeys = {
       builtinFsSearchDesc: 'Cerca file e contenuti nel vault',
       builtinFsReadLabel: 'Leggi',
       builtinFsReadDesc: 'Leggi file del vault',
+      builtinContextPruneToolResultsLabel: 'Pota risultati strumenti',
+      builtinContextPruneToolResultsDesc:
+        'Escludi i risultati storici degli strumenti dal contesto futuro',
       builtinContextCompactLabel: 'Compatta contesto',
       builtinContextCompactDesc:
         'Comprimi la cronologia meno recente in un riepilogo',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -389,6 +389,8 @@ export const zh: TranslationKeys = {
       builtinFsSearchDesc: '搜索库内文件与内容',
       builtinFsReadLabel: '读取',
       builtinFsReadDesc: '读取库内文件',
+      builtinContextPruneToolResultsLabel: '裁剪工具调用结果',
+      builtinContextPruneToolResultsDesc: '从后续上下文中排除历史工具结果',
       builtinContextCompactLabel: '压缩上下文',
       builtinContextCompactDesc: '将较早对话压缩为摘要',
       builtinToolSearchLabel: '加载工具',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -307,6 +307,8 @@ export type TranslationKeys = {
       builtinFsSearchDesc?: string
       builtinFsReadLabel?: string
       builtinFsReadDesc?: string
+      builtinContextPruneToolResultsLabel?: string
+      builtinContextPruneToolResultsDesc?: string
       builtinContextCompactLabel?: string
       builtinContextCompactDesc?: string
       builtinToolSearchLabel?: string

--- a/src/utils/chat/requestContextBuilder.test.ts
+++ b/src/utils/chat/requestContextBuilder.test.ts
@@ -467,6 +467,144 @@ describe('RequestContextBuilder generateRequestMessages', () => {
 
   const emptyArgs = createCompleteToolCallArguments({ value: {} })
 
+  it('hides pruned tool results from future request context', async () => {
+    const app = {
+      vault: {
+        adapter: {
+          exists: jest.fn().mockResolvedValue(false),
+          mkdir: jest.fn().mockResolvedValue(undefined),
+          read: jest.fn().mockResolvedValue(''),
+          write: jest.fn().mockResolvedValue(undefined),
+        },
+      },
+    } as unknown as ReturnType<typeof createMockApp>
+
+    const builder = new RequestContextBuilder(app as never, settings)
+
+    const requestMessages = await builder.generateRequestMessages({
+      messages: [
+        {
+          role: 'user',
+          id: 'user-1',
+          content: null,
+          promptContent: 'first prompt',
+          mentionables: [],
+        },
+        {
+          role: 'assistant',
+          id: 'assistant-tool',
+          content: '',
+          toolCallRequests: [
+            {
+              id: 'edit-1',
+              name: 'yolo_local__fs_edit',
+              arguments: emptyArgs,
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          id: 'tool-edit',
+          toolCalls: [
+            {
+              request: {
+                id: 'edit-1',
+                name: 'yolo_local__fs_edit',
+                arguments: emptyArgs,
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: {
+                  type: 'text',
+                  text: JSON.stringify({
+                    tool: 'fs_edit',
+                    path: 'note.md',
+                    status: 'ok',
+                  }),
+                },
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          id: 'assistant-prune',
+          content: '',
+          toolCallRequests: [
+            {
+              id: 'prune-1',
+              name: 'yolo_local__context_prune_tool_results',
+              arguments: emptyArgs,
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          id: 'tool-prune',
+          toolCalls: [
+            {
+              request: {
+                id: 'prune-1',
+                name: 'yolo_local__context_prune_tool_results',
+                arguments: emptyArgs,
+              },
+              response: {
+                status: ToolCallResponseStatus.Success,
+                data: {
+                  type: 'text',
+                  text: JSON.stringify({
+                    tool: 'context_prune_tool_results',
+                    operation: 'prune_selected',
+                    acceptedToolCallIds: ['edit-1'],
+                    ignoredToolCallIds: [],
+                  }),
+                },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          id: 'user-2',
+          content: null,
+          promptContent: 'follow-up prompt',
+          mentionables: [],
+        },
+      ],
+      hasTools: true,
+      hasMemoryTools: false,
+      model: {
+        provider: 'openai',
+        model: 'gpt-test',
+        name: 'gpt-test',
+      } as never,
+      conversationId: 'conversation-1',
+      systemPromptSnapshotMode: 'create',
+    })
+
+    expect(
+      requestMessages.some(
+        (message) =>
+          message.role === 'tool' && message.tool_call.id === 'edit-1',
+      ),
+    ).toBe(false)
+    expect(
+      requestMessages.some(
+        (message) =>
+          message.role === 'assistant' &&
+          (message.tool_calls ?? []).some(
+            (toolCall) => toolCall.id === 'edit-1',
+          ),
+      ),
+    ).toBe(false)
+    expect(
+      requestMessages.some(
+        (message) =>
+          message.role === 'tool' && message.tool_call.id === 'prune-1',
+      ),
+    ).toBe(true)
+  })
+
   it('injects compact summary and retains the latest assistant tool boundary', async () => {
     const app = {
       vault: {

--- a/src/utils/chat/requestContextBuilder.ts
+++ b/src/utils/chat/requestContextBuilder.ts
@@ -79,6 +79,11 @@ import {
   filterEmptyAssistantMessages,
   filterRequestMessagesByToolBoundary,
 } from './tool-boundary'
+import {
+  collectContextPrunedToolCallIds,
+  filterContextPrunedAssistantToolCalls,
+  filterContextPrunedToolCalls,
+} from './tool-context-pruning'
 
 /** Regex matching the `<user_selected_skills>...</user_selected_skills>` block
  * produced by `buildSelectedSkillsPrompt`. Used by the breakdown estimator to
@@ -812,6 +817,7 @@ export class RequestContextBuilder {
     compaction?: ChatConversationCompactionLike | null
   }): Promise<RequestMessage[]> {
     const requestMessages: RequestMessage[] = []
+    const prunedToolCallIds = collectContextPrunedToolCallIds(messages)
 
     const latestCompaction = getLatestChatConversationCompaction(compaction)
 
@@ -842,7 +848,9 @@ export class RequestContextBuilder {
           }
 
           if (message.role === 'assistant') {
-            requestMessages.push(...this.parseAssistantMessage({ message }))
+            requestMessages.push(
+              ...this.parseAssistantMessage({ message, prunedToolCallIds }),
+            )
             continue
           }
 
@@ -851,7 +859,9 @@ export class RequestContextBuilder {
             continue
           }
 
-          requestMessages.push(...this.parseToolMessage({ message }))
+          requestMessages.push(
+            ...this.parseToolMessage({ message, prunedToolCallIds }),
+          )
         }
 
         if (
@@ -879,7 +889,9 @@ export class RequestContextBuilder {
       }
 
       if (message.role === 'assistant') {
-        requestMessages.push(...this.parseAssistantMessage({ message }))
+        requestMessages.push(
+          ...this.parseAssistantMessage({ message, prunedToolCallIds }),
+        )
         continue
       }
 
@@ -888,7 +900,9 @@ export class RequestContextBuilder {
         continue
       }
 
-      requestMessages.push(...this.parseToolMessage({ message }))
+      requestMessages.push(
+        ...this.parseToolMessage({ message, prunedToolCallIds }),
+      )
     }
 
     return filterRequestMessagesByToolBoundary(
@@ -1043,8 +1057,10 @@ export class RequestContextBuilder {
 
   private parseAssistantMessage({
     message,
+    prunedToolCallIds,
   }: {
     message: ChatAssistantMessage
+    prunedToolCallIds?: ReadonlySet<string>
   }): RequestMessage[] {
     let citationContent: string | null = null
     if (message.annotations && message.annotations.length > 0) {
@@ -1067,12 +1083,14 @@ ${message.annotations
         ].join('\n'),
         reasoning: message.reasoning,
         providerMetadata: message.metadata?.providerMetadata,
-        tool_calls:
+        tool_calls: filterContextPrunedAssistantToolCalls(
           message.toolCallRequests
             ?.map((toolCall) => this.normalizeToolCallRequest(toolCall))
             .filter((toolCall): toolCall is NonNullable<typeof toolCall> =>
               Boolean(toolCall),
             ) ?? undefined,
+          prunedToolCallIds ?? new Set<string>(),
+        ),
       },
     ]
   }
@@ -1114,13 +1132,18 @@ ${message.annotations
 
   private parseToolMessage({
     message,
+    prunedToolCallIds,
   }: {
     message: ChatToolMessage
+    prunedToolCallIds?: ReadonlySet<string>
   }): RequestMessage[] {
     const toolMessages: RequestMessage[] = []
     const collectedContentParts: ContentPart[] = []
 
-    for (const toolCall of message.toolCalls) {
+    for (const toolCall of filterContextPrunedToolCalls(
+      message.toolCalls,
+      prunedToolCallIds ?? new Set<string>(),
+    )) {
       switch (toolCall.response.status) {
         case ToolCallResponseStatus.PendingApproval:
         case ToolCallResponseStatus.Running:

--- a/src/utils/chat/tool-context-pruning.test.ts
+++ b/src/utils/chat/tool-context-pruning.test.ts
@@ -1,0 +1,143 @@
+import type { ChatMessage } from '../../types/chat'
+import {
+  ToolCallResponseStatus,
+  createCompleteToolCallArguments,
+} from '../../types/tool-call.types'
+
+import {
+  collectContextPrunedToolCallIds,
+  filterContextPrunedAssistantToolCalls,
+  filterContextPrunedToolCalls,
+} from './tool-context-pruning'
+
+const emptyArgs = createCompleteToolCallArguments({ value: {} })
+
+describe('tool context pruning', () => {
+  it('collects pruned tool call ids from successful context prune tool results', () => {
+    const messages: ChatMessage[] = [
+      {
+        role: 'tool',
+        id: 'tool-message-1',
+        toolCalls: [
+          {
+            request: {
+              id: 'prune-call',
+              name: 'yolo_local__context_prune_tool_results',
+              arguments: emptyArgs,
+            },
+            response: {
+              status: ToolCallResponseStatus.Success,
+              data: {
+                type: 'text',
+                text: JSON.stringify({
+                  acceptedToolCallIds: [' read-1 ', 'read-2', 'read-1'],
+                }),
+              },
+            },
+          },
+        ],
+      },
+    ]
+
+    expect([...collectContextPrunedToolCallIds(messages)]).toEqual([
+      'read-1',
+      'read-2',
+    ])
+  })
+
+  it('filters pruned tool calls from assistant and tool messages', () => {
+    const prunedToolCallIds = new Set(['read-1', 'edit-1'])
+
+    expect(
+      filterContextPrunedAssistantToolCalls(
+        [
+          {
+            id: 'read-1',
+            name: 'yolo_local__fs_read',
+            arguments: emptyArgs,
+          },
+          {
+            id: 'edit-1',
+            name: 'yolo_local__fs_edit',
+            arguments: emptyArgs,
+          },
+        ],
+        prunedToolCallIds,
+      ),
+    ).toBeUndefined()
+
+    expect(
+      filterContextPrunedToolCalls(
+        [
+          {
+            request: {
+              id: 'read-1',
+              name: 'yolo_local__fs_read',
+              arguments: emptyArgs,
+            },
+            response: {
+              status: ToolCallResponseStatus.Success,
+              data: { type: 'text', text: '{}' },
+            },
+          },
+          {
+            request: {
+              id: 'edit-1',
+              name: 'yolo_local__fs_edit',
+              arguments: emptyArgs,
+            },
+            response: {
+              status: ToolCallResponseStatus.Success,
+              data: { type: 'text', text: '{}' },
+            },
+          },
+          {
+            request: {
+              id: 'prune-1',
+              name: 'yolo_local__context_prune_tool_results',
+              arguments: emptyArgs,
+            },
+            response: {
+              status: ToolCallResponseStatus.Success,
+              data: { type: 'text', text: '{}' },
+            },
+          },
+        ],
+        prunedToolCallIds,
+      ),
+    ).toHaveLength(1)
+  })
+
+  it('keeps context control tools even when ids are present in prune results', () => {
+    const prunedToolCallIds = new Set(['prune-1', 'compact-1'])
+
+    expect(
+      filterContextPrunedAssistantToolCalls(
+        [
+          {
+            id: 'prune-1',
+            name: 'yolo_local__context_prune_tool_results',
+            arguments: emptyArgs,
+          },
+          {
+            id: 'compact-1',
+            name: 'yolo_local__context_compact',
+            arguments: emptyArgs,
+          },
+        ],
+        prunedToolCallIds,
+      ),
+    ).toEqual([
+      {
+        id: 'prune-1',
+        name: 'yolo_local__context_prune_tool_results',
+        arguments: emptyArgs,
+      },
+      {
+        id: 'compact-1',
+        name: 'yolo_local__context_compact',
+        arguments: emptyArgs,
+      },
+    ])
+  })
+})

--- a/src/utils/chat/tool-context-pruning.ts
+++ b/src/utils/chat/tool-context-pruning.ts
@@ -1,0 +1,132 @@
+import { getLocalFileToolServerName } from '../../core/mcp/localFileTools'
+import { parseToolName } from '../../core/mcp/tool-name-utils'
+import type { ChatMessage, ChatToolMessage } from '../../types/chat'
+import type { ToolCallRequest } from '../../types/tool-call.types'
+import { ToolCallResponseStatus } from '../../types/tool-call.types'
+
+const CONTEXT_PRUNE_TOOL_NAME = 'context_prune_tool_results'
+const CONTEXT_COMPACT_TOOL_NAME = 'context_compact'
+const LOAD_TOOL_SCHEMAS_TOOL_NAME = 'load_tool_schemas'
+
+const normalizeToolName = (toolName: string): string => {
+  try {
+    const parsed = parseToolName(toolName)
+    if (parsed.serverName === getLocalFileToolServerName()) {
+      return parsed.toolName
+    }
+  } catch {
+    // Keep original tool name when it is already unqualified.
+  }
+
+  return toolName
+}
+
+export const isContextPruneToolName = (toolName: string): boolean => {
+  return normalizeToolName(toolName) === CONTEXT_PRUNE_TOOL_NAME
+}
+
+export const isContextPrunableToolName = (toolName: string): boolean => {
+  const normalized = normalizeToolName(toolName)
+  // `load_tool_schemas` results carry the on-demand tool disclosure state for
+  // the rest of the conversation — pruning them would silently drop the
+  // schemas the model relies on to keep calling those tools. Compaction is the
+  // long-term fallback (it copies schemas into `loadedDeferredToolSchemas`).
+  return (
+    normalized !== CONTEXT_PRUNE_TOOL_NAME &&
+    normalized !== CONTEXT_COMPACT_TOOL_NAME &&
+    normalized !== LOAD_TOOL_SCHEMAS_TOOL_NAME
+  )
+}
+
+const getPrunedToolCallIdsFromText = (text: string): string[] => {
+  try {
+    const parsed = JSON.parse(text) as {
+      acceptedToolCallIds?: unknown
+      prunedToolCallIds?: unknown
+      toolCallIds?: unknown
+    }
+
+    const candidate = Array.isArray(parsed.acceptedToolCallIds)
+      ? parsed.acceptedToolCallIds
+      : Array.isArray(parsed.prunedToolCallIds)
+        ? parsed.prunedToolCallIds
+        : parsed.toolCallIds
+
+    if (!Array.isArray(candidate)) {
+      return []
+    }
+
+    return candidate
+      .filter((value): value is string => typeof value === 'string')
+      .map((value) => value.trim())
+      .filter(
+        (value, index, arr) => value.length > 0 && arr.indexOf(value) === index,
+      )
+  } catch {
+    return []
+  }
+}
+
+export const collectContextPrunedToolCallIds = (
+  messages: ChatMessage[],
+): Set<string> => {
+  const prunedToolCallIds = new Set<string>()
+
+  for (const message of messages) {
+    if (message.role !== 'tool') {
+      continue
+    }
+
+    for (const toolCall of message.toolCalls) {
+      if (
+        toolCall.response.status !== ToolCallResponseStatus.Success ||
+        toolCall.response.data.type !== 'text' ||
+        !isContextPruneToolName(toolCall.request.name)
+      ) {
+        continue
+      }
+
+      for (const prunedToolCallId of getPrunedToolCallIdsFromText(
+        toolCall.response.data.text,
+      )) {
+        prunedToolCallIds.add(prunedToolCallId)
+      }
+    }
+  }
+
+  return prunedToolCallIds
+}
+
+export const filterContextPrunedAssistantToolCalls = (
+  toolCalls: ToolCallRequest[] | undefined,
+  prunedToolCallIds: ReadonlySet<string>,
+): ToolCallRequest[] | undefined => {
+  if (!toolCalls || toolCalls.length === 0 || prunedToolCallIds.size === 0) {
+    return toolCalls
+  }
+
+  const nextToolCalls = toolCalls.filter((toolCall) => {
+    return !(
+      prunedToolCallIds.has(toolCall.id) &&
+      isContextPrunableToolName(toolCall.name)
+    )
+  })
+
+  return nextToolCalls.length > 0 ? nextToolCalls : undefined
+}
+
+export const filterContextPrunedToolCalls = (
+  toolCalls: ChatToolMessage['toolCalls'],
+  prunedToolCallIds: ReadonlySet<string>,
+): ChatToolMessage['toolCalls'] => {
+  if (toolCalls.length === 0 || prunedToolCallIds.size === 0) {
+    return toolCalls
+  }
+
+  return toolCalls.filter((toolCall) => {
+    return !(
+      prunedToolCallIds.has(toolCall.request.id) &&
+      isContextPrunableToolName(toolCall.request.name)
+    )
+  })
+}


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要

恢复被 faff7ef 移除的 `yolo_local__context_prune_tool_results` 工具，保留其原有逻辑，并让它**默认关闭**（已在 `BUILTIN_DEFAULT_DISABLED_TOOL_SHORT_NAMES` 中）。用户需要在 Agent 设置里手动开启才能使用。

本 PR 是对 faff7ef 的语义 revert，非 `git revert`，因为 faff7ef 之后有两处独立改动与之冲突，需要手动合并：

1. **`localFileTools.ts` 冲突**：faff7ef 移除时 `FsFileOpAction` 还有旧值 (`create_file/delete_file/...`)，之后被重构成 `write/delete/...`。本 PR 保留新版 `FsFileOpAction`，仅将 `ContextPruneMode = 'selected' | 'all'` 类型和 prune handler 加回来。
2. **`requestContextBuilder.test.ts` 冲突**：恢复的测试用例缺少 `systemPromptSnapshotMode: 'create'` 参数（该参数在 faff7ef 之后才成为必填项），已补全。

## 恢复的文件

| 文件 | 变更 |
|------|------|
| `src/utils/chat/tool-context-pruning.ts` | 重新创建（132 行） |
| `src/utils/chat/tool-context-pruning.test.ts` | 重新创建（143 行） |
| `src/core/mcp/localFileTools.ts` | 加回 tool 定义、handler、helper 函数 |
| `src/core/mcp/localFileTools.test.ts` | 加回 6 个测试用例 |
| `src/utils/chat/requestContextBuilder.ts` | 加回 prune 过滤链路 |
| `src/utils/chat/requestContextBuilder.test.ts` | 加回端到端测试 |
| `src/core/agent/tool-preferences.ts` | 加回 `context_prune_tool_results` 到禁用列表 |
| `src/core/agent/builtinToolUiMeta.ts` | 加回 UI 元数据 |
| `src/i18n/locales/{en,zh,it}.ts` | 加回翻译 |
| `src/i18n/types.ts` | 加回类型定义 |

## Claude 分析要点

- 工具机制本身完整：MCP tool 定义 → `callLocalFileTool` handler → `requestContextBuilder` 里的过滤链路，三段全部恢复，逻辑一致。
- `ContextPruneMode` 类型与 `FsFileOpAction` 并列放置，不存在命名冲突。
- 工具默认关闭，符合 Lapis0x0 在 issue 里的明确意图（"off by default"）。

## Codex 二审反馈

Codex 在只读沙箱下做了深度审查（检查了工具注册链路、`callLocalFileTool` 调用路径、`toolPreferences` 的默认禁用机制、`filterContextPruned*` 函数的调用点等），未发现阻断性问题。

## 校验清单

- [x] 冲突手动解决，无残余 conflict marker
- [x] `npm run type:check` — 只有预存的 `baseUrl` 弃用警告（与本 PR 无关）
- [x] `jest --testPathPattern="tool-context-pruning|localFileTools|requestContextBuilder|tool-preferences"` — **全部 131 条 tests PASS**

## 关联 Issue

Closes #372

---

*Deployed by lapis0x0-bot, your friendly neighbourhood code custodian.*
*Fun fact: The shortest war in history lasted only 38-45 minutes (Anglo-Zanzibar War, 1896). This PR took longer to write.*