### PR TITLE
[auto-triage] Fix sidebar chat keyboard scroll jump (#394)

### DIFF
--- a/src/components/chat-view/useAutoScroll.test.ts
+++ b/src/components/chat-view/useAutoScroll.test.ts
@@ -1,0 +1,21 @@
+import { isUpwardKeyboardScrollIntent } from './useAutoScroll'
+
+function makeKeyboardEvent(key: string): Pick<KeyboardEvent, 'key'> {
+  return { key }
+}
+
+describe('isUpwardKeyboardScrollIntent', () => {
+  it.each(['ArrowUp', 'PageUp', 'Home'])(
+    'treats %s as upward keyboard scroll intent',
+    (key) => {
+      expect(isUpwardKeyboardScrollIntent(makeKeyboardEvent(key))).toBe(true)
+    },
+  )
+
+  it.each(['ArrowDown', 'PageDown', 'End', ' ', 'Enter', 'Escape'])(
+    'ignores %s because it does not move history upward',
+    (key) => {
+      expect(isUpwardKeyboardScrollIntent(makeKeyboardEvent(key))).toBe(false)
+    },
+  )
+})

--- a/src/components/chat-view/useAutoScroll.ts
+++ b/src/components/chat-view/useAutoScroll.ts
@@ -7,6 +7,7 @@ const NEAR_BOTTOM_THRESHOLD = 24
 const REATTACH_BOTTOM_THRESHOLD = 96
 const FOLLOW_MAX_FRAMES = 6
 const FOLLOW_SETTLE_THRESHOLD_PX = 2
+const UPWARD_SCROLL_KEYS = new Set(['ArrowUp', 'PageUp', 'Home'])
 
 type UseAutoScrollProps = {
   scrollContainerRef: React.RefObject<HTMLElement>
@@ -21,6 +22,12 @@ type UseAutoScrollProps = {
    * in surfaces like Quick Ask where both fired on every token.
    */
   followFromReactCommitsOnly?: boolean
+}
+
+export function isUpwardKeyboardScrollIntent(
+  event: Pick<KeyboardEvent, 'key'>,
+) {
+  return UPWARD_SCROLL_KEYS.has(event.key)
 }
 
 export function useAutoScroll({
@@ -254,6 +261,12 @@ export function useAutoScroll({
       }
     }
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isUpwardKeyboardScrollIntent(event)) {
+        markUserScrollIntent()
+      }
+    }
+
     const handleTouchStart = (event: TouchEvent) => {
       lastTouchYRef.current = event.touches[0]?.clientY ?? null
     }
@@ -294,6 +307,11 @@ export function useAutoScroll({
     })
     scrollContainerElement.addEventListener('pointerdown', markUserScrollIntent)
     scrollContainerElement.addEventListener('scroll', handleScroll)
+    scrollContainerElement.ownerDocument.addEventListener(
+      'keydown',
+      handleKeyDown,
+      true,
+    )
     return () => {
       scrollContainerElement.removeEventListener('wheel', handleWheel)
       scrollContainerElement.removeEventListener('touchstart', handleTouchStart)
@@ -308,6 +326,11 @@ export function useAutoScroll({
         markUserScrollIntent,
       )
       scrollContainerElement.removeEventListener('scroll', handleScroll)
+      scrollContainerElement.ownerDocument.removeEventListener(
+        'keydown',
+        handleKeyDown,
+        true,
+      )
     }
   }, [
     hasRecentUserScrollIntent,


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->
Codex 自动分诊修复 #394。

## 改动摘要
- 在聊天自动滚动 hook 中识别键盘向上滚动意图：`ArrowUp`、`PageUp`、`Home`。
- 当用户用键盘把聊天列表从底部向上滚动时，后续 scroll 事件会退出 auto-follow，避免虚拟列表继续把视图拉回底部。
- 新增 `isUpwardKeyboardScrollIntent` 的单元测试，锁住 PageUp 等键的行为。

## Codex 分析要点
- #394 描述的问题只在侧边栏 Chat 多轮对话并停在最新消息末尾时触发，和当前 `useAutoScroll` 的贴底跟随逻辑相符。
- 原实现已处理鼠标滚轮和触摸向上滚动，但键盘 PageUp 不会先写入用户滚动意图；在虚拟化聊天列表中，auto-follow 仍可能认为需要贴底，造成“向上滚动后跳回/乱跳”。
- 修复边界只收敛在用户向上浏览历史时退出跟随，不改变主动点击“回到底部”或流式输出时的跟随行为。

## 校验
- [x] `npm test -- --runTestsByPath src/components/chat-view/useAutoScroll.test.ts src/components/chat-view/ChatTimelineList.test.tsx`
- [x] `npm run type:check`
- [x] `npx prettier --check src/components/chat-view/useAutoScroll.ts src/components/chat-view/useAutoScroll.test.ts`
- [x] `git diff --check`

关联 issue: https://github.com/Lapis0x0/obsidian-yolo/issues/394