### PR TITLE
更新 DeepSeek V4 能力与接口配置

### DIFF
--- a/scripts/smoke-test-stub-tools.mjs
+++ b/scripts/smoke-test-stub-tools.mjs
@@ -63,7 +63,7 @@ const USER_PROMPT =
 async function testAnthropic() {
   const p = findProvider('DeepSeek')
   if (!p) return { skipped: 'DeepSeek provider missing' }
-  const model = 'deepseek-chat'
+  const model = 'deepseek-v4-flash'
   const url = `${norm(p.baseUrl)}/v1/messages`
   const body = {
     model,

--- a/scripts/smoke-test-stub-tools.mjs
+++ b/scripts/smoke-test-stub-tools.mjs
@@ -17,6 +17,22 @@ const target = process.argv[2] ?? 'all'
 
 const findProvider = (id) => data.providers.find((p) => p.id === id)
 const norm = (s) => (s ?? '').replace(/\/$/, '')
+const deepSeekAnthropicBaseUrl = (baseUrl) => {
+  const normalized = norm(baseUrl || 'https://api.deepseek.com').replace(
+    /\/v1$/,
+    '',
+  )
+  try {
+    const url = new URL(normalized)
+    const path = url.pathname.replace(/\/$/, '')
+    if (url.hostname === 'api.deepseek.com' && path === '') {
+      return `${normalized}/anthropic`
+    }
+  } catch {
+    return normalized
+  }
+  return normalized
+}
 
 const STUB_OPEN = {
   type: 'object',
@@ -64,7 +80,7 @@ async function testAnthropic() {
   const p = findProvider('DeepSeek')
   if (!p) return { skipped: 'DeepSeek provider missing' }
   const model = 'deepseek-v4-flash'
-  const url = `${norm(p.baseUrl)}/v1/messages`
+  const url = `${deepSeekAnthropicBaseUrl(p.baseUrl)}/v1/messages`
   const body = {
     model,
     max_tokens: 512,

--- a/src/components/chat-view/chat-input/LexicalContentEditable.tsx
+++ b/src/components/chat-view/chat-input/LexicalContentEditable.tsx
@@ -29,7 +29,6 @@ import {
 import ObsidianFileDropPlugin from './plugins/drop/ObsidianFileDropPlugin'
 import DragDropPaste from './plugins/image/DragDropPastePlugin'
 import ImagePastePlugin from './plugins/image/ImagePastePlugin'
-import PlainTextPastePlugin from './plugins/paste/PlainTextPastePlugin'
 import AutoLinkMentionPlugin from './plugins/mention/AutoLinkMentionPlugin'
 import { MentionNode } from './plugins/mention/MentionNode'
 import MentionPlugin from './plugins/mention/MentionPlugin'
@@ -43,6 +42,7 @@ import OnEnterPlugin from './plugins/on-enter/OnEnterPlugin'
 import OnMutationPlugin, {
   NodeMutations,
 } from './plugins/on-mutation/OnMutationPlugin'
+import PlainTextPastePlugin from './plugins/paste/PlainTextPastePlugin'
 // templates feature removed
 
 export type LexicalContentEditableProps = {

--- a/src/components/chat-view/tool-cards/subagentResultAdapter.ts
+++ b/src/components/chat-view/tool-cards/subagentResultAdapter.ts
@@ -1,6 +1,9 @@
 import { getLocalFileToolServerName } from '../../../core/mcp/localFileTools'
 import { getToolName } from '../../../core/mcp/tool-name-utils'
-import type { ChatSubagentResultMessage, ChatToolMessage } from '../../../types/chat'
+import type {
+  ChatSubagentResultMessage,
+  ChatToolMessage,
+} from '../../../types/chat'
 import {
   type ToolCallRequest,
   type ToolCallResponse,
@@ -22,7 +25,9 @@ export function buildSynthToolMessageFromSubagentResult(
   }
 }
 
-function buildSynthRequest(message: ChatSubagentResultMessage): ToolCallRequest {
+function buildSynthRequest(
+  message: ChatSubagentResultMessage,
+): ToolCallRequest {
   return {
     id: `result-${message.taskId}`,
     name: getToolName(getLocalFileToolServerName(), 'delegate_subagent'),
@@ -36,7 +41,9 @@ function buildSynthRequest(message: ChatSubagentResultMessage): ToolCallRequest 
   }
 }
 
-function buildSynthResponse(message: ChatSubagentResultMessage): ToolCallResponse {
+function buildSynthResponse(
+  message: ChatSubagentResultMessage,
+): ToolCallResponse {
   const text = message.content || message.status
 
   switch (message.status) {

--- a/src/components/settings/modals/AgentToolsModal.tsx
+++ b/src/components/settings/modals/AgentToolsModal.tsx
@@ -7,6 +7,7 @@ import {
   SettingsProvider,
   useSettings,
 } from '../../../contexts/settings-context'
+import { DEFAULT_BLOCKED_PREFIXES } from '../../../core/agent/bash/command-classifier'
 import {
   BUILTIN_TOOL_CATEGORY_I18N,
   BUILTIN_TOOL_CATEGORY_ORDER,
@@ -19,7 +20,6 @@ import {
   getBuiltinToolDisplayIndex,
   getBuiltinToolUiMeta,
 } from '../../../core/agent/builtinToolUiMeta'
-import { DEFAULT_BLOCKED_PREFIXES } from '../../../core/agent/bash/command-classifier'
 import { JS_SANDBOX_TOOL_NAME } from '../../../core/mcp/jsSandboxTool'
 import {
   LOCAL_FS_SPLIT_ACTION_TOOL_NAMES,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -639,15 +639,17 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   },
   {
     providerId: PROVIDER_PRESET_INFO.deepseek.defaultProviderId,
-    id: 'deepseek/deepseek-chat',
-    model: 'deepseek-chat',
+    id: 'deepseek/deepseek-v4-flash',
+    model: 'deepseek-v4-flash',
     enable: false,
+    reasoningType: 'openai',
   },
   {
     providerId: PROVIDER_PRESET_INFO.deepseek.defaultProviderId,
-    id: 'deepseek/deepseek-reasoner',
-    model: 'deepseek-reasoner',
+    id: 'deepseek/deepseek-v4-pro',
+    model: 'deepseek-v4-pro',
     enable: false,
+    reasoningType: 'openai',
   },
   {
     providerId: PROVIDER_PRESET_INFO.xiaomimimo.defaultProviderId,

--- a/src/core/agent/service.ts
+++ b/src/core/agent/service.ts
@@ -23,14 +23,14 @@ import { DEFAULT_BRANCH_ID } from './branch'
 import { CitationRegistry } from './citationRegistry'
 import type { AsyncTaskRecord } from './external-cli/async-task-registry'
 import type { ExternalCliEvent } from './external-cli/streamBus'
+import { NativeAgentRuntime } from './native-runtime'
+import { PromptSourceWatcher } from './promptSourceWatcher'
 import {
-  buildSubagentParentContext,
   type SubagentParentContext,
+  buildSubagentParentContext,
 } from './subagent/parent-context'
 import { subagentStreamBus } from './subagent/stream-bus'
 import type { SubagentTaskRecord } from './subagent/types'
-import { NativeAgentRuntime } from './native-runtime'
-import { PromptSourceWatcher } from './promptSourceWatcher'
 import { SystemPromptSnapshotStore } from './systemPromptSnapshotStore'
 import {
   AgentRunContext,
@@ -148,7 +148,9 @@ function buildSubagentResultMessage(
     taskId: record.taskId,
     source: record.source,
     title: record.title,
-    status: result?.status ?? (record.status === 'running' ? 'completed' : record.status),
+    status:
+      result?.status ??
+      (record.status === 'running' ? 'completed' : record.status),
     content: result?.content ?? record.error ?? '',
     durationMs: result?.durationMs ?? completedAt - record.createdAt,
     toolUseCount: result?.toolUseCount ?? 0,
@@ -1041,8 +1043,10 @@ export class AgentService {
   getPendingApprovalSubagentParentContext(
     conversationId: string,
   ): SubagentParentContext | undefined {
-    const recovery = this.getOrCreateConversationEntry(conversationId)
-      .pendingApprovalRecoveryContext
+    const recovery =
+      this.getOrCreateConversationEntry(
+        conversationId,
+      ).pendingApprovalRecoveryContext
     if (!recovery) {
       return undefined
     }
@@ -1075,8 +1079,7 @@ export class AgentService {
     const recoveryContext = conversationEntry.pendingApprovalRecoveryContext
     const activeRunInput = located.runEntry?.lastRunInput ?? null
     const activeLoopConfig = located.runEntry?.lastLoopConfig ?? null
-    const lastRunInput =
-      activeRunInput ?? recoveryContext?.lastRunInput ?? null
+    const lastRunInput = activeRunInput ?? recoveryContext?.lastRunInput ?? null
     const lastLoopConfig =
       activeLoopConfig ?? recoveryContext?.lastLoopConfig ?? null
     const lastRunContext =
@@ -1157,9 +1160,7 @@ export class AgentService {
       return false
     }
 
-    if (
-      isTrailingResolvedToolMessage(nextMessages, toolMessage.id)
-    ) {
+    if (isTrailingResolvedToolMessage(nextMessages, toolMessage.id)) {
       await this.run({
         conversationId,
         loopConfig: lastLoopConfig,
@@ -2062,10 +2063,7 @@ export class AgentService {
         messages: updatedMessages,
         status: status ?? conversationEntry.state.status,
       }
-      this.syncPendingApprovalRecoveryContext(
-        conversationId,
-        updatedMessages,
-      )
+      this.syncPendingApprovalRecoveryContext(conversationId, updatedMessages)
     }
 
     this.recomputeConversationState(conversationId)

--- a/src/core/agent/subagent/delegate-subagent-tool.test.ts
+++ b/src/core/agent/subagent/delegate-subagent-tool.test.ts
@@ -5,7 +5,9 @@ import { DELEGATE_SUBAGENT_TOOL_SHORT_NAME } from './constants'
 describe('delegate_subagent tool registration', () => {
   it('registers description and prompt only in the input schema', () => {
     const tools = getLocalFileTools({ vaultBasePath: '/vault' })
-    const tool = tools.find((entry) => entry.name === DELEGATE_SUBAGENT_TOOL_SHORT_NAME)
+    const tool = tools.find(
+      (entry) => entry.name === DELEGATE_SUBAGENT_TOOL_SHORT_NAME,
+    )
     expect(tool).toBeDefined()
     expect(tool?.inputSchema).toMatchObject({
       type: 'object',

--- a/src/core/agent/subagent/parent-context.ts
+++ b/src/core/agent/subagent/parent-context.ts
@@ -3,7 +3,10 @@ import type {
   AssistantWorkspaceScope,
 } from '../../../types/assistant.types'
 import type { ChatModel } from '../../../types/chat-model.types'
-import type { LLMProvider, LLMProviderApiType } from '../../../types/provider.types'
+import type {
+  LLMProvider,
+  LLMProviderApiType,
+} from '../../../types/provider.types'
 import type { ReasoningLevel } from '../../../types/reasoning'
 import type { RequestContextBuilder } from '../../../utils/chat/requestContextBuilder'
 import type { BaseLLMProvider } from '../../llm/base'

--- a/src/core/agent/subagent/runner.ts
+++ b/src/core/agent/subagent/runner.ts
@@ -39,7 +39,8 @@ function countToolUses(messages: ChatMessage[]): number {
     return (
       count +
       message.toolCalls.filter(
-        (toolCall) => toolCall.response.status === ToolCallResponseStatus.Success,
+        (toolCall) =>
+          toolCall.response.status === ToolCallResponseStatus.Success,
       ).length
     )
   }, 0)
@@ -214,8 +215,7 @@ export async function runSubagent(
     taskId,
     title,
     status: 'running',
-    note:
-      'Subagent started asynchronously. The result will arrive as a follow-up background event when the child run completes.',
+    note: 'Subagent started asynchronously. The result will arrive as a follow-up background event when the child run completes.',
   }
 }
 

--- a/src/core/agent/subagent/tool-filter.ts
+++ b/src/core/agent/subagent/tool-filter.ts
@@ -13,7 +13,9 @@ export function filterAllowedToolsForSubagent(
     return []
   }
 
-  const filtered = parentAllowedToolNames.filter((name) => !blockedSet.has(name))
+  const filtered = parentAllowedToolNames.filter(
+    (name) => !blockedSet.has(name),
+  )
   return filtered.length > 0 ? filtered : []
 }
 

--- a/src/core/llm/deepseekAnthropicProvider.test.ts
+++ b/src/core/llm/deepseekAnthropicProvider.test.ts
@@ -18,9 +18,7 @@ describe('resolveDeepSeekAnthropicBaseUrl', () => {
 
   it('keeps explicit Anthropic paths and custom gateways', () => {
     expect(
-      resolveDeepSeekAnthropicBaseUrl(
-        'https://api.deepseek.com/anthropic/v1',
-      ),
+      resolveDeepSeekAnthropicBaseUrl('https://api.deepseek.com/anthropic/v1'),
     ).toBe('https://api.deepseek.com/anthropic')
     expect(resolveDeepSeekAnthropicBaseUrl('https://proxy.example/v1')).toBe(
       'https://proxy.example',

--- a/src/core/llm/deepseekAnthropicProvider.test.ts
+++ b/src/core/llm/deepseekAnthropicProvider.test.ts
@@ -1,0 +1,29 @@
+import { resolveDeepSeekAnthropicBaseUrl } from './deepseekAnthropicProvider'
+
+describe('resolveDeepSeekAnthropicBaseUrl', () => {
+  it('defaults to the official DeepSeek Anthropic-compatible endpoint', () => {
+    expect(resolveDeepSeekAnthropicBaseUrl(undefined)).toBe(
+      'https://api.deepseek.com/anthropic',
+    )
+  })
+
+  it('maps the official OpenAI-compatible root to the Anthropic path', () => {
+    expect(resolveDeepSeekAnthropicBaseUrl('https://api.deepseek.com')).toBe(
+      'https://api.deepseek.com/anthropic',
+    )
+    expect(resolveDeepSeekAnthropicBaseUrl('https://api.deepseek.com/')).toBe(
+      'https://api.deepseek.com/anthropic',
+    )
+  })
+
+  it('keeps explicit Anthropic paths and custom gateways', () => {
+    expect(
+      resolveDeepSeekAnthropicBaseUrl(
+        'https://api.deepseek.com/anthropic/v1',
+      ),
+    ).toBe('https://api.deepseek.com/anthropic')
+    expect(resolveDeepSeekAnthropicBaseUrl('https://proxy.example/v1')).toBe(
+      'https://proxy.example',
+    )
+  })
+})

--- a/src/core/llm/deepseekAnthropicProvider.ts
+++ b/src/core/llm/deepseekAnthropicProvider.ts
@@ -4,6 +4,7 @@ import {
 } from '@anthropic-ai/sdk/resources/messages'
 
 import { RequestMessage } from '../../types/llm/request'
+import { LLMProvider } from '../../types/provider.types'
 
 import { AnthropicProvider } from './anthropic'
 
@@ -12,7 +13,41 @@ import { AnthropicProvider } from './anthropic'
 // signature 真实性，只要 thinking block 存在即可，这里沿用占位符。
 const PLACEHOLDER_SIGNATURE = 'c2lnbmF0dXJlX3BsYWNlaG9sZGVy'
 
+export const resolveDeepSeekAnthropicBaseUrl = (
+  baseUrl: string | undefined,
+): string => {
+  const normalized = (baseUrl?.trim() || 'https://api.deepseek.com')
+    .replace(/\/+$/, '')
+    .replace(/\/v1$/, '')
+
+  try {
+    const url = new URL(normalized)
+    const path = url.pathname.replace(/\/+$/, '')
+    if (url.hostname === 'api.deepseek.com' && path === '') {
+      return `${normalized}/anthropic`
+    }
+  } catch {
+    // Keep malformed/custom values intact; the request layer will surface the
+    // actual connection error instead of a migration-time guess.
+  }
+
+  return normalized
+}
+
 export class DeepSeekAnthropicProvider extends AnthropicProvider {
+  constructor(
+    provider: LLMProvider,
+    options?: ConstructorParameters<typeof AnthropicProvider>[1],
+  ) {
+    super(
+      {
+        ...provider,
+        baseUrl: resolveDeepSeekAnthropicBaseUrl(provider.baseUrl),
+      },
+      options,
+    )
+  }
+
   protected parseRequestMessage(message: RequestMessage): MessageParam | null {
     const parsed = super.parseRequestMessage(message)
     if (

--- a/src/core/llm/deepseekCapabilities.test.ts
+++ b/src/core/llm/deepseekCapabilities.test.ts
@@ -45,7 +45,7 @@ describe('applyDeepSeekCapabilities', () => {
     })
   })
 
-  it('skips deepseek-reasoner regardless of level (V3.2 has no toggle)', () => {
+  it('skips legacy deepseek-reasoner regardless of level', () => {
     expect(run(reasonerModel, 'off')).toEqual({})
     expect(run(reasonerModel, 'high')).toEqual({})
   })

--- a/src/core/llm/deepseekCapabilities.ts
+++ b/src/core/llm/deepseekCapabilities.ts
@@ -12,8 +12,8 @@ type DeepSeekRequestRecord = Record<string, unknown>
  * V4 only accepts `reasoning_effort` of `high` / `max` and toggles thinking via a
  * top-level `thinking: { type }` field; thinking is enabled by default.
  *
- * V3.2 `deepseek-reasoner` predates these parameters and is being deprecated in
- * July; we skip it entirely to preserve current behavior.
+ * Legacy `deepseek-reasoner` encodes thinking in the model alias itself and is
+ * scheduled for retirement on 2026-07-24; skip it to preserve alias semantics.
  */
 export function applyDeepSeekCapabilities(params: {
   request: DeepSeekRequestRecord

--- a/src/core/mcp/localFileTools.ts
+++ b/src/core/mcp/localFileTools.ts
@@ -2735,30 +2735,6 @@ async function maybeWithInternalWrite<T>(
   return task()
 }
 
-async function maybeWithInternalWrites<T>(
-  promptSourceWatcher: PromptSourceWatcher | undefined,
-  paths: string[],
-  task: () => Promise<T>,
-): Promise<T> {
-  const watched = paths.filter((path) =>
-    promptSourceWatcher?.isWatchedPath(path),
-  )
-  if (!promptSourceWatcher || watched.length === 0) {
-    return task()
-  }
-  for (const path of watched) {
-    promptSourceWatcher.markInternalWriteStart(path)
-  }
-  try {
-    return await task()
-  } finally {
-    await Promise.resolve()
-    for (const path of watched) {
-      promptSourceWatcher.markInternalWriteEnd(path)
-    }
-  }
-}
-
 export async function callLocalFileTool({
   app,
   settings,
@@ -3673,16 +3649,12 @@ export async function callLocalFileTool({
           }
 
           appliedContent = reviewResult.finalContent
-          await maybeWithInternalWrite(
-            promptSourceWatcher,
-            path,
-            () => app.vault.modify(file, appliedContent),
+          await maybeWithInternalWrite(promptSourceWatcher, path, () =>
+            app.vault.modify(file, appliedContent),
           )
         } else {
-          await maybeWithInternalWrite(
-            promptSourceWatcher,
-            path,
-            () => app.vault.modify(file, nextContent),
+          await maybeWithInternalWrite(promptSourceWatcher, path, () =>
+            app.vault.modify(file, nextContent),
           )
         }
 
@@ -3738,19 +3710,20 @@ export async function callLocalFileTool({
         const path = normalizePath(getTextArg(args, 'path'))
         return maybeWithInternalWrite(promptSourceWatcher, path, () =>
           executeFsFileOps({
-          app,
-          settings,
-          action: 'write',
-          item: {
-            path,
-            content: getTextArg(args, 'content'),
-          },
-          signal,
-          tool: 'fs_write',
-          conversationId,
-          roundId,
-          toolCallId,
-        }))
+            app,
+            settings,
+            action: 'write',
+            item: {
+              path,
+              content: getTextArg(args, 'content'),
+            },
+            signal,
+            tool: 'fs_write',
+            conversationId,
+            roundId,
+            toolCallId,
+          }),
+        )
       }
 
       case 'fs_delete': {
@@ -3758,19 +3731,20 @@ export async function callLocalFileTool({
         const recursive = getOptionalBooleanArg(args, 'recursive')
         return maybeWithInternalWrite(promptSourceWatcher, path, () =>
           executeFsFileOps({
-          app,
-          settings,
-          action: 'delete',
-          item: {
-            path,
-            ...(recursive === undefined ? {} : { recursive }),
-          },
-          signal,
-          tool: 'fs_delete',
-          conversationId,
-          roundId,
-          toolCallId,
-        }))
+            app,
+            settings,
+            action: 'delete',
+            item: {
+              path,
+              ...(recursive === undefined ? {} : { recursive }),
+            },
+            signal,
+            tool: 'fs_delete',
+            conversationId,
+            roundId,
+            toolCallId,
+          }),
+        )
       }
 
       case 'fs_create_dir': {

--- a/src/core/mcp/localFileTools.ts
+++ b/src/core/mcp/localFileTools.ts
@@ -3649,9 +3649,6 @@ export async function callLocalFileTool({
           }
 
           appliedContent = reviewResult.finalContent
-          await maybeWithInternalWrite(promptSourceWatcher, path, () =>
-            app.vault.modify(file, appliedContent),
-          )
         } else {
           await maybeWithInternalWrite(promptSourceWatcher, path, () =>
             app.vault.modify(file, nextContent),

--- a/src/core/web-search/runner.ts
+++ b/src/core/web-search/runner.ts
@@ -1,11 +1,11 @@
 import { scrapeUrlGeneric } from './genericScrape'
 import { getWebSearchProvider } from './registry'
 import {
-  isProviderScrapeApiEnabled,
   type WebSearchProviderOptions,
   type WebSearchResult,
   type WebSearchScrapeResult,
   type WebSearchSettings,
+  isProviderScrapeApiEnabled,
 } from './types'
 
 const SHORT_ID_LENGTH = 6

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,8 +125,8 @@ import type {
   MentionableImage,
 } from './types/mentionable'
 import { MentionableFile, MentionableFolder } from './types/mentionable'
-import { applyKnownMaxContextTokensToChatModels } from './utils/llm/model-capability-registry'
 import { stableStringify } from './utils/json/stableStringify'
+import { applyKnownMaxContextTokensToChatModels } from './utils/llm/model-capability-registry'
 import { getMentionableBlockData } from './utils/obsidian'
 import { ensureBufferByteLengthCompat } from './utils/runtime/ensureBufferByteLengthCompat'
 

--- a/src/types/provider.types.test.ts
+++ b/src/types/provider.types.test.ts
@@ -1,5 +1,6 @@
 import {
   getDefaultRequestTransportModeForPresetType,
+  getSupportedApiTypesForPresetType,
   llmProviderSchema,
 } from './provider.types'
 
@@ -103,5 +104,14 @@ describe('getDefaultRequestTransportModeForPresetType', () => {
     expect(
       getDefaultRequestTransportModeForPresetType('chatgpt-oauth', false),
     ).toBeUndefined()
+  })
+})
+
+describe('getSupportedApiTypesForPresetType', () => {
+  it('limits DeepSeek to its official OpenAI-compatible and Anthropic APIs', () => {
+    expect(getSupportedApiTypesForPresetType('deepseek')).toEqual([
+      'openai-compatible',
+      'anthropic',
+    ])
   })
 })

--- a/src/types/provider.types.ts
+++ b/src/types/provider.types.ts
@@ -151,6 +151,9 @@ export function getSupportedApiTypesForPresetType(
     case 'gemini':
       defaults.add('openai-compatible')
       break
+    case 'deepseek':
+      defaults.add('anthropic')
+      break
     case 'amazon-bedrock':
       defaults.add('openai-compatible')
       break

--- a/src/utils/chat/exportConversation.ts
+++ b/src/utils/chat/exportConversation.ts
@@ -163,6 +163,7 @@ function groupSerializedAssistantAndToolMessages(
         message.role === 'external_agent_result' ||
         message.role === 'subagent_result'
       ) {
+        // These side-channel messages are exported through their owning assistant turn.
       } else {
         const lastItem = acc[acc.length - 1]
         if (

--- a/src/utils/chat/timeline.test.ts
+++ b/src/utils/chat/timeline.test.ts
@@ -1,4 +1,7 @@
-import type { AssistantToolMessageGroup, ChatToolMessage } from '../../types/chat'
+import type {
+  AssistantToolMessageGroup,
+  ChatToolMessage,
+} from '../../types/chat'
 import { ToolCallResponseStatus } from '../../types/tool-call.types'
 
 import { buildMessageTimelineItems } from './timeline'

--- a/src/utils/llm/model-capability-registry.test.ts
+++ b/src/utils/llm/model-capability-registry.test.ts
@@ -25,12 +25,15 @@ describe('model-capability-registry', () => {
     )
     expect(resolveKnownMaxContextTokens('gemini-2.5-flash')).toBe(1048576)
     expect(resolveKnownMaxContextTokens('openrouter/grok-4-fast')).toBe(2000000)
+    expect(resolveKnownMaxContextTokens('deepseek/deepseek-v4-pro')).toBe(
+      1048576,
+    )
   })
 
   it('resolves known modalities per model', () => {
-    expect(resolveKnownChatModelModalities('deepseek/deepseek-chat')).toEqual([
-      'text',
-    ])
+    expect(
+      resolveKnownChatModelModalities('deepseek/deepseek-v4-flash'),
+    ).toEqual(['text'])
     expect(
       resolveKnownChatModelModalities('anthropic/claude-sonnet-4.5'),
     ).toEqual(expect.arrayContaining(['text', 'vision']))

--- a/src/utils/llm/model-capability-registry.ts
+++ b/src/utils/llm/model-capability-registry.ts
@@ -30,6 +30,8 @@ const KNOWN_MODEL_CAPABILITIES: Record<string, KnownChatModelCapability> = {
   },
   'gemini-2.0-flash': { context: 1048576, modalities: ['text', 'vision'] },
   'gemini-2.0-flash-lite': { context: 1048576, modalities: ['text', 'vision'] },
+  'deepseek-v4-flash': { context: 1048576, modalities: ['text'] },
+  'deepseek-v4-pro': { context: 1048576, modalities: ['text'] },
   'deepseek-reasoner': { context: 65536, modalities: ['text'] },
 }
 

--- a/src/utils/model-id-utils.test.ts
+++ b/src/utils/model-id-utils.test.ts
@@ -6,9 +6,9 @@ describe('model-id-utils', () => {
     expect(detectReasoningTypeFromModelId('deepseek/deepseek-v4-flash')).toBe(
       'openai',
     )
-    expect(detectReasoningTypeFromModelId('provider/custom-deepseek-v4-pro')).toBe(
-      'openai',
-    )
+    expect(
+      detectReasoningTypeFromModelId('provider/custom-deepseek-v4-pro'),
+    ).toBe('openai')
     expect(detectReasoningTypeFromModelId('deepseek-chat')).toBe('none')
   })
 })

--- a/src/utils/model-id-utils.test.ts
+++ b/src/utils/model-id-utils.test.ts
@@ -1,0 +1,14 @@
+import { detectReasoningTypeFromModelId } from './model-id-utils'
+
+describe('model-id-utils', () => {
+  it('classifies DeepSeek V4 as OpenAI-compatible reasoning by model id', () => {
+    expect(detectReasoningTypeFromModelId('deepseek-v4-pro')).toBe('openai')
+    expect(detectReasoningTypeFromModelId('deepseek/deepseek-v4-flash')).toBe(
+      'openai',
+    )
+    expect(detectReasoningTypeFromModelId('provider/custom-deepseek-v4-pro')).toBe(
+      'openai',
+    )
+    expect(detectReasoningTypeFromModelId('deepseek-chat')).toBe('none')
+  })
+})

--- a/src/utils/model-id-utils.ts
+++ b/src/utils/model-id-utils.ts
@@ -93,7 +93,7 @@ export function migrateModelId(oldModelId: string, providerId: string): string {
 
 /**
  * Detect reasoning type based on model id keywords.
- * Returns 'openai' when the id looks like GPT/o-series; 'gemini' when it contains 'gemini';
+ * Returns 'openai' when the id looks like GPT/o-series or DeepSeek V4; 'gemini' when it contains 'gemini';
  * 'anthropic' when it contains 'claude'; otherwise 'none' (ambiguous ids need explicit `reasoningType`).
  */
 export function detectReasoningTypeFromModelId(
@@ -117,6 +117,10 @@ export function detectReasoningTypeFromModelId(
     s.includes('gpt5') ||
     s.includes('gpt-5')
   ) {
+    return 'openai'
+  }
+
+  if (s.includes('deepseek-v4')) {
     return 'openai'
   }
 


### PR DESCRIPTION
## 简介

本 PR 将 DeepSeek 的默认模型配置更新为 V4 API 当前模型，并补充与 V4 相关的自动识别和 Anthropic-compatible endpoint 配置。

需要说明：DeepSeek V4 的 `thinking` / `reasoning_effort` 请求参数映射已由现有 `applyDeepSeekCapabilities` 支持；本 PR 不新增这套请求适配逻辑，只是让新的默认模型和自动添加模型能正确接入现有 reasoningType 机制。

## 主要改动

- 将默认 DeepSeek 模型从 `deepseek-chat` / `deepseek-reasoner` 更新为 `deepseek-v4-flash` / `deepseek-v4-pro`。
- 给新的默认 DeepSeek V4 模型标记 `reasoningType: openai`、1M context、text-only。
- 自动检测模型 ID 时，将 `deepseek-v4-*` 识别为 OpenAI-style reasoning，方便批量/联网添加模型。
- DeepSeek provider 支持选择官方 Anthropic-compatible API。
- DeepSeek Anthropic-compatible 默认 endpoint 修正为 `https://api.deepseek.com/anthropic`。
- 更新相关测试与 smoke test model ID。

## 不包含

- 不迁移已有用户配置中的 `deepseek-chat` / `deepseek-reasoner`。
- 不新增 DeepSeek V4 reasoning 参数映射逻辑，该逻辑此前已存在。

## 备注

旧模型别名的迁移需要单独决策：`deepseek-reasoner` 并不简单等价于 `deepseek-v4-pro`，而更接近 `deepseek-v4-flash` 的 thinking 模式；同时还需要决定是否自动改写用户已整理过的模型列表。