### PR TITLE
[auto-triage] 压缩后刷新 system prompt (#386)

### DIFF
--- a/src/utils/chat/requestContextBuilder.test.ts
+++ b/src/utils/chat/requestContextBuilder.test.ts
@@ -1838,6 +1838,56 @@ describe('RequestContextBuilder system prompt freezing', () => {
     expect(getSystemContent(other)).toContain('MEM_V2')
   })
 
+  it('refreshes memory in the system prompt after conversation compaction', async () => {
+    const store = new SystemPromptSnapshotStore()
+    const builder = new RequestContextBuilder(makeApp(), baseSettings, {
+      includeSkills: false,
+      systemPromptSnapshotStore: store,
+    })
+
+    memMock.mockResolvedValue({ global: 'MEM_BEFORE_COMPACT', assistant: null })
+    memMock.mockClear()
+
+    const beforeCompact = await builder.generateRequestMessages({
+      messages: userMessages,
+      model,
+      conversationId: 'conv-1',
+      hasMemoryTools: true,
+      systemPromptSnapshotMode: 'create',
+    })
+    expect(getSystemContent(beforeCompact)).toContain('MEM_BEFORE_COMPACT')
+
+    memMock.mockResolvedValue({ global: 'MEM_AFTER_COMPACT', assistant: null })
+
+    const afterMemoryWrite = await builder.generateRequestMessages({
+      messages: userMessages,
+      model,
+      conversationId: 'conv-1',
+      hasMemoryTools: true,
+      systemPromptSnapshotMode: 'create',
+    })
+    expect(getSystemContent(afterMemoryWrite)).toContain('MEM_BEFORE_COMPACT')
+    expect(getSystemContent(afterMemoryWrite)).not.toContain(
+      'MEM_AFTER_COMPACT',
+    )
+
+    const afterCompact = await builder.generateRequestMessages({
+      messages: userMessages,
+      model,
+      conversationId: 'conv-1',
+      hasMemoryTools: true,
+      compaction: {
+        anchorMessageId: 'tool-compact',
+        summary: 'Earlier context summary',
+        compactedAt: 1,
+        triggerToolCallId: 'compact-1',
+      },
+      systemPromptSnapshotMode: 'create',
+    })
+    expect(getSystemContent(afterCompact)).toContain('MEM_AFTER_COMPACT')
+    expect(memMock).toHaveBeenCalledTimes(2)
+  })
+
   it('refreshes the snapshot when a prompt-relevant setting changes', async () => {
     const store = new SystemPromptSnapshotStore()
     memMock.mockResolvedValue({ global: 'MEM', assistant: null })

--- a/src/utils/chat/requestContextBuilder.ts
+++ b/src/utils/chat/requestContextBuilder.ts
@@ -639,6 +639,7 @@ export class RequestContextBuilder {
           conversationId,
           hasTools,
           hasMemoryTools,
+          compaction,
           mode: systemPromptSnapshotMode,
         })
     const systemMessage: RequestMessage = {
@@ -1530,11 +1531,13 @@ ${entries}
     conversationId,
     hasTools,
     hasMemoryTools,
+    compaction,
     mode,
   }: {
     conversationId: string
     hasTools: boolean
     hasMemoryTools: boolean
+    compaction?: ChatConversationCompactionLike | null
     mode: SystemPromptSnapshotMode
   }): Promise<SystemPromptSnapshot> {
     const build = async (): Promise<SystemPromptSnapshot> => {
@@ -1559,6 +1562,7 @@ ${entries}
     const fingerprint = this.computeSystemPromptFingerprint(
       hasTools,
       hasMemoryTools,
+      compaction,
     )
     return store.getOrCreate(conversationId, fingerprint, build, {
       reuseOnly: mode === 'reuse',
@@ -1576,8 +1580,10 @@ ${entries}
   private computeSystemPromptFingerprint(
     hasTools: boolean,
     hasMemoryTools: boolean,
+    compaction?: ChatConversationCompactionLike | null,
   ): string {
     const assistant = this.getCurrentAssistant()
+    const latestCompaction = getLatestChatConversationCompaction(compaction)
     // The exact memory files this request will read. Captures baseDir, the
     // assistant name, AND the sibling-driven duplicate index — so a same-named
     // assistant being added/renamed (which changes which file we read) refreshes
@@ -1599,6 +1605,17 @@ ${entries}
         .sort(),
       currentAssistantId: this.settings.currentAssistantId ?? '',
       memoryPaths,
+      // A context compaction restarts the conversation from a compressed
+      // boundary. Refresh the frozen system prompt after that boundary so
+      // memory written before compaction is visible again, without refreshing
+      // on every memory-file write during the same uncompressed context.
+      latestCompaction: latestCompaction
+        ? {
+            anchorMessageId: latestCompaction.anchorMessageId,
+            triggerToolCallId: latestCompaction.triggerToolCallId ?? null,
+            compactedAt: latestCompaction.compactedAt,
+          }
+        : null,
       // Only assistant fields that reach the system prompt — not modelId / icon /
       // updatedAt, which would over-evict on unrelated edits. `enabledSkills` is
       // legacy and not consulted by skill filtering, so it is intentionally out.


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->
Codex 自动 triage PR，关联 #386。

## 改动摘要
- 将最新 context compaction 的稳定身份纳入 system prompt snapshot fingerprint。
- 保留同一未压缩上下文内的 memory/system prompt 冻结策略，避免每次记忆文件写入都刷新前缀缓存。
- 增加回归测试：记忆写入后同会话仍冻结，但 compaction 状态进入请求后会重新读取 memory 并刷新 system prompt。

## Codex 分析要点
- owner 最新指令明确收窄了 #386：当前对话内记忆不刷新可以接受，因为模型仍可能通过工具结果知道自己刚修改了记忆。
- 压缩后模型可能丢失压缩前工具调用细节，因此需要在压缩边界之后重建 system prompt，让压缩前写入的 memory 重新进入系统提示。
- 使用 `anchorMessageId / triggerToolCallId / compactedAt` 作为 fingerprint 输入，可以覆盖手动压缩、自动阈值压缩和 `context_compact` 工具触发压缩，同时不把 summary 文本或 memory 文件内容纳入 fingerprint。

## 校验
- [x] `npm test -- --runTestsByPath src/utils/chat/requestContextBuilder.test.ts`
- [x] `npm run type:check`
- [x] `git diff --check`

## 关联
- Fixes https://github.com/Lapis0x0/obsidian-yolo/issues/386
