### PR TITLE
为 JS 执行工具补一个 HTML 解析辅助

### DIFF
--- a/src/core/mcp/jsSandboxSettings.ts
+++ b/src/core/mcp/jsSandboxSettings.ts
@@ -106,7 +106,7 @@ export function buildJsSandboxToolDescription(s: JsSandboxSettings): string {
       `Network: fetch/XMLHttpRequest/WebSocket are browser-native (CORS/CSP apply). For cross-origin reads: \`const data = await (await $fetch(url, {method?,headers?,body?,contentType?})).text()\`. Host-routed, ${fetchCapKb} KB cap, max ${fetchMaxConcurrent} concurrent calls per execution (excess throw)`,
     )
     enabled.push(
-      'HTML parsing: await $utils.html.extract(html,{baseUrl?,maxTextChars?,maxItems?})->{title,text,meta,headings,links,images}; await $utils.html.select(html,cssSelector,{baseUrl?,limit?,includeHtml?})->[{tag,text,attrs,html?}]',
+      'HTML parsing: await $utils.html.extract(html,{baseUrl?,maxTextChars?,maxItems?})->{title,lang,text,meta,headings:[{level,text}],links:[{text,href}],images:[{alt,src}]} (baseUrl resolves relative href/src); await $utils.html.select(html,cssSelector,{baseUrl?,limit?,includeHtml?})->[{tag,text,attrs,html?}]',
     )
   }
 

--- a/src/core/mcp/jsSandboxSettings.ts
+++ b/src/core/mcp/jsSandboxSettings.ts
@@ -105,6 +105,9 @@ export function buildJsSandboxToolDescription(s: JsSandboxSettings): string {
     enabled.push(
       `Network: fetch/XMLHttpRequest/WebSocket are browser-native (CORS/CSP apply). For cross-origin reads: \`const data = await (await $fetch(url, {method?,headers?,body?,contentType?})).text()\`. Host-routed, ${fetchCapKb} KB cap, max ${fetchMaxConcurrent} concurrent calls per execution (excess throw)`,
     )
+    enabled.push(
+      'HTML parsing: await $utils.html.extract(html,{baseUrl?,maxTextChars?,maxItems?})->{title,text,meta,headings,links,images}; await $utils.html.select(html,cssSelector,{baseUrl?,limit?,includeHtml?})->[{tag,text,attrs,html?}]',
+    )
   }
 
   if (s.allowDbQuery) {

--- a/src/core/mcp/jsSandboxTool.ts
+++ b/src/core/mcp/jsSandboxTool.ts
@@ -314,7 +314,22 @@ function matrixMultiply(a, b, options) {
   )
 }
 
-function createSandboxUtils() {
+function createSandboxHtmlUtils() {
+  return {
+    extract(markup, options) {
+      return proxyCall('html_extract', { html: String(markup ?? ''), options })
+    },
+    select(markup, selector, options) {
+      return proxyCall('html_select', {
+        html: String(markup ?? ''),
+        selector,
+        options
+      })
+    }
+  }
+}
+
+function createSandboxUtils(options) {
   const json = {
     flatten(value) {
       return flattenJson(value, '', [])
@@ -458,10 +473,19 @@ function createSandboxUtils() {
     }
   }
 
-  return deepFreeze({ json, text, stats, matrix, date })
+  const utils = { json, text, stats, matrix, date }
+  if (options && options.includeHtml) {
+    // HTML parsing is coupled to network/fetch mode: it is mainly for fetched
+    // web pages, and keeping it conditional avoids advertising extra surface
+    // to agents that cannot retrieve remote HTML in the first place.
+    utils.html = createSandboxHtmlUtils()
+  }
+
+  return deepFreeze(utils)
 }
 
-const SANDBOX_UTILS = createSandboxUtils()
+const SANDBOX_UTILS = createSandboxUtils({ includeHtml: false })
+const SANDBOX_UTILS_WITH_HTML = createSandboxUtils({ includeHtml: true })
 
 function disableAmbientCapabilities(allowScripts, allowFetch) {
   // allowScripts is the "full power" switch: once the model can pull in and
@@ -596,7 +620,7 @@ function buildScope(rawVars) {
     } : null,
     $links: Array.isArray(rawVars && rawVars.$links) ? rawVars.$links : [],
     $tags: Array.isArray(rawVars && rawVars.$tags) ? rawVars.$tags : [],
-    $utils: SANDBOX_UTILS,
+    $utils: hostFetchAllowed ? SANDBOX_UTILS_WITH_HTML : SANDBOX_UTILS,
     $db: caps.allowDbQuery ? {
       search: (query, limit) => proxyCall('db_query', { method: 'search', query, limit }),
       find: (keyword, limit) => proxyCall('db_query', { method: 'find', keyword, limit }),
@@ -937,6 +961,191 @@ function cleanupWorker(reqId) {
   }
 }
 
+function clampInteger(value, fallback, min, max) {
+  const number = typeof value === 'number' && Number.isFinite(value)
+    ? Math.floor(value)
+    : fallback
+  return Math.min(max, Math.max(min, number))
+}
+
+function normalizeWhitespace(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim()
+}
+
+function truncateString(value, maxChars) {
+  const text = String(value || '')
+  return text.length > maxChars ? text.slice(0, maxChars) + '...' : text
+}
+
+function resolveHtmlUrl(value, baseUrl) {
+  const raw = String(value || '').trim()
+  if (!raw) return raw
+  if (typeof baseUrl !== 'string' || baseUrl.trim() === '') return raw
+  try {
+    return new URL(raw, baseUrl).href
+  } catch {
+    return raw
+  }
+}
+
+function getPayloadOptions(payload) {
+  return payload && payload.options && typeof payload.options === 'object'
+    ? payload.options
+    : {}
+}
+
+function parseHtmlDocument(payload) {
+  if (typeof DOMParser !== 'function') {
+    throw new Error('DOMParser is not available in this JavaScript sandbox.')
+  }
+  return new DOMParser().parseFromString(String(payload.html || ''), 'text/html')
+}
+
+function collectElementAttrs(element, baseUrl) {
+  const attrs = Object.create(null)
+  for (const attr of Array.from(element.attributes || [])) {
+    attrs[attr.name] = truncateString(attr.value, 1000)
+  }
+  if (attrs.href) attrs.href = resolveHtmlUrl(attrs.href, baseUrl)
+  if (attrs.src) attrs.src = resolveHtmlUrl(attrs.src, baseUrl)
+  return attrs
+}
+
+function elementToSummary(element, options) {
+  const baseUrl = typeof options.baseUrl === 'string' ? options.baseUrl : ''
+  const textMaxChars = clampInteger(options.textMaxChars, 4000, 200, 20000)
+  const result = {
+    tag: element.tagName.toLowerCase(),
+    text: truncateString(normalizeWhitespace(element.textContent), textMaxChars),
+    attrs: collectElementAttrs(element, baseUrl)
+  }
+  if (options.includeHtml === true) {
+    result.html = truncateString(
+      element.outerHTML || '',
+      clampInteger(options.htmlMaxChars, 8000, 500, 50000)
+    )
+  }
+  return result
+}
+
+function getDocumentBaseUrl(document, options) {
+  if (typeof options.baseUrl === 'string' && options.baseUrl.trim() !== '') {
+    return options.baseUrl
+  }
+  const base = document.querySelector('base[href]')
+  return base ? String(base.getAttribute('href') || '') : ''
+}
+
+function extractPageText(document, maxChars) {
+  const source = document.body || document.documentElement
+  if (!source) return ''
+  const clone = source.cloneNode(true)
+  // Scripts/styles never execute through DOMParser, but removing noisy nodes
+  // gives models the page text they usually wanted from an HTML scrape.
+  clone
+    .querySelectorAll('script,style,noscript,svg,canvas,template')
+    .forEach((node) => node.remove())
+  return truncateString(normalizeWhitespace(clone.textContent), maxChars)
+}
+
+function extractHtmlPage(payload) {
+  const options = getPayloadOptions(payload)
+  const document = parseHtmlDocument(payload)
+  const baseUrl = getDocumentBaseUrl(document, options)
+  const maxItems = clampInteger(options.maxItems, 100, 1, 500)
+  const maxTextChars = clampInteger(options.maxTextChars, 20000, 1000, 100000)
+  const meta = Object.create(null)
+
+  for (const node of Array.from(
+    document.querySelectorAll('meta[name],meta[property]')
+  )) {
+    const key = node.getAttribute('name') || node.getAttribute('property')
+    const content = node.getAttribute('content')
+    if (key && content && meta[key] === undefined) {
+      meta[key] = truncateString(content, 2000)
+    }
+  }
+
+  const headings = Array.from(document.querySelectorAll('h1,h2,h3,h4,h5,h6'))
+    .slice(0, maxItems)
+    .map((node) => ({
+      level: Number(node.tagName.slice(1)),
+      text: truncateString(normalizeWhitespace(node.textContent), 1000)
+    }))
+    .filter((item) => item.text)
+
+  const links = Array.from(document.querySelectorAll('a[href]'))
+    .slice(0, maxItems)
+    .map((node) => ({
+      text: truncateString(normalizeWhitespace(node.textContent), 1000),
+      href: resolveHtmlUrl(node.getAttribute('href') || '', baseUrl)
+    }))
+    .filter((item) => item.href)
+
+  const images = Array.from(document.querySelectorAll('img[src]'))
+    .slice(0, maxItems)
+    .map((node) => ({
+      alt: truncateString(node.getAttribute('alt') || '', 1000),
+      src: resolveHtmlUrl(node.getAttribute('src') || '', baseUrl)
+    }))
+    .filter((item) => item.src)
+
+  return {
+    title: normalizeWhitespace(document.querySelector('title')?.textContent),
+    lang: document.documentElement?.getAttribute('lang') || null,
+    text: extractPageText(document, maxTextChars),
+    meta,
+    headings,
+    links,
+    images
+  }
+}
+
+function selectHtmlElements(payload) {
+  const options = getPayloadOptions(payload)
+  const selector = typeof payload.selector === 'string' ? payload.selector : ''
+  if (!selector.trim()) {
+    throw new Error('selector must be a non-empty CSS selector.')
+  }
+  const document = parseHtmlDocument(payload)
+  const baseUrl = getDocumentBaseUrl(document, options)
+  const limit = clampInteger(options.limit, 50, 1, 200)
+  return Array.from(document.querySelectorAll(selector))
+    .slice(0, limit)
+    .map((element) => elementToSummary(element, { ...options, baseUrl }))
+}
+
+function sendWorkerProxyResponse(entry, proxyId, value, error) {
+  entry.worker.postMessage({
+    channel: CHANNEL,
+    type: 'proxy_res',
+    proxyId,
+    value,
+    error
+  })
+}
+
+function handleLocalProxyRequest(entry, payload) {
+  if (payload.cap !== 'html_extract' && payload.cap !== 'html_select') {
+    return false
+  }
+  try {
+    const value =
+      payload.cap === 'html_extract'
+        ? extractHtmlPage(payload.payload || {})
+        : selectHtmlElements(payload.payload || {})
+    sendWorkerProxyResponse(entry, payload.proxyId, value)
+  } catch (error) {
+    sendWorkerProxyResponse(
+      entry,
+      payload.proxyId,
+      undefined,
+      error && error.message ? String(error.message) : String(error)
+    )
+  }
+  return true
+}
+
 function startRun(data) {
   if (typeof Worker !== 'function' || typeof Blob !== 'function') {
     postToParent({
@@ -979,6 +1188,9 @@ function startRun(data) {
     }
     // Proxy request from Worker → forward to parent host, keep worker alive.
     if (payload.type === 'proxy_req') {
+      if (handleLocalProxyRequest(entry, payload)) {
+        return
+      }
       postToParent({
         type: 'proxy_req',
         reqId: data.reqId,

--- a/src/core/mcp/jsSandboxTool.ts
+++ b/src/core/mcp/jsSandboxTool.ts
@@ -159,6 +159,7 @@ type JsSandboxToolCallResult =
 
 const JS_SANDBOX_WORKER_SCRIPT = String.raw`
 const CHANNEL = 'yolo-js-sandbox-v1'
+const HTML_PARSE_MAX_INPUT_BYTES = 2 * 1024 * 1024
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 
 function deepFreeze(value) {
@@ -314,14 +315,33 @@ function matrixMultiply(a, b, options) {
   )
 }
 
+function getStringByteLength(value) {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(value).length
+  }
+  return value.length
+}
+
+function normalizeHtmlInput(markup) {
+  const html = String(markup ?? '')
+  const byteLength = getStringByteLength(html)
+  if (byteLength > HTML_PARSE_MAX_INPUT_BYTES) {
+    throw new Error(
+      '$utils.html input exceeds ' + HTML_PARSE_MAX_INPUT_BYTES +
+      ' bytes. Pass a smaller HTML fragment or narrow the fetched response first.'
+    )
+  }
+  return html
+}
+
 function createSandboxHtmlUtils() {
   return {
     extract(markup, options) {
-      return proxyCall('html_extract', { html: String(markup ?? ''), options })
+      return proxyCall('html_extract', { html: normalizeHtmlInput(markup), options })
     },
     select(markup, selector, options) {
       return proxyCall('html_select', {
-        html: String(markup ?? ''),
+        html: normalizeHtmlInput(markup),
         selector,
         options
       })
@@ -944,6 +964,7 @@ self.addEventListener('message', async (event) => {
 const JS_SANDBOX_IFRAME_SCRIPT = String.raw`
 const CHANNEL = 'yolo-js-sandbox-v1'
 const WORKER_SCRIPT = ${JSON.stringify(JS_SANDBOX_WORKER_SCRIPT)}
+const HTML_PARSE_MAX_INPUT_BYTES = 2 * 1024 * 1024
 const workers = new Map()
 
 function postToParent(payload) {
@@ -974,7 +995,11 @@ function normalizeWhitespace(value) {
 
 function truncateString(value, maxChars) {
   const text = String(value || '')
-  return text.length > maxChars ? text.slice(0, maxChars) + '...' : text
+  const limit = Math.max(0, Math.floor(Number(maxChars) || 0))
+  if (text.length <= limit) return text
+  if (limit === 0) return ''
+  if (limit <= 3) return '.'.repeat(limit)
+  return Array.from(text).slice(0, limit - 3).join('') + '...'
 }
 
 function resolveHtmlUrl(value, baseUrl) {
@@ -988,6 +1013,13 @@ function resolveHtmlUrl(value, baseUrl) {
   }
 }
 
+function getStringByteLength(value) {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(value).length
+  }
+  return value.length
+}
+
 function getPayloadOptions(payload) {
   return payload && payload.options && typeof payload.options === 'object'
     ? payload.options
@@ -998,7 +1030,14 @@ function parseHtmlDocument(payload) {
   if (typeof DOMParser !== 'function') {
     throw new Error('DOMParser is not available in this JavaScript sandbox.')
   }
-  return new DOMParser().parseFromString(String(payload.html || ''), 'text/html')
+  const html = String(payload.html || '')
+  if (getStringByteLength(html) > HTML_PARSE_MAX_INPUT_BYTES) {
+    throw new Error(
+      '$utils.html input exceeds ' + HTML_PARSE_MAX_INPUT_BYTES +
+      ' bytes. Pass a smaller HTML fragment or narrow the fetched response first.'
+    )
+  }
+  return new DOMParser().parseFromString(html, 'text/html')
 }
 
 function collectElementAttrs(element, baseUrl) {
@@ -1029,23 +1068,46 @@ function elementToSummary(element, options) {
 }
 
 function getDocumentBaseUrl(document, options) {
-  if (typeof options.baseUrl === 'string' && options.baseUrl.trim() !== '') {
-    return options.baseUrl
-  }
+  const fallback = typeof options.baseUrl === 'string' ? options.baseUrl.trim() : ''
   const base = document.querySelector('base[href]')
-  return base ? String(base.getAttribute('href') || '') : ''
+  const baseHref = base ? String(base.getAttribute('href') || '').trim() : ''
+  if (!baseHref) return fallback
+  if (fallback) {
+    try {
+      return new URL(baseHref, fallback).href
+    } catch {
+      return fallback
+    }
+  }
+  try {
+    return new URL(baseHref).href
+  } catch {
+    return ''
+  }
 }
 
 function extractPageText(document, maxChars) {
   const source = document.body || document.documentElement
   if (!source) return ''
-  const clone = source.cloneNode(true)
   // Scripts/styles never execute through DOMParser, but removing noisy nodes
-  // gives models the page text they usually wanted from an HTML scrape.
-  clone
+  // gives models the page text they usually wanted from an HTML scrape. The
+  // parsed document is single-use, so mutate it instead of cloning the body.
+  source
     .querySelectorAll('script,style,noscript,svg,canvas,template')
     .forEach((node) => node.remove())
-  return truncateString(normalizeWhitespace(clone.textContent), maxChars)
+  return truncateString(normalizeWhitespace(source.textContent), maxChars)
+}
+
+function collectItems(document, selector, limit, mapElement) {
+  const results = []
+  for (const element of document.querySelectorAll(selector)) {
+    const item = mapElement(element)
+    if (item) {
+      results.push(item)
+      if (results.length >= limit) break
+    }
+  }
+  return results
 }
 
 function extractHtmlPage(payload) {
@@ -1066,29 +1128,40 @@ function extractHtmlPage(payload) {
     }
   }
 
-  const headings = Array.from(document.querySelectorAll('h1,h2,h3,h4,h5,h6'))
-    .slice(0, maxItems)
-    .map((node) => ({
-      level: Number(node.tagName.slice(1)),
-      text: truncateString(normalizeWhitespace(node.textContent), 1000)
-    }))
-    .filter((item) => item.text)
+  const headings = collectItems(
+    document,
+    'h1,h2,h3,h4,h5,h6',
+    maxItems,
+    (node) => {
+      const text = truncateString(normalizeWhitespace(node.textContent), 1000)
+      return text
+        ? {
+            level: Number(node.tagName.slice(1)),
+            text
+          }
+        : null
+    }
+  )
 
-  const links = Array.from(document.querySelectorAll('a[href]'))
-    .slice(0, maxItems)
-    .map((node) => ({
-      text: truncateString(normalizeWhitespace(node.textContent), 1000),
-      href: resolveHtmlUrl(node.getAttribute('href') || '', baseUrl)
-    }))
-    .filter((item) => item.href)
+  const links = collectItems(document, 'a[href]', maxItems, (node) => {
+    const href = resolveHtmlUrl(node.getAttribute('href') || '', baseUrl)
+    return href
+      ? {
+          text: truncateString(normalizeWhitespace(node.textContent), 1000),
+          href
+        }
+      : null
+  })
 
-  const images = Array.from(document.querySelectorAll('img[src]'))
-    .slice(0, maxItems)
-    .map((node) => ({
-      alt: truncateString(node.getAttribute('alt') || '', 1000),
-      src: resolveHtmlUrl(node.getAttribute('src') || '', baseUrl)
-    }))
-    .filter((item) => item.src)
+  const images = collectItems(document, 'img[src]', maxItems, (node) => {
+    const src = resolveHtmlUrl(node.getAttribute('src') || '', baseUrl)
+    return src
+      ? {
+          alt: truncateString(node.getAttribute('alt') || '', 1000),
+          src
+        }
+      : null
+  })
 
   return {
     title: normalizeWhitespace(document.querySelector('title')?.textContent),
@@ -1110,9 +1183,12 @@ function selectHtmlElements(payload) {
   const document = parseHtmlDocument(payload)
   const baseUrl = getDocumentBaseUrl(document, options)
   const limit = clampInteger(options.limit, 50, 1, 200)
-  return Array.from(document.querySelectorAll(selector))
-    .slice(0, limit)
-    .map((element) => elementToSummary(element, { ...options, baseUrl }))
+  const results = []
+  for (const element of document.querySelectorAll(selector)) {
+    results.push(elementToSummary(element, { ...options, baseUrl }))
+    if (results.length >= limit) break
+  }
+  return results
 }
 
 function sendWorkerProxyResponse(entry, proxyId, value, error) {

--- a/src/core/mcp/jsSandboxTool.ts
+++ b/src/core/mcp/jsSandboxTool.ts
@@ -1205,6 +1205,15 @@ function handleLocalProxyRequest(entry, payload) {
   if (payload.cap !== 'html_extract' && payload.cap !== 'html_select') {
     return false
   }
+  if (!entry.allowHtml) {
+    sendWorkerProxyResponse(
+      entry,
+      payload.proxyId,
+      undefined,
+      '$utils.html is not enabled'
+    )
+    return true
+  }
   try {
     const value =
       payload.cap === 'html_extract'
@@ -1249,7 +1258,12 @@ function startRun(data) {
     return
   }
 
-  workers.set(data.reqId, { worker, token })
+  const caps = (data.vars && data.vars._caps) || {}
+  workers.set(data.reqId, {
+    worker,
+    token,
+    allowHtml: Boolean(caps.allowFetch || caps.allowExternalScripts)
+  })
 
   worker.onmessage = (event) => {
     const payload = event.data


### PR DESCRIPTION
## 简介

本 PR 给内置 `js_eval` JavaScript 执行工具新增轻量 HTML 解析辅助，方便模型解析网页内容。该能力只在 `js_eval` 开启网络请求能力时暴露：

- `await $utils.html.extract(html, { baseUrl?, maxTextChars?, maxItems? })`
  - 返回 `{ title, lang, text, meta, headings, links, images }`，其中 `baseUrl` 用于补全相对 `href` / `src`
- `await $utils.html.select(html, cssSelector, { baseUrl?, limit?, includeHtml? })`
  - 返回匹配元素的 `{ tag, text, attrs, html? }`

本次补充 HTML 解析，是因为网页解析在抓取、整理资料、抽取链接和正文时相对容易用到。而 `js_eval` 的用户代码运行在 isolated classic Worker 中，没有 DOM、`document`、`DOMParser` 等网页解析能力。面对这样的限制，首先考虑的是通过加载外部脚本实现，不能什么都往固定提示词里加。但网页解析比较特别，相关脚本在当前沙盒能力下大概率出问题。虽然模型可以自己写正则处理 HTML，但真实网页的标签嵌套、缺失闭合、属性顺序、引号风格、实体转义、相对链接和正文噪声都容易让临时 regex 失效，每次临时发明一套 HTML regex 也过于复杂。

实现上，让 Worker 通过已有消息通道调用 sandbox iframe 内的 DOMParser，只返回可 JSON 序列化的摘要结果，不向 Worker 传递 DOM 对象。为避免超大 HTML 在 iframe 主线程同步解析时卡住界面，接口会拒绝超过内置上限的 HTML 输入；需要先截取更小片段或缩小抓取结果再解析。通过把易错、重复、与 HTML 容错规则相关的部分收进稳定接口，减少模型写错 regex 的概率，也让工具结果更可控。
