### PR TITLE
[auto-triage] 修复会话内记忆更新不生效 (#386)

### DIFF
--- a/src/core/memory/memoryManager.ts
+++ b/src/core/memory/memoryManager.ts
@@ -640,6 +640,64 @@ export const resolveMemoryFilePaths = ({
   }
 }
 
+const getMemoryFileSignature = ({
+  app,
+  path,
+}: {
+  app: App
+  path: string | null
+}): {
+  path: string | null
+  exists: boolean
+  mtime: number | null
+  size: number | null
+} => {
+  if (!path) {
+    return {
+      path: null,
+      exists: false,
+      mtime: null,
+      size: null,
+    }
+  }
+
+  const existing = app.vault.getAbstractFileByPath(path)
+  if (!(existing instanceof TFile)) {
+    return {
+      path,
+      exists: false,
+      mtime: null,
+      size: null,
+    }
+  }
+
+  return {
+    path,
+    exists: true,
+    mtime: existing.stat.mtime,
+    size: existing.stat.size,
+  }
+}
+
+export const resolveMemoryFileSignatures = ({
+  app,
+  settings,
+  assistantId,
+}: {
+  app: App
+  settings?: MemorySettingsLike
+  assistantId?: string
+}): {
+  global: ReturnType<typeof getMemoryFileSignature>
+  assistant: ReturnType<typeof getMemoryFileSignature>
+} => {
+  const paths = resolveMemoryFilePaths({ settings, assistantId })
+  return {
+    global: getMemoryFileSignature({ app, path: paths.global }),
+    assistant: getMemoryFileSignature({ app, path: paths.assistant }),
+  }
+}
+
 export async function memoryAdd({
   app,
   settings,

--- a/src/utils/chat/requestContextBuilder.test.ts
+++ b/src/utils/chat/requestContextBuilder.test.ts
@@ -6,9 +6,19 @@ jest.mock('../../database/json/chat/promptSnapshotStore', () => ({
 
 jest.mock('../../core/memory/memoryManager', () => ({
   getMemoryPromptContext: jest.fn(async () => ''),
-  resolveMemoryFilePaths: jest.fn(() => ({
-    global: 'YOLO/memory/global.md',
-    assistant: null,
+  resolveMemoryFileSignatures: jest.fn(() => ({
+    global: {
+      path: 'YOLO/memory/global.md',
+      exists: false,
+      mtime: null,
+      size: null,
+    },
+    assistant: {
+      path: null,
+      exists: false,
+      mtime: null,
+      size: null,
+    },
   })),
 }))
 
@@ -18,7 +28,10 @@ jest.mock('../llm/image', () => ({
 }))
 
 import { SystemPromptSnapshotStore } from '../../core/agent/systemPromptSnapshotStore'
-import { getMemoryPromptContext } from '../../core/memory/memoryManager'
+import {
+  getMemoryPromptContext,
+  resolveMemoryFileSignatures,
+} from '../../core/memory/memoryManager'
 import type { YoloSettings } from '../../settings/schema/setting.types'
 import type { ChatUserMessage } from '../../types/chat'
 import type { ChatModel } from '../../types/chat-model.types'
@@ -1777,6 +1790,24 @@ describe('RequestContextBuilder system prompt freezing', () => {
   ]
 
   const memMock = jest.mocked(getMemoryPromptContext)
+  const memorySignaturesMock = jest.mocked(resolveMemoryFileSignatures)
+
+  const mockDefaultMemorySignatures = () => {
+    memorySignaturesMock.mockReturnValue({
+      global: {
+        path: 'YOLO/memory/global.md',
+        exists: false,
+        mtime: null,
+        size: null,
+      },
+      assistant: {
+        path: null,
+        exists: false,
+        mtime: null,
+        size: null,
+      },
+    })
+  }
 
   const makeApp = () =>
     createMockApp({ files: [], fileContents: new Map() }) as never
@@ -1791,9 +1822,14 @@ describe('RequestContextBuilder system prompt freezing', () => {
 
   afterAll(() => {
     memMock.mockResolvedValue({ global: null, assistant: null })
+    mockDefaultMemorySignatures()
   })
 
-  it('freezes memory in the system prompt for the conversation lifetime (create mode)', async () => {
+  beforeEach(() => {
+    mockDefaultMemorySignatures()
+  })
+
+  it('refreshes memory in the system prompt when memory files change mid-conversation', async () => {
     const store = new SystemPromptSnapshotStore()
     const builder = new RequestContextBuilder(makeApp(), baseSettings, {
       includeSkills: false,
@@ -1801,6 +1837,20 @@ describe('RequestContextBuilder system prompt freezing', () => {
     })
 
     memMock.mockResolvedValue({ global: 'MEM_V1', assistant: null })
+    memorySignaturesMock.mockReturnValue({
+      global: {
+        path: 'YOLO/memory/global.md',
+        exists: true,
+        mtime: 100,
+        size: 6,
+      },
+      assistant: {
+        path: null,
+        exists: false,
+        mtime: null,
+        size: null,
+      },
+    })
     memMock.mockClear()
 
     const first = await builder.generateRequestMessages({
@@ -1814,6 +1864,20 @@ describe('RequestContextBuilder system prompt freezing', () => {
 
     // Memory is rewritten mid-conversation (e.g. a memory_add tool call).
     memMock.mockResolvedValue({ global: 'MEM_V2', assistant: null })
+    memorySignaturesMock.mockReturnValue({
+      global: {
+        path: 'YOLO/memory/global.md',
+        exists: true,
+        mtime: 200,
+        size: 6,
+      },
+      assistant: {
+        path: null,
+        exists: false,
+        mtime: null,
+        size: null,
+      },
+    })
 
     const second = await builder.generateRequestMessages({
       messages: userMessages,
@@ -1822,20 +1886,9 @@ describe('RequestContextBuilder system prompt freezing', () => {
       hasMemoryTools: true,
       systemPromptSnapshotMode: 'create',
     })
-    // Frozen: still V1, and memory was not re-read for the second iteration.
-    expect(getSystemContent(second)).toContain('MEM_V1')
-    expect(getSystemContent(second)).not.toContain('MEM_V2')
-    expect(memMock).toHaveBeenCalledTimes(1)
-
-    // A fresh conversation picks up the latest memory.
-    const other = await builder.generateRequestMessages({
-      messages: userMessages,
-      model,
-      conversationId: 'conv-2',
-      hasMemoryTools: true,
-      systemPromptSnapshotMode: 'create',
-    })
-    expect(getSystemContent(other)).toContain('MEM_V2')
+    expect(getSystemContent(second)).toContain('MEM_V2')
+    expect(getSystemContent(second)).not.toContain('MEM_V1')
+    expect(memMock).toHaveBeenCalledTimes(2)
   })
 
   it('refreshes the snapshot when a prompt-relevant setting changes', async () => {

--- a/src/utils/chat/requestContextBuilder.ts
+++ b/src/utils/chat/requestContextBuilder.ts
@@ -13,7 +13,7 @@ import type {
 } from '../../core/agent/systemPromptSnapshotStore'
 import {
   getMemoryPromptContext,
-  resolveMemoryFilePaths,
+  resolveMemoryFileSignatures,
 } from '../../core/memory/memoryManager'
 import { getProjectInstructionsSection } from '../../core/project-instructions'
 import {
@@ -1566,23 +1566,23 @@ ${entries}
   }
 
   /**
-   * Stable fingerprint of every *configuration-level* input that legitimately
-   * changes the system prompt text. A change here refreshes the frozen
-   * snapshot; everything NOT listed (memory file content, project-instruction
-   * and skill file content, time variables) is intentionally frozen until the
-   * next conversation. Settings that never reach the system prompt (reasoning
-   * level, chat mode, …) are excluded so they don't evict the snapshot.
+   * Stable fingerprint of every input that legitimately changes the system
+   * prompt text. A change here refreshes the frozen snapshot; everything NOT
+   * listed (project-instruction and skill file content, time variables) is
+   * intentionally frozen until the next conversation. Settings that never reach
+   * the system prompt (reasoning level, chat mode, …) are excluded so they
+   * don't evict the snapshot.
    */
   private computeSystemPromptFingerprint(
     hasTools: boolean,
     hasMemoryTools: boolean,
   ): string {
     const assistant = this.getCurrentAssistant()
-    // The exact memory files this request will read. Captures baseDir, the
-    // assistant name, AND the sibling-driven duplicate index — so a same-named
-    // assistant being added/renamed (which changes which file we read) refreshes
-    // the snapshot even though the current assistant's own fields are unchanged.
-    const memoryPaths = resolveMemoryFilePaths({
+    // The exact memory files this request will read plus their current vault
+    // stats. Captures path changes and memory writes so same-conversation turns
+    // see memories added / updated by earlier tool calls.
+    const memoryFiles = resolveMemoryFileSignatures({
+      app: this.app,
       settings: this.settings,
       assistantId: this.settings.currentAssistantId,
     })
@@ -1598,7 +1598,7 @@ ${entries}
         .map((id) => id.trim())
         .sort(),
       currentAssistantId: this.settings.currentAssistantId ?? '',
-      memoryPaths,
+      memoryFiles,
       // Only assistant fields that reach the system prompt — not modelId / icon /
       // updatedAt, which would over-evict on unrelated edits. `enabledSkills` is
       // legacy and not consulted by skill filtering, so it is intentionally out.


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->
Codex 自动 triage PR，关联 #386。

## 改动摘要
- 在记忆模块新增当前会读取的记忆文件签名：路径、是否存在、mtime、size。
- 将记忆文件签名纳入 system prompt snapshot fingerprint。
- 更新 request context 测试：同一 conversationId 中，记忆文件被工具写入后，下一轮请求会重新读取最新记忆。

## Codex 分析要点
- 问题根因是 `SystemPromptSnapshotStore` 按 conversationId 缓存完整 system prompt，而原 fingerprint 只包含设置级输入和记忆路径，不包含记忆文件变化。
- 记忆工具写入 global / assistant memory 后，后续同会话请求仍命中旧 snapshot，因此表现为“会话开启后记忆冻结”。
- 本修复保留 snapshot 机制，但让真正会影响记忆上下文的文件写入刷新 snapshot；项目指令、技能文件内容和时间变量仍按原策略冻结，避免扩大行为面。

## 校验
- [x] `npm test -- --runTestsByPath src/utils/chat/requestContextBuilder.test.ts src/core/memory/memoryManager.test.ts`
- [x] `npm run type:check`
- [x] `git diff --check`

## 关联
- Fixes https://github.com/Lapis0x0/obsidian-yolo/issues/386
