### PR TITLE
[auto-triage] Allow text file formats in @ mentions (#414)

### DIFF
--- a/src/utils/fuzzy-search.test.ts
+++ b/src/utils/fuzzy-search.test.ts
@@ -1,0 +1,9 @@
+import { MENTION_SEARCHABLE_EXTENSIONS } from './fuzzy-search'
+
+describe('MENTION_SEARCHABLE_EXTENSIONS', () => {
+  it('includes conservative text formats for @ file mentions', () => {
+    for (const extension of ['canvas', 'base', 'json', 'yaml', 'yml', 'txt']) {
+      expect(MENTION_SEARCHABLE_EXTENSIONS.has(extension)).toBe(true)
+    }
+  })
+})

--- a/src/utils/fuzzy-search.ts
+++ b/src/utils/fuzzy-search.ts
@@ -6,10 +6,20 @@ import { MentionableFile, MentionableFolder } from '../types/mentionable'
 import { IMAGE_FILE_EXTENSIONS } from './llm/image'
 import { calculateFileDistance, getOpenFiles } from './obsidian'
 
+const TEXT_MENTION_SEARCHABLE_EXTENSIONS = [
+  'base',
+  'canvas',
+  'json',
+  'txt',
+  'yaml',
+  'yml',
+]
+
 /** Extensions included in @ mention fuzzy search (vault files). */
 export const MENTION_SEARCHABLE_EXTENSIONS = new Set([
   'md',
   'pdf',
+  ...TEXT_MENTION_SEARCHABLE_EXTENSIONS,
   ...IMAGE_FILE_EXTENSIONS,
 ])
 


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要
- 在 `@` 文件搜索白名单中加入保守文本格式：`.canvas`、`.base`、`.json`、`.yaml`、`.yml`、`.txt`。
- 保持图片、PDF、Markdown 的既有处理不变，不引入“任意文件类型”设置。
- 增加单元测试，防止这些文本格式从候选集合中回退。

## Codex 分析要点
- owner 在 #414 中确认先做保守方案。
- 当前 request context builder 已会在 full context 模式下把非图片、非 PDF 文件按文本读取；本 PR 只让这些明确文本格式能通过 `@` 搜索候选被选中。
- Canvas/Bases 的结构化语义理解仍未实现，后续如果要节点/边摘要或 Bases 查询语义，应拆成专门 feature。

## 校验
- [x] `npm run type:check`
- [x] `npm test -- src/utils/fuzzy-search.test.ts`

关联：#414