### PR TITLE
[auto-triage] Support skills in hidden YOLO folders (#384)

### DIFF
--- a/src/components/chat-view/chat-input/ChatUserInput.tsx
+++ b/src/components/chat-view/chat-input/ChatUserInput.tsx
@@ -30,7 +30,10 @@ import { useApp } from '../../../contexts/app-context'
 import { useLanguage } from '../../../contexts/language-context'
 import { useSettings } from '../../../contexts/settings-context'
 import { getYoloSnippetsPath } from '../../../core/paths/yoloPaths'
-import { listLiteSkillEntries } from '../../../core/skills/liteSkills'
+import {
+  type LiteSkillEntry,
+  listLiteSkillEntriesAsync,
+} from '../../../core/skills/liteSkills'
 import { isSkillEnabledForAssistant } from '../../../core/skills/skillPolicy'
 import { openSnippetsFileInVault } from '../../../core/snippets/snippetsFile'
 import { ChatSelectedSkill } from '../../../types/chat'
@@ -270,6 +273,27 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
       [mentionables],
     )
 
+    const [allSkillEntries, setAllSkillEntries] = useState<LiteSkillEntry[]>([])
+
+    useEffect(() => {
+      let cancelled = false
+      void listLiteSkillEntriesAsync(app, { settings })
+        .then((entries) => {
+          if (!cancelled) {
+            setAllSkillEntries(entries)
+          }
+        })
+        .catch((error: unknown) => {
+          console.warn('[YOLO] Failed to list skills', error)
+          if (!cancelled) {
+            setAllSkillEntries([])
+          }
+        })
+      return () => {
+        cancelled = true
+      }
+    }, [app, settings])
+
     const availableSkills = useMemo(() => {
       const assistants = settings.assistants || []
       const currentAssistant = currentAssistantId
@@ -283,7 +307,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
       }
 
       const disabledSkillNames = settings.skills?.disabledSkillIds ?? []
-      return listLiteSkillEntries(app, { settings }).filter((skill) =>
+      return allSkillEntries.filter((skill) =>
         isSkillEnabledForAssistant({
           assistant: currentAssistant,
           skillName: skill.name,
@@ -291,7 +315,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
           defaultLoadMode: skill.mode,
         }),
       )
-    }, [app, currentAssistantId, settings])
+    }, [allSkillEntries, currentAssistantId, settings])
 
     const availableSnippets = useSnippetEntries()
 

--- a/src/components/chat-view/useChatStreamManager.ts
+++ b/src/components/chat-view/useChatStreamManager.ts
@@ -28,7 +28,7 @@ import { getChatModelClient } from '../../core/llm/manager'
 import type { AutoPromotedTransportMode } from '../../core/llm/requestTransport'
 import { shouldUseStreamingForProvider } from '../../core/llm/streamingPolicy'
 import { promoteProviderTransportModeToObsidian } from '../../core/llm/transportModePromotion'
-import { listLiteSkillEntries } from '../../core/skills/liteSkills'
+import { listLiteSkillEntriesAsync } from '../../core/skills/liteSkills'
 import { isSkillEnabledForAssistant } from '../../core/skills/skillPolicy'
 import {
   ChatConversationCompaction,
@@ -469,7 +469,7 @@ export function useChatStreamManager({
       const effectiveModel = resolvedClient.model
       const disabledSkillNames = settings.skills?.disabledSkillIds ?? []
       const enabledSkillEntries = selectedAssistant
-        ? listLiteSkillEntries(app, { settings }).filter((skill) =>
+        ? (await listLiteSkillEntriesAsync(app, { settings })).filter((skill) =>
             isSkillEnabledForAssistant({
               assistant: selectedAssistant,
               skillName: skill.name,
@@ -709,12 +709,13 @@ export function useChatStreamManager({
         const effectiveModel = resolvedClient.model
         const disabledSkillNames = settings.skills?.disabledSkillIds ?? []
         const enabledSkillEntries = selectedAssistant
-          ? listLiteSkillEntries(app, { settings }).filter((skill) =>
-              isSkillEnabledForAssistant({
-                assistant: selectedAssistant,
-                skillName: skill.name,
-                disabledSkillNames,
-              }),
+          ? (await listLiteSkillEntriesAsync(app, { settings })).filter(
+              (skill) =>
+                isSkillEnabledForAssistant({
+                  assistant: selectedAssistant,
+                  skillName: skill.name,
+                  disabledSkillNames,
+                }),
             )
           : []
         const allowedSkillNames = enabledSkillEntries.map((skill) => skill.name)
@@ -973,7 +974,7 @@ export function useChatStreamManager({
       const effectiveModel = resolvedClient.model
       const disabledSkillNames = settings.skills?.disabledSkillIds ?? []
       const enabledSkillEntries = selectedAssistant
-        ? listLiteSkillEntries(app, { settings }).filter((skill) =>
+        ? (await listLiteSkillEntriesAsync(app, { settings })).filter((skill) =>
             isSkillEnabledForAssistant({
               assistant: selectedAssistant,
               skillName: skill.name,

--- a/src/components/panels/quick-ask/QuickAskPanel.tsx
+++ b/src/components/panels/quick-ask/QuickAskPanel.tsx
@@ -35,7 +35,7 @@ import { materializeTextEditPlan } from '../../../core/edits/textEditEngine'
 import { parseTextEditPlan } from '../../../core/edits/textEditPlan'
 import { LLMModelNotFoundException } from '../../../core/llm/exception'
 import { getChatModelClient } from '../../../core/llm/manager'
-import { listLiteSkillEntries } from '../../../core/skills/liteSkills'
+import { listLiteSkillEntriesAsync } from '../../../core/skills/liteSkills'
 import { isSkillEnabledForAssistant } from '../../../core/skills/skillPolicy'
 import type {
   QuickAskLaunchMode,
@@ -1095,12 +1095,13 @@ export function QuickAskPanel({
         const effectiveModel = model
         const disabledSkillNames = settings.skills?.disabledSkillIds ?? []
         const enabledSkillEntries = selectedAssistant
-          ? listLiteSkillEntries(app, { settings }).filter((skill) =>
-              isSkillEnabledForAssistant({
-                assistant: selectedAssistant,
-                skillName: skill.name,
-                disabledSkillNames,
-              }),
+          ? (await listLiteSkillEntriesAsync(app, { settings })).filter(
+              (skill) =>
+                isSkillEnabledForAssistant({
+                  assistant: selectedAssistant,
+                  skillName: skill.name,
+                  disabledSkillNames,
+                }),
             )
           : []
         const allowedSkillNames = enabledSkillEntries.map((skill) => skill.name)

--- a/src/components/settings/modals/AgentSkillsModal.tsx
+++ b/src/components/settings/modals/AgentSkillsModal.tsx
@@ -1,5 +1,5 @@
 import { App, Notice, TFile, TFolder } from 'obsidian'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useLanguage } from '../../../contexts/language-context'
 import {
@@ -8,8 +8,9 @@ import {
 } from '../../../contexts/settings-context'
 import { getYoloSkillsDir } from '../../../core/paths/yoloPaths'
 import {
+  type LiteSkillEntry,
   humanizeSkillName,
-  listLiteSkillEntries,
+  listLiteSkillEntriesAsync,
 } from '../../../core/skills/liteSkills'
 import YoloPlugin from '../../../main'
 import { ObsidianButton } from '../../common/ObsidianButton'
@@ -77,9 +78,25 @@ function AgentSkillsModalContent({
     [disabledSkillNames],
   )
 
-  const skills = useMemo(() => {
+  const [skills, setSkills] = useState<LiteSkillEntry[]>([])
+  useEffect(() => {
+    let cancelled = false
     void refreshTick
-    return listLiteSkillEntries(app, { settings })
+    void listLiteSkillEntriesAsync(app, { settings })
+      .then((entries) => {
+        if (!cancelled) {
+          setSkills(entries)
+        }
+      })
+      .catch((error: unknown) => {
+        console.warn('[YOLO] Failed to list skills', error)
+        if (!cancelled) {
+          setSkills([])
+        }
+      })
+    return () => {
+      cancelled = true
+    }
   }, [app, refreshTick, settings])
 
   const deletableSkills = useMemo(

--- a/src/components/settings/sections/AgentSection.tsx
+++ b/src/components/settings/sections/AgentSection.tsx
@@ -22,8 +22,9 @@ import {
 } from '../../../core/mcp/localFileTools'
 import { McpManager } from '../../../core/mcp/mcpManager'
 import {
+  type LiteSkillEntry,
   humanizeSkillName,
-  listLiteSkillEntries,
+  listLiteSkillEntriesAsync,
 } from '../../../core/skills/liteSkills'
 import { isSkillEnabledForAssistant } from '../../../core/skills/skillPolicy'
 import { Assistant } from '../../../types/assistant.types'
@@ -285,10 +286,25 @@ export function AgentSection({ app }: AgentSectionProps) {
     return tools
   }, [settings.mcp.builtinToolOptions, t])
 
-  const allSkillEntries = useMemo(
-    () => listLiteSkillEntries(app, { settings }),
-    [app, settings],
-  )
+  const [allSkillEntries, setAllSkillEntries] = useState<LiteSkillEntry[]>([])
+  useEffect(() => {
+    let cancelled = false
+    void listLiteSkillEntriesAsync(app, { settings })
+      .then((entries) => {
+        if (!cancelled) {
+          setAllSkillEntries(entries)
+        }
+      })
+      .catch((error: unknown) => {
+        console.warn('[YOLO] Failed to list skills', error)
+        if (!cancelled) {
+          setAllSkillEntries([])
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [app, settings])
   const disabledSkillIds = settings.skills?.disabledSkillIds ?? []
   const disabledSkillSet = useMemo(
     () => new Set(disabledSkillIds),

--- a/src/components/settings/sections/AgentsSectionContent.tsx
+++ b/src/components/settings/sections/AgentsSectionContent.tsx
@@ -52,7 +52,7 @@ import {
   LiteSkillEntry,
   getLiteSkillDocument,
   humanizeSkillName,
-  listLiteSkillEntries,
+  listLiteSkillEntriesAsync,
 } from '../../../core/skills/liteSkills'
 import {
   getDisabledSkillNameSet,
@@ -969,10 +969,25 @@ export function AgentsSectionContent({
     return result
   }, [draftAgent, estimatedToolContextTokens.perTool, visibleToolGroups])
 
-  const skillEntries = useMemo<LiteSkillEntry[]>(
-    () => listLiteSkillEntries(app, { settings }),
-    [app, settings],
-  )
+  const [skillEntries, setSkillEntries] = useState<LiteSkillEntry[]>([])
+  useEffect(() => {
+    let cancelled = false
+    void listLiteSkillEntriesAsync(app, { settings })
+      .then((entries) => {
+        if (!cancelled) {
+          setSkillEntries(entries)
+        }
+      })
+      .catch((error: unknown) => {
+        console.warn('[YOLO] Failed to list skills', error)
+        if (!cancelled) {
+          setSkillEntries([])
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [app, settings])
 
   const disabledSkillIds = useMemo(
     () => settings.skills?.disabledSkillIds ?? [],

--- a/src/core/skills/liteSkills.test.ts
+++ b/src/core/skills/liteSkills.test.ts
@@ -1,7 +1,9 @@
 import { App } from 'obsidian'
 
 import {
+  getLiteSkillDocument,
   humanizeSkillName,
+  listLiteSkillEntriesAsync,
   migrateVaultSkillFrontmatter,
   rewriteSkillFrontmatterIdToName,
 } from './liteSkills'
@@ -184,11 +186,43 @@ const makeFakeApp = (
   const app = {
     vault: {
       getMarkdownFiles: (): FakeFile[] => files.map((f) => f.file),
+      getAbstractFileByPath: (path: string) =>
+        files.find((f) => f.file.path === path)?.file ?? null,
+      cachedRead: (file: FakeFile) => Promise.resolve(reads[file.path]),
       read: (file: FakeFile) => Promise.resolve(reads[file.path]),
       modify: (file: FakeFile, content: string) => {
         reads[file.path] = content
         modifies.push({ path: file.path, content })
         return Promise.resolve()
+      },
+      adapter: {
+        exists: (path: string) =>
+          Promise.resolve(
+            files.some(
+              (f) => f.file.path === path || f.file.path.startsWith(`${path}/`),
+            ),
+          ),
+        list: (path: string) => {
+          const filesInDir: string[] = []
+          const folderSet = new Set<string>()
+          for (const { file } of files) {
+            if (!file.path.startsWith(`${path}/`)) {
+              continue
+            }
+            const relativePath = file.path.slice(path.length + 1)
+            const slashIndex = relativePath.indexOf('/')
+            if (slashIndex === -1) {
+              filesInDir.push(file.path)
+            } else {
+              folderSet.add(`${path}/${relativePath.slice(0, slashIndex)}`)
+            }
+          }
+          return Promise.resolve({
+            files: filesInDir,
+            folders: [...folderSet],
+          })
+        },
+        read: (path: string) => Promise.resolve(reads[path]),
       },
     },
     metadataCache: {
@@ -279,6 +313,64 @@ describe('migrateVaultSkillFrontmatter', () => {
 
     expect(reads['YOLO/skills/good.md']).toContain('name: good')
     expect(reads['YOLO/skills/good.md']).not.toMatch(/^id:/m)
+  })
+})
+
+describe('lite skill adapter discovery', () => {
+  it('lists and opens skills stored under a hidden YOLO base directory', async () => {
+    const hiddenSkill = {
+      file: {
+        path: '.obsidian/yolo/skills/hidden-skill/SKILL.md',
+        name: 'SKILL.md',
+        extension: 'md',
+      },
+      content: [
+        '---',
+        'name: hidden-skill',
+        'description: Works from a hidden folder',
+        'mode: always',
+        '---',
+        '',
+        '# Hidden Skill',
+      ].join('\n'),
+    }
+
+    const { app } = makeFakeApp([hiddenSkill])
+    ;(
+      app.vault as unknown as {
+        getMarkdownFiles: () => FakeFile[]
+        getAbstractFileByPath: (path: string) => FakeFile | null
+      }
+    ).getMarkdownFiles = () => []
+    ;(
+      app.vault as unknown as {
+        getAbstractFileByPath: (path: string) => FakeFile | null
+      }
+    ).getAbstractFileByPath = () => null
+
+    const settings = { yolo: { baseDir: '.obsidian/yolo' } }
+
+    const entries = await listLiteSkillEntriesAsync(app, { settings })
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'hidden-skill',
+          description: 'Works from a hidden folder',
+          mode: 'always',
+          path: '.obsidian/yolo/skills/hidden-skill/SKILL.md',
+        }),
+      ]),
+    )
+
+    const document = await getLiteSkillDocument({
+      app,
+      name: 'hidden-skill',
+      settings,
+    })
+    expect(document?.content).toContain('# Hidden Skill')
+    expect(document?.entry.path).toBe(
+      '.obsidian/yolo/skills/hidden-skill/SKILL.md',
+    )
   })
 })
 

--- a/src/core/skills/liteSkills.ts
+++ b/src/core/skills/liteSkills.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from 'obsidian'
+import { App, TFile, normalizePath } from 'obsidian'
 
 import {
   YOLO_SKILLS_INDEX_FILE_NAME,
@@ -32,6 +32,8 @@ export type LiteSkillDocument = {
 }
 
 const CLAUDE_SKILL_FILE_NAME = 'SKILL.md'
+
+type SkillFileLike = Pick<TFile, 'path' | 'name' | 'extension'>
 
 const normalizeSkillMode = (value: unknown): LiteSkillMode => {
   if (typeof value !== 'string') {
@@ -88,11 +90,22 @@ const parseFrontmatterFromContent = (
   return frontmatter
 }
 
+const fileLikeFromPath = (path: string): SkillFileLike => {
+  const normalized = normalizePath(path)
+  const name = normalized.split('/').pop() ?? normalized
+  const dotIndex = name.lastIndexOf('.')
+  return {
+    path: normalized,
+    name,
+    extension: dotIndex === -1 ? '' : name.slice(dotIndex + 1),
+  }
+}
+
 const toLiteSkillEntry = ({
   file,
   frontmatter,
 }: {
-  file: TFile
+  file: SkillFileLike
   frontmatter?: Record<string, unknown> | null
 }): LiteSkillEntry | null => {
   const name = asTrimmedString(frontmatter?.name)
@@ -116,7 +129,7 @@ const isLiteSkillFile = ({
   file,
   skillsDirPrefix,
 }: {
-  file: TFile
+  file: SkillFileLike
   skillsDirPrefix: string
 }): boolean => {
   if (!file.path.startsWith(skillsDirPrefix) || file.extension !== 'md') {
@@ -135,16 +148,67 @@ const isLiteSkillFile = ({
   return file.name === CLAUDE_SKILL_FILE_NAME
 }
 
+const isLiteSkillPath = ({
+  path,
+  skillsDirPrefix,
+}: {
+  path: string
+  skillsDirPrefix: string
+}): boolean =>
+  isLiteSkillFile({ file: fileLikeFromPath(path), skillsDirPrefix })
+
 type SkillSettings = {
   yolo?: {
     baseDir?: string
   }
 }
 
-type SkillRegistryRecord = {
+type VaultSkillRegistryRecord = {
   entry: LiteSkillEntry
-  /** Backing vault file, or `null` for a builtin skill. */
+  source: 'vault-file' | 'adapter-file'
   file: TFile | null
+}
+
+type BuiltinSkillRegistryRecord = {
+  entry: LiteSkillEntry
+  source: 'builtin'
+  file: TFile | null
+}
+
+type SkillRegistryRecord = VaultSkillRegistryRecord | BuiltinSkillRegistryRecord
+
+const getVaultFileFromPath = (app: App, path: string): TFile | null => {
+  const abstractFile = app.vault.getAbstractFileByPath(path)
+  return abstractFile instanceof TFile ? abstractFile : null
+}
+
+const listAdapterMarkdownPaths = async ({
+  app,
+  dir,
+}: {
+  app: App
+  dir: string
+}): Promise<string[]> => {
+  try {
+    if (!(await app.vault.adapter.exists(dir))) {
+      return []
+    }
+
+    const listing = await app.vault.adapter.list(dir)
+    const nested = await Promise.all(
+      listing.folders.map((folder) =>
+        listAdapterMarkdownPaths({ app, dir: folder }),
+      ),
+    )
+
+    return [...listing.files, ...nested.flat()]
+  } catch (error) {
+    console.warn(
+      `[YOLO] Failed to list skills directory ${dir}; skipping.`,
+      error,
+    )
+    return []
+  }
 }
 
 /**
@@ -178,6 +242,7 @@ const buildSkillRegistry = ({
         mode: skill.mode,
         path: skill.path,
       },
+      source: 'builtin',
       file: null,
     })
   })
@@ -199,8 +264,72 @@ const buildSkillRegistry = ({
     if (vaultClaimed.has(entry.name)) {
       continue
     }
-    registry.set(entry.name, { entry, file })
+    registry.set(entry.name, { entry, source: 'vault-file', file })
     vaultClaimed.add(entry.name)
+  }
+
+  return registry
+}
+
+const buildSkillRegistryAsync = async ({
+  app,
+  settings,
+}: {
+  app: App
+  settings?: SkillSettings
+}): Promise<Map<string, SkillRegistryRecord>> => {
+  const registry = new Map<string, SkillRegistryRecord>()
+
+  listBuiltinLiteSkills({
+    skillsDir: getYoloSkillsDir(settings),
+    snippetsPath: getYoloSnippetsPath(settings),
+  }).forEach((skill) => {
+    registry.set(skill.name, {
+      entry: {
+        name: skill.name,
+        description: skill.description,
+        mode: skill.mode,
+        path: skill.path,
+      },
+      source: 'builtin',
+      file: null,
+    })
+  })
+
+  const skillsDir = getYoloSkillsDir(settings)
+  const skillsDirPrefix = getYoloSkillsDirPrefix(settings)
+  const paths = (await listAdapterMarkdownPaths({ app, dir: skillsDir }))
+    .filter((path) => isLiteSkillPath({ path, skillsDirPrefix }))
+    .sort((a, b) => a.localeCompare(b))
+
+  const vaultClaimed = new Set<string>()
+  for (const path of paths) {
+    try {
+      const file = getVaultFileFromPath(app, path)
+      const frontmatter =
+        file !== null
+          ? app.metadataCache.getFileCache(file)?.frontmatter
+          : parseFrontmatterFromContent(await app.vault.adapter.read(path))
+      const entry = toLiteSkillEntry({
+        file: file ?? fileLikeFromPath(path),
+        frontmatter: frontmatter ?? null,
+      })
+      if (!entry || vaultClaimed.has(entry.name)) {
+        continue
+      }
+
+      registry.set(entry.name, {
+        entry,
+        source: file ? 'vault-file' : 'adapter-file',
+        file,
+      })
+      vaultClaimed.add(entry.name)
+    } catch (error) {
+      console.warn(
+        `[YOLO] Failed to read skill metadata for ${path}; skipping.`,
+        error,
+      )
+    }
   }
 
   return registry
@@ -213,6 +342,24 @@ export function listLiteSkillEntries(
   },
 ): LiteSkillEntry[] {
   return [...buildSkillRegistry({ app, settings: options?.settings }).values()]
+    .map((record) => record.entry)
+    .sort((a, b) => a.path.localeCompare(b.path))
+}
+
+export async function listLiteSkillEntriesAsync(
+  app: App,
+  options?: {
+    settings?: SkillSettings
+  },
+): Promise<LiteSkillEntry[]> {
+  return [
+    ...(
+      await buildSkillRegistryAsync({
+        app,
+        settings: options?.settings,
+      })
+    ).values(),
+  ]
     .map((record) => record.entry)
     .sort((a, b) => a.path.localeCompare(b.path))
 }
@@ -233,23 +380,25 @@ export async function getLiteSkillDocument({
 
   // Resolve through the SAME registry as `list`, so a name displayed in the UI
   // opens exactly the file/builtin that was displayed.
-  const record = buildSkillRegistry({ app, settings }).get(target)
+  const record = (await buildSkillRegistryAsync({ app, settings })).get(target)
   if (!record) {
     return null
   }
 
-  if (record.file) {
-    const content = await app.vault.cachedRead(record.file)
-    const metadataFrontmatter = app.metadataCache.getFileCache(
-      record.file,
-    )?.frontmatter
+  if (record.source !== 'builtin') {
+    const content = record.file
+      ? await app.vault.cachedRead(record.file)
+      : await app.vault.adapter.read(record.entry.path)
+    const metadataFrontmatter = record.file
+      ? app.metadataCache.getFileCache(record.file)?.frontmatter
+      : null
     const parsedFrontmatter = parseFrontmatterFromContent(content)
     const mergedFrontmatter = {
       ...(metadataFrontmatter ?? {}),
       ...(parsedFrontmatter ?? {}),
     }
     const entry = toLiteSkillEntry({
-      file: record.file,
+      file: record.file ?? fileLikeFromPath(record.entry.path),
       frontmatter: mergedFrontmatter,
     })
     if (!entry) {

--- a/src/utils/chat/requestContextBuilder.ts
+++ b/src/utils/chat/requestContextBuilder.ts
@@ -18,7 +18,7 @@ import {
 import { getProjectInstructionsSection } from '../../core/project-instructions'
 import {
   getLiteSkillDocument,
-  listLiteSkillEntries,
+  listLiteSkillEntriesAsync,
 } from '../../core/skills/liteSkills'
 import {
   isSkillEnabledForAssistant,
@@ -1705,14 +1705,17 @@ ${memoryParts.join('\n\n')}
     if (this.includeSkills) {
       const disabledSkillNames = this.settings.skills?.disabledSkillIds ?? []
       const enabledSkillEntries = currentAssistant
-        ? listLiteSkillEntries(this.app, { settings: this.settings }).filter(
-            (skill) =>
-              isSkillEnabledForAssistant({
-                assistant: currentAssistant,
-                skillName: skill.name,
-                disabledSkillNames,
-                defaultLoadMode: skill.mode,
-              }),
+        ? (
+            await listLiteSkillEntriesAsync(this.app, {
+              settings: this.settings,
+            })
+          ).filter((skill) =>
+            isSkillEnabledForAssistant({
+              assistant: currentAssistant,
+              skillName: skill.name,
+              disabledSkillNames,
+              defaultLoadMode: skill.mode,
+            }),
           )
         : []
 


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要

- 允许 skill 发现逻辑通过 vault adapter 扫描配置的 `YOLO 根目录/skills`，覆盖 `.obsidian/...` 等不会进入 Obsidian markdown 索引的隐藏目录。
- 将运行时可用 skill 列表、`open_skill`、聊天输入 `/` skill 候选、Quick Ask 和 Agent 设置里的 skill 列表切到异步发现结果。
- 保留 adapter 扫描失败时的内置 skill 可用性，避免隐藏目录或权限问题导致整个 skill registry 失效。
- 增加隐藏目录 skill 的列表和打开测试。

## Codex 分析要点

#384 的根因不是路径规范化，而是现有 skill 发现依赖 `app.vault.getMarkdownFiles()`；隐藏目录下的 markdown 可能不在 Obsidian vault 文件索引里，因此设置为 `.obsidian/...` 后无法被枚举。使用 adapter 直接读取配置目录可以解决这个发现层缺口，同时不改变用户配置格式。

## 校验清单

- `npm run type:check`
- `npm test -- src/core/skills/liteSkills.test.ts`
- `npm run prettier:check -- src/core/skills/liteSkills.ts src/core/skills/liteSkills.test.ts src/components/chat-view/chat-input/ChatUserInput.tsx src/components/chat-view/useChatStreamManager.ts src/components/panels/quick-ask/QuickAskPanel.tsx src/components/settings/modals/AgentSkillsModal.tsx src/components/settings/sections/AgentSection.tsx src/components/settings/sections/AgentsSectionContent.tsx src/utils/chat/requestContextBuilder.ts`

## 关联

- Closes https://github.com/Lapis0x0/obsidian-yolo/issues/384
