### PR TITLE
[auto-triage] Allow one hour model request timeout (#398)

### DIFF
--- a/src/components/settings/sections/DefaultModelsAndPromptsSection.tsx
+++ b/src/components/settings/sections/DefaultModelsAndPromptsSection.tsx
@@ -7,7 +7,10 @@ import {
 } from '../../../constants'
 import { useLanguage } from '../../../contexts/language-context'
 import { useSettings } from '../../../contexts/settings-context'
-import { DEFAULT_MODEL_REQUEST_TIMEOUT_MS } from '../../../settings/schema/setting.types'
+import {
+  DEFAULT_MODEL_REQUEST_TIMEOUT_MS,
+  MAX_MODEL_REQUEST_TIMEOUT_MS,
+} from '../../../settings/schema/setting.types'
 import {
   ObsidianDropdown,
   type ObsidianDropdownOptionGroup,
@@ -109,6 +112,9 @@ export function DefaultModelsAndPromptsSection({
   const primaryRequestTimeoutMs =
     settings.continuationOptions.primaryRequestTimeoutMs ??
     DEFAULT_MODEL_REQUEST_TIMEOUT_MS
+  const maxPrimaryRequestTimeoutSeconds = Math.floor(
+    MAX_MODEL_REQUEST_TIMEOUT_MS / 1000,
+  )
   const [
     primaryRequestTimeoutSecondsInput,
     setPrimaryRequestTimeoutSecondsInput,
@@ -210,7 +216,10 @@ export function DefaultModelsAndPromptsSection({
                 setPrimaryRequestTimeoutSecondsInput(value)
                 const nextSeconds = parseIntegerInput(value)
                 if (nextSeconds === null) return
-                const clampedSeconds = Math.min(600, Math.max(1, nextSeconds))
+                const clampedSeconds = Math.min(
+                  maxPrimaryRequestTimeoutSeconds,
+                  Math.max(1, nextSeconds),
+                )
                 commitSettingsUpdate(
                   {
                     continuationOptions: {
@@ -228,7 +237,10 @@ export function DefaultModelsAndPromptsSection({
                 const nextSeconds =
                   parsedSeconds === null
                     ? Math.round(primaryRequestTimeoutMs / 1000)
-                    : Math.min(600, Math.max(1, parsedSeconds))
+                    : Math.min(
+                        maxPrimaryRequestTimeoutSeconds,
+                        Math.max(1, parsedSeconds),
+                      )
                 setPrimaryRequestTimeoutSecondsInput(String(nextSeconds))
                 if (nextSeconds * 1000 !== primaryRequestTimeoutMs) {
                   commitSettingsUpdate(

--- a/src/core/llm/requestPolicy.test.ts
+++ b/src/core/llm/requestPolicy.test.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_MODEL_REQUEST_TIMEOUT_MS } from '../../settings/schema/setting.types'
+import {
+  DEFAULT_MODEL_REQUEST_TIMEOUT_MS,
+  MAX_MODEL_REQUEST_TIMEOUT_MS,
+} from '../../settings/schema/setting.types'
 
 import {
   DEFAULT_MODEL_REQUEST_POLICY,
@@ -47,7 +50,17 @@ describe('requestPolicy', () => {
         },
       } as never),
     ).toEqual({
-      timeoutMs: 600000,
+      timeoutMs: 999999,
+    })
+
+    expect(
+      resolveModelRequestPolicy({
+        continuationOptions: {
+          primaryRequestTimeoutMs: MAX_MODEL_REQUEST_TIMEOUT_MS + 1000,
+        },
+      } as never),
+    ).toEqual({
+      timeoutMs: MAX_MODEL_REQUEST_TIMEOUT_MS,
     })
   })
 

--- a/src/core/llm/requestPolicy.ts
+++ b/src/core/llm/requestPolicy.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_MODEL_REQUEST_TIMEOUT_MS,
+  MAX_MODEL_REQUEST_TIMEOUT_MS,
   YoloSettings,
 } from '../../settings/schema/setting.types'
 import { RequestTransportMode } from '../../types/provider.types'
@@ -25,7 +26,7 @@ export const resolveModelRequestPolicy = (
   settings: Pick<YoloSettings, 'continuationOptions'>,
 ): ModelRequestPolicy => {
   const timeoutMs = Math.min(
-    600000,
+    MAX_MODEL_REQUEST_TIMEOUT_MS,
     Math.max(
       1000,
       settings.continuationOptions?.primaryRequestTimeoutMs ??

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -111,6 +111,7 @@ export const DEFAULT_TAB_COMPLETION_OPTIONS: TabCompletionOptionDefaults = {
 }
 
 export const DEFAULT_MODEL_REQUEST_TIMEOUT_MS = 60000
+export const MAX_MODEL_REQUEST_TIMEOUT_MS = 60 * 60 * 1000
 
 const notificationOptionsSchema = z
   .object({
@@ -561,7 +562,7 @@ export const yoloSettingsSchema = z.object({
         .number()
         .int()
         .min(1000)
-        .max(600000)
+        .max(MAX_MODEL_REQUEST_TIMEOUT_MS)
         .optional(),
     })
     .catch({


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->
Codex auto-triage for #398.

## Change Summary
- Raises the configurable primary model request timeout ceiling from 600 seconds to 3600 seconds.
- Keeps the default timeout unchanged at 60 seconds.
- Shares the max timeout constant across schema validation, runtime request policy, and settings UI clamp logic.

## Codex Analysis
- The reported limit comes from the existing `primaryRequestTimeoutMs` setting being capped at 600000ms in both schema/runtime logic and 600s in the settings UI.
- This is a bounded small enhancement: users can opt into longer waits for very slow local CPU models without changing existing default behavior.

## Verification
- [x] `npm run type:check`
- [x] `npm test -- --runTestsByPath src/core/llm/requestPolicy.test.ts`

## Related
- Closes https://github.com/Lapis0x0/obsidian-yolo/issues/398