### PR TITLE
[auto-triage] Stop forwarding internal reasoningLevel to OpenAI-compatible vendors (#389)

### DIFF
--- a/src/core/llm/openaiMessageAdapter.test.ts
+++ b/src/core/llm/openaiMessageAdapter.test.ts
@@ -105,6 +105,30 @@ describe('OpenAIMessageAdapter', () => {
     ])
   })
 
+  it('does not forward internal reasoningLevel as a vendor extension', () => {
+    const params = adapter.buildParams({
+      model: 'gpt-5.4-mini',
+      stream: true,
+      reasoningLevel: 'off',
+      reasoning: {
+        effort: 'none',
+        exclude: true,
+      },
+      messages: [
+        {
+          role: 'user',
+          content: 'hello',
+        },
+      ],
+    }) as unknown as Record<string, unknown>
+
+    expect(params.reasoning).toEqual({
+      effort: 'none',
+      exclude: true,
+    })
+    expect(params.reasoningLevel).toBeUndefined()
+  })
+
   it('translates document content parts into OpenAI file content (OpenRouter-style PDF passthrough)', () => {
     const params = adapter.buildParams({
       model: 'gemini-2.5-flash',

--- a/src/core/llm/openaiMessageAdapter.ts
+++ b/src/core/llm/openaiMessageAdapter.ts
@@ -109,6 +109,7 @@ const RESERVED_REQUEST_KEYS = new Set([
   'tools',
   'tool_choice',
   'reasoning_effort',
+  'reasoningLevel',
   'web_search_options',
   'messages',
   'max_tokens',


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要

- 将内部请求字段 `reasoningLevel` 加入 OpenAI Chat Completions adapter 的保留字段列表，避免它被 `attachVendorExtensions` 当作 vendor extension 透传给上游。
- 新增回归测试，确认已翻译出的 `reasoning` 参数会保留，但内部 `reasoningLevel` 不会出现在最终请求参数中。

## Codex 分析要点

#389 的示例请求里同时出现了 adapter 翻译后的 `reasoning: { effort: "none", exclude: true }` 和 YOLO 内部字段 `reasoningLevel: "off"`。代码路径显示 OpenAI-compatible provider 会先根据 `reasoningLevel` 生成 provider 参数，随后 `OpenAIMessageAdapter.attachVendorExtensions` 会把不在保留列表中的请求字段补回最终 payload，因此 `reasoningLevel` 会被错误地透传。

这次 PR 只处理这个无歧义的小修。issue 中关于 Tab 补全是否应剥离模型级 hosted tools / web search / custom parameters，以及 auxiliary 请求是否应保留 `reasoningType` 以发送“关闭 reasoning”的 provider 参数，会影响内部辅助请求策略，建议由 maintainer 确认后再做后续改动。

## 校验

- [x] `npm test -- --runTestsByPath src/core/llm/openaiMessageAdapter.test.ts`
- [x] `npm run type:check`

## 关联

- 原 issue: https://github.com/Lapis0x0/obsidian-yolo/issues/389