### PR TITLE
fix(chatgpt-oauth): codex endpoint compatibility for health check and model fetch

### DIFF
--- a/src/components/settings/modals/AddChatModelModal.tsx
+++ b/src/components/settings/modals/AddChatModelModal.tsx
@@ -11,6 +11,7 @@ import { App, Notice, requestUrl } from 'obsidian'
 import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react'
 
 import { DEFAULT_CHAT_MODELS } from '../../../constants'
+import { BAKED_PLUGIN_VERSION } from '../../../constants/bakedVersion'
 import { useLanguage } from '../../../contexts/language-context'
 import { listBedrockChatModelIds } from '../../../core/llm/bedrockCatalog'
 import YoloPlugin from '../../../main'
@@ -55,7 +56,7 @@ type CustomParameterFormEntry = CustomParameter & {
   uid: string
 }
 
-const MODEL_IDENTIFIER_KEYS = ['id', 'name', 'model'] as const
+const MODEL_IDENTIFIER_KEYS = ['id', 'slug', 'name', 'model'] as const
 
 const REASONING_TYPES = ['none', 'openai', 'gemini', 'anthropic'] as const
 type ReasoningType = (typeof REASONING_TYPES)[number]
@@ -133,8 +134,14 @@ const extractModelIdentifier = (value: unknown): string | null => {
   return null
 }
 
+const isHiddenModel = (value: unknown): boolean => {
+  if (!value || typeof value !== 'object') return false
+  return (value as Record<string, unknown>).visibility === 'hide'
+}
+
 const collectModelIdentifiers = (values: unknown[]): string[] =>
   values
+    .filter((entry) => !isHiddenModel(entry))
     .map((entry) => extractModelIdentifier(entry))
     .filter((id): id is string => Boolean(id))
 
@@ -156,12 +163,10 @@ const CHATGPT_OAUTH_DEFAULT_MODELS = Array.from(
     ...DEFAULT_CHAT_MODELS.filter((model) =>
       model.providerId.startsWith('chatgpt-oauth'),
     ).map((model) => model.model),
-    'gpt-5.1-codex',
-    'gpt-5.1-codex-max',
-    'gpt-5.1-codex-mini',
-    'gpt-5.2',
-    'gpt-5.2-codex',
     'gpt-5.5',
+    'gpt-5.4',
+    'gpt-5.4-mini',
+    'gpt-5.3-codex-spark',
   ]),
 )
 
@@ -401,47 +406,56 @@ function AddChatModelModalComponent({
             ]),
           )
 
+          const oauthHeaders = {
+            Accept: 'application/json',
+            Authorization: `Bearer ${credential.accessToken}`,
+            originator: 'opencode',
+            ...(credential.accountId
+              ? { 'ChatGPT-Account-Id': credential.accountId }
+              : {}),
+            ...(providerHeaders ?? {}),
+          }
+
+          const tryFetchModels = async (
+            url: string,
+          ): Promise<string[] | null> => {
+            const response = await requestUrl({
+              url,
+              method: 'GET',
+              headers: oauthHeaders,
+            })
+            if (response.status < 200 || response.status >= 300) {
+              return null
+            }
+            const json = response.json ?? JSON.parse(response.text)
+            const buckets: string[] = []
+            if (Array.isArray(json?.data)) {
+              buckets.push(...collectModelIdentifiers(json.data))
+            }
+            if (Array.isArray(json?.models)) {
+              buckets.push(...collectModelIdentifiers(json.models))
+            }
+            if (Array.isArray(json)) {
+              buckets.push(...collectModelIdentifiers(json))
+            }
+            return buckets.length > 0 ? buckets : null
+          }
+
           let lastErr: unknown = null
           for (const url of urlCandidates) {
             try {
-              const response = await requestUrl({
-                url,
-                method: 'GET',
-                headers: {
-                  Accept: 'application/json',
-                  Authorization: `Bearer ${credential.accessToken}`,
-                  originator: 'opencode',
-                  ...(credential.accountId
-                    ? { 'ChatGPT-Account-Id': credential.accountId }
-                    : {}),
-                  ...(providerHeaders ?? {}),
-                },
-              })
-              if (response.status < 200 || response.status >= 300) {
-                lastErr = new Error(
-                  `Failed to fetch models: ${response.status}`,
+              let models = await tryFetchModels(url)
+              if (!models) {
+                const sep = url.includes('?') ? '&' : '?'
+                models = await tryFetchModels(
+                  `${url}${sep}client_version=${BAKED_PLUGIN_VERSION}`,
                 )
-                continue
               }
-              const json = response.json ?? JSON.parse(response.text)
-              const buckets: string[] = []
-              if (Array.isArray(json?.data)) {
-                buckets.push(...collectModelIdentifiers(json.data))
-              }
-              if (Array.isArray(json?.models)) {
-                buckets.push(...collectModelIdentifiers(json.models))
-              }
-              if (Array.isArray(json)) {
-                buckets.push(...collectModelIdentifiers(json))
-              }
+              if (!models) continue
 
               const unique = Array.from(
-                new Set([...buckets, ...CHATGPT_OAUTH_DEFAULT_MODELS]),
+                new Set([...models, ...CHATGPT_OAUTH_DEFAULT_MODELS]),
               ).sort()
-              if (unique.length === 0) {
-                lastErr = new Error('Empty models list in response')
-                continue
-              }
 
               setAvailableModels(unique)
               plugin.setCachedModelList(selectedProvider.id, unique, 'chat')

--- a/src/components/settings/modals/AddChatModelModal.tsx
+++ b/src/components/settings/modals/AddChatModelModal.tsx
@@ -14,6 +14,11 @@ import { DEFAULT_CHAT_MODELS } from '../../../constants'
 import { BAKED_PLUGIN_VERSION } from '../../../constants/bakedVersion'
 import { useLanguage } from '../../../contexts/language-context'
 import { listBedrockChatModelIds } from '../../../core/llm/bedrockCatalog'
+import { listChatGPTOAuthModels } from '../../../core/llm/chatgptOAuthModelCatalog'
+import {
+  collectModelIdentifiers,
+  extractModelIdentifier,
+} from '../../../core/llm/modelCatalogIdentifiers'
 import YoloPlugin from '../../../main'
 import {
   ChatModel,
@@ -55,8 +60,6 @@ type AddChatModelModalComponentProps = {
 type CustomParameterFormEntry = CustomParameter & {
   uid: string
 }
-
-const MODEL_IDENTIFIER_KEYS = ['id', 'slug', 'name', 'model'] as const
 
 const REASONING_TYPES = ['none', 'openai', 'gemini', 'anthropic'] as const
 type ReasoningType = (typeof REASONING_TYPES)[number]
@@ -116,34 +119,6 @@ const clampMaxContextTokens = (value: number): number =>
 
 const clampMaxOutputTokens = (value: number): number =>
   Math.max(1, Math.floor(value))
-
-const extractModelIdentifier = (value: unknown): string | null => {
-  if (typeof value === 'string') {
-    return value
-  }
-  if (!value || typeof value !== 'object') {
-    return null
-  }
-  const record = value as Record<string, unknown>
-  for (const key of MODEL_IDENTIFIER_KEYS) {
-    const candidate = record[key]
-    if (typeof candidate === 'string' && candidate.length > 0) {
-      return candidate
-    }
-  }
-  return null
-}
-
-const isHiddenModel = (value: unknown): boolean => {
-  if (!value || typeof value !== 'object') return false
-  return (value as Record<string, unknown>).visibility === 'hide'
-}
-
-const collectModelIdentifiers = (values: unknown[]): string[] =>
-  values
-    .filter((entry) => !isHiddenModel(entry))
-    .map((entry) => extractModelIdentifier(entry))
-    .filter((id): id is string => Boolean(id))
 
 const normalizeGeminiBaseUrl = (raw?: string): string | undefined => {
   if (!raw) return undefined
@@ -392,88 +367,30 @@ function AddChatModelModalComponent({
             return
           }
 
-          const base = (
-            selectedProvider.baseUrl?.trim() ||
-            'https://chatgpt.com/backend-api/codex'
-          ).replace(/\/+$/, '')
-          const baseWithoutVersion = base.replace(/\/v\d+$/, '')
-          const urlCandidates = Array.from(
-            new Set([
-              `${base}/models`,
-              `${baseWithoutVersion}/models`,
-              `${base}/responses/models`,
-              `${baseWithoutVersion}/responses/models`,
-            ]),
-          )
-
-          const oauthHeaders = {
-            Accept: 'application/json',
-            Authorization: `Bearer ${credential.accessToken}`,
-            originator: 'opencode',
-            ...(credential.accountId
-              ? { 'ChatGPT-Account-Id': credential.accountId }
-              : {}),
-            ...(providerHeaders ?? {}),
-          }
-
-          const tryFetchModels = async (
-            url: string,
-          ): Promise<string[] | null> => {
-            const response = await requestUrl({
-              url,
-              method: 'GET',
-              headers: oauthHeaders,
+          try {
+            const models = await listChatGPTOAuthModels({
+              baseUrl: selectedProvider.baseUrl,
+              accessToken: credential.accessToken,
+              accountId: credential.accountId,
+              headers: providerHeaders,
+              clientVersion: BAKED_PLUGIN_VERSION,
             })
-            if (response.status < 200 || response.status >= 300) {
-              return null
-            }
-            const json = response.json ?? JSON.parse(response.text)
-            const buckets: string[] = []
-            if (Array.isArray(json?.data)) {
-              buckets.push(...collectModelIdentifiers(json.data))
-            }
-            if (Array.isArray(json?.models)) {
-              buckets.push(...collectModelIdentifiers(json.models))
-            }
-            if (Array.isArray(json)) {
-              buckets.push(...collectModelIdentifiers(json))
-            }
-            return buckets.length > 0 ? buckets : null
+            const unique = Array.from(
+              new Set([...models, ...CHATGPT_OAUTH_DEFAULT_MODELS]),
+            ).sort()
+            setAvailableModels(unique)
+            plugin.setCachedModelList(selectedProvider.id, unique, 'chat')
+          } catch (error) {
+            console.warn(
+              '[YOLO] Failed to fetch ChatGPT OAuth models, fallback to defaults.',
+              error,
+            )
+            const fallback = Array.from(
+              new Set(CHATGPT_OAUTH_DEFAULT_MODELS),
+            ).sort()
+            setAvailableModels(fallback)
+            plugin.setCachedModelList(selectedProvider.id, fallback, 'chat')
           }
-
-          let lastErr: unknown = null
-          for (const url of urlCandidates) {
-            try {
-              let models = await tryFetchModels(url)
-              if (!models) {
-                const sep = url.includes('?') ? '&' : '?'
-                models = await tryFetchModels(
-                  `${url}${sep}client_version=${BAKED_PLUGIN_VERSION}`,
-                )
-              }
-              if (!models) continue
-
-              const unique = Array.from(
-                new Set([...models, ...CHATGPT_OAUTH_DEFAULT_MODELS]),
-              ).sort()
-
-              setAvailableModels(unique)
-              plugin.setCachedModelList(selectedProvider.id, unique, 'chat')
-              return
-            } catch (error) {
-              lastErr = error
-            }
-          }
-
-          console.warn(
-            '[YOLO] Failed to fetch ChatGPT OAuth models, fallback to defaults.',
-            lastErr,
-          )
-          const fallback = Array.from(
-            new Set(CHATGPT_OAUTH_DEFAULT_MODELS),
-          ).sort()
-          setAvailableModels(fallback)
-          plugin.setCachedModelList(selectedProvider.id, fallback, 'chat')
           return
         }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -583,9 +583,9 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   },
   {
     providerId: PROVIDER_PRESET_INFO['chatgpt-oauth'].defaultProviderId,
-    id: 'chatgpt-oauth/gpt-5.3-codex',
-    model: 'gpt-5.3-codex',
-    name: 'GPT-5.3 Codex',
+    id: 'chatgpt-oauth/gpt-5.3-codex-spark',
+    model: 'gpt-5.3-codex-spark',
+    name: 'GPT-5.3 Codex Spark',
     enable: false,
     reasoningType: 'openai',
   },

--- a/src/core/llm/chatgptOAuthModelCatalog.test.ts
+++ b/src/core/llm/chatgptOAuthModelCatalog.test.ts
@@ -1,0 +1,84 @@
+jest.mock('obsidian', () => ({
+  requestUrl: jest.fn(),
+}))
+
+import { requestUrl } from 'obsidian'
+
+import { listChatGPTOAuthModels } from './chatgptOAuthModelCatalog'
+
+const requestUrlMock = requestUrl as jest.MockedFunction<typeof requestUrl>
+
+describe('listChatGPTOAuthModels', () => {
+  beforeEach(() => {
+    requestUrlMock.mockReset()
+  })
+
+  it('extracts model slugs and filters hidden models', async () => {
+    requestUrlMock.mockResolvedValue({
+      status: 200,
+      json: {
+        data: [
+          { slug: 'gpt-5.3-codex-spark' },
+          { slug: 'hidden-model', visibility: 'hide' },
+          { id: 'gpt-5.5' },
+        ],
+      },
+      text: '',
+    } as never)
+
+    const models = await listChatGPTOAuthModels({
+      accessToken: 'access-token',
+      accountId: 'account-id',
+      headers: { 'X-Custom': 'value' },
+      clientVersion: '1.5.12.7',
+    })
+
+    expect(models).toEqual(['gpt-5.3-codex-spark', 'gpt-5.5'])
+    expect(requestUrlMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://chatgpt.com/backend-api/codex/models',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          Authorization: 'Bearer access-token',
+          'ChatGPT-Account-Id': 'account-id',
+          'X-Custom': 'value',
+          originator: 'opencode',
+        }),
+      }),
+    )
+  })
+
+  it('retries the same models endpoint with client_version after an empty response', async () => {
+    requestUrlMock
+      .mockResolvedValueOnce({
+        status: 200,
+        json: { data: [] },
+        text: '',
+      } as never)
+      .mockResolvedValueOnce({
+        status: 200,
+        json: { models: [{ slug: 'gpt-5.4' }] },
+        text: '',
+      } as never)
+
+    const models = await listChatGPTOAuthModels({
+      baseUrl: 'https://chatgpt.com/backend-api/codex',
+      accessToken: 'access-token',
+      clientVersion: '1.5.12.7 beta',
+    })
+
+    expect(models).toEqual(['gpt-5.4'])
+    expect(requestUrlMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        url: 'https://chatgpt.com/backend-api/codex/models',
+      }),
+    )
+    expect(requestUrlMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        url: 'https://chatgpt.com/backend-api/codex/models?client_version=1.5.12.7%20beta',
+      }),
+    )
+  })
+})

--- a/src/core/llm/chatgptOAuthModelCatalog.ts
+++ b/src/core/llm/chatgptOAuthModelCatalog.ts
@@ -1,0 +1,115 @@
+import { requestUrl } from 'obsidian'
+
+import { collectModelIdentifiers } from './modelCatalogIdentifiers'
+
+const DEFAULT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex'
+
+type ChatGPTOAuthModelCatalogOptions = {
+  baseUrl?: string
+  accessToken: string
+  accountId?: string
+  headers?: Record<string, string>
+  clientVersion: string
+}
+
+const collectModelsFromJson = (json: unknown): string[] => {
+  const record =
+    json && typeof json === 'object' ? (json as Record<string, unknown>) : null
+  const buckets: string[] = []
+
+  if (Array.isArray(record?.data)) {
+    buckets.push(...collectModelIdentifiers(record.data))
+  }
+  if (Array.isArray(record?.models)) {
+    buckets.push(...collectModelIdentifiers(record.models))
+  }
+  if (Array.isArray(json)) {
+    buckets.push(...collectModelIdentifiers(json))
+  }
+
+  return buckets
+}
+
+const getModelUrlCandidates = (rawBaseUrl?: string): string[] => {
+  const base = (rawBaseUrl?.trim() || DEFAULT_CODEX_BASE_URL).replace(
+    /\/+$/,
+    '',
+  )
+  const baseWithoutVersion = base.replace(/\/v\d+$/, '')
+  return Array.from(
+    new Set([
+      `${base}/models`,
+      `${baseWithoutVersion}/models`,
+      `${base}/responses/models`,
+      `${baseWithoutVersion}/responses/models`,
+    ]),
+  )
+}
+
+const appendClientVersion = (url: string, clientVersion: string): string => {
+  const sep = url.includes('?') ? '&' : '?'
+  return `${url}${sep}client_version=${encodeURIComponent(clientVersion)}`
+}
+
+const fetchModelsFromUrl = async (
+  url: string,
+  headers: Record<string, string>,
+): Promise<string[]> => {
+  const response = await requestUrl({
+    url,
+    method: 'GET',
+    headers,
+  })
+
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`Failed to fetch models from ${url}: ${response.status}`)
+  }
+
+  const json = response.json ?? JSON.parse(response.text)
+  const models = collectModelsFromJson(json)
+  if (models.length === 0) {
+    throw new Error(`Empty models list in response from ${url}`)
+  }
+  return models
+}
+
+export async function listChatGPTOAuthModels({
+  baseUrl,
+  accessToken,
+  accountId,
+  headers,
+  clientVersion,
+}: ChatGPTOAuthModelCatalogOptions): Promise<string[]> {
+  const oauthHeaders: Record<string, string> = {
+    Accept: 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+    originator: 'opencode',
+    ...(accountId ? { 'ChatGPT-Account-Id': accountId } : {}),
+    ...(headers ?? {}),
+  }
+  let lastErr: unknown = null
+
+  for (const url of getModelUrlCandidates(baseUrl)) {
+    try {
+      const models = await fetchModelsFromUrl(url, oauthHeaders)
+      return Array.from(new Set(models)).sort()
+    } catch (error) {
+      lastErr = error
+    }
+
+    try {
+      const models = await fetchModelsFromUrl(
+        appendClientVersion(url, clientVersion),
+        oauthHeaders,
+      )
+      return Array.from(new Set(models)).sort()
+    } catch (error) {
+      lastErr = error
+    }
+  }
+
+  if (lastErr instanceof Error) {
+    throw lastErr
+  }
+  throw new Error('Failed to fetch ChatGPT OAuth models from all endpoints')
+}

--- a/src/core/llm/chatgptOAuthProvider.ts
+++ b/src/core/llm/chatgptOAuthProvider.ts
@@ -62,20 +62,6 @@ function injectChatgptHostedTools<
   }
 }
 
-const CODEX_UNSUPPORTED_FIELDS = new Set([
-  'max_output_tokens',
-  'temperature',
-  'top_p',
-])
-
-function stripCodexUnsupportedFields<T extends Record<string, unknown>>(
-  body: T,
-): T {
-  return Object.fromEntries(
-    Object.entries(body).filter(([key]) => !CODEX_UNSUPPORTED_FIELDS.has(key)),
-  ) as T
-}
-
 const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex'
 const CODEX_API_ENDPOINT = 'https://chatgpt.com/backend-api/codex/responses'
 const OAUTH_PROVIDER_API_KEY = 'chatgpt-oauth'
@@ -146,37 +132,33 @@ export class ChatGPTOAuthProvider extends BaseLLMProvider<LLMProvider> {
       }
     }
 
-    const body = stripCodexUnsupportedFields(
-      this.adapter.buildRequest(
-        this.applyCustomModelParameters(model, {
-          ...formattedRequest,
-          stream: true,
-        }),
-      ),
+    const body = this.adapter.buildRequest(
+      this.applyCustomModelParameters(model, {
+        ...formattedRequest,
+        stream: true,
+      }),
+      { profile: 'codex' },
     ) as ResponseCreateParamsStreaming
 
     return runWithRequestTransport({
       mode: this.requestTransportMode,
       memoryKey: this.requestTransportMemoryKey,
       runBrowser: async () =>
-        this.generateResponseWithFallback(
+        this.generateResponseFromResponsesStream(
           this.browserClient,
           body,
-          formattedRequest,
           options,
         ),
       runObsidian: async () =>
-        this.generateResponseWithFallback(
+        this.generateResponseFromResponsesStream(
           this.obsidianClient,
           body,
-          formattedRequest,
           options,
         ),
       runNode: async () =>
-        this.generateResponseWithFallback(
+        this.generateResponseFromResponsesStream(
           this.nodeClient,
           body,
-          formattedRequest,
           options,
         ),
     })
@@ -201,10 +183,9 @@ export class ChatGPTOAuthProvider extends BaseLLMProvider<LLMProvider> {
       }
     }
 
-    const body = stripCodexUnsupportedFields(
-      this.adapter.buildRequest(
-        this.applyCustomModelParameters(model, formattedRequest),
-      ),
+    const body = this.adapter.buildRequest(
+      this.applyCustomModelParameters(model, formattedRequest),
+      { profile: 'codex' },
     ) as ResponseCreateParamsStreaming
 
     return runWithRequestTransportForStream({
@@ -212,26 +193,20 @@ export class ChatGPTOAuthProvider extends BaseLLMProvider<LLMProvider> {
       memoryKey: this.requestTransportMemoryKey,
       signal: options?.signal,
       createBrowserStream: async (signal) =>
-        this.streamResponseWithFallback(
-          this.browserClient,
-          body,
-          formattedRequest,
-          { ...options, signal: signal ?? options?.signal },
-        ),
+        this.createResponsesStream(this.browserClient, body, {
+          ...options,
+          signal: signal ?? options?.signal,
+        }),
       createObsidianStream: async (signal) =>
-        this.streamResponseWithFallback(
-          this.obsidianClient,
-          body,
-          formattedRequest,
-          { ...options, signal: signal ?? options?.signal },
-        ),
+        this.createResponsesStream(this.obsidianClient, body, {
+          ...options,
+          signal: signal ?? options?.signal,
+        }),
       createNodeStream: async (signal) =>
-        this.streamResponseWithFallback(
-          this.nodeClient,
-          body,
-          formattedRequest,
-          { ...options, signal: signal ?? options?.signal },
-        ),
+        this.createResponsesStream(this.nodeClient, body, {
+          ...options,
+          signal: signal ?? options?.signal,
+        }),
     })
   }
 
@@ -296,10 +271,9 @@ export class ChatGPTOAuthProvider extends BaseLLMProvider<LLMProvider> {
     return input instanceof Request ? new Request(url, input) : url
   }
 
-  private async generateResponseWithFallback(
+  private async generateResponseFromResponsesStream(
     client: OpenAI,
     body: ResponseCreateParamsStreaming,
-    _request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming> {
     return this.collectResponseFromStream(
@@ -309,10 +283,9 @@ export class ChatGPTOAuthProvider extends BaseLLMProvider<LLMProvider> {
     )
   }
 
-  private async streamResponseWithFallback(
+  private async createResponsesStream(
     client: OpenAI,
     body: ResponseCreateParamsStreaming,
-    _request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>> {
     return this.toStream(

--- a/src/core/llm/chatgptOAuthProvider.ts
+++ b/src/core/llm/chatgptOAuthProvider.ts
@@ -28,7 +28,6 @@ import { BaseLLMProvider } from './base'
 import { ChatGPTOAuthResponsesAdapter } from './chatgptOAuthResponsesAdapter'
 import { LLMProviderNotConfiguredException } from './exception'
 import { NoStainlessOpenAI } from './NoStainlessOpenAI'
-import { OpenAIMessageAdapter } from './openaiMessageAdapter'
 import { ModelRequestPolicy, resolveSdkMaxRetries } from './requestPolicy'
 import {
   createRequestTransportMemoryKey,
@@ -63,13 +62,26 @@ function injectChatgptHostedTools<
   }
 }
 
+const CODEX_UNSUPPORTED_FIELDS = new Set([
+  'max_output_tokens',
+  'temperature',
+  'top_p',
+])
+
+function stripCodexUnsupportedFields<T extends Record<string, unknown>>(
+  body: T,
+): T {
+  return Object.fromEntries(
+    Object.entries(body).filter(([key]) => !CODEX_UNSUPPORTED_FIELDS.has(key)),
+  ) as T
+}
+
 const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex'
 const CODEX_API_ENDPOINT = 'https://chatgpt.com/backend-api/codex/responses'
 const OAUTH_PROVIDER_API_KEY = 'chatgpt-oauth'
 
 export class ChatGPTOAuthProvider extends BaseLLMProvider<LLMProvider> {
   private readonly adapter = new ChatGPTOAuthResponsesAdapter()
-  private readonly chatAdapter = new OpenAIMessageAdapter()
   private readonly browserClient: OpenAI
   private readonly obsidianClient: OpenAI
   private readonly nodeClient: OpenAI
@@ -134,11 +146,13 @@ export class ChatGPTOAuthProvider extends BaseLLMProvider<LLMProvider> {
       }
     }
 
-    const body = this.adapter.buildRequest(
-      this.applyCustomModelParameters(model, {
-        ...formattedRequest,
-        stream: true,
-      }),
+    const body = stripCodexUnsupportedFields(
+      this.adapter.buildRequest(
+        this.applyCustomModelParameters(model, {
+          ...formattedRequest,
+          stream: true,
+        }),
+      ),
     ) as ResponseCreateParamsStreaming
 
     return runWithRequestTransport({
@@ -187,8 +201,10 @@ export class ChatGPTOAuthProvider extends BaseLLMProvider<LLMProvider> {
       }
     }
 
-    const body = this.adapter.buildRequest(
-      this.applyCustomModelParameters(model, formattedRequest),
+    const body = stripCodexUnsupportedFields(
+      this.adapter.buildRequest(
+        this.applyCustomModelParameters(model, formattedRequest),
+      ),
     ) as ResponseCreateParamsStreaming
 
     return runWithRequestTransportForStream({
@@ -273,7 +289,6 @@ export class ChatGPTOAuthProvider extends BaseLLMProvider<LLMProvider> {
     const parsed = new URL(url)
     if (
       parsed.pathname.includes('/v1/responses') ||
-      parsed.pathname.includes('/chat/completions') ||
       parsed.pathname.endsWith('/responses')
     ) {
       return CODEX_API_ENDPOINT
@@ -281,53 +296,30 @@ export class ChatGPTOAuthProvider extends BaseLLMProvider<LLMProvider> {
     return input instanceof Request ? new Request(url, input) : url
   }
 
-  private isBadRequest(error: unknown): boolean {
-    return (
-      typeof error === 'object' &&
-      error !== null &&
-      'status' in error &&
-      (error as { status?: unknown }).status === 400
-    )
-  }
-
   private async generateResponseWithFallback(
     client: OpenAI,
     body: ResponseCreateParamsStreaming,
-    request: LLMRequestNonStreaming,
+    _request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming> {
-    try {
-      return await this.collectResponseFromStream(
-        (await client.responses.create(body, {
-          signal: options?.signal,
-        })) as AsyncIterable<ResponseStreamEvent>,
-      )
-    } catch (error) {
-      if (!this.isBadRequest(error)) {
-        throw error
-      }
-      return this.chatAdapter.generateResponse(client, request, options)
-    }
+    return this.collectResponseFromStream(
+      (await client.responses.create(body, {
+        signal: options?.signal,
+      })) as AsyncIterable<ResponseStreamEvent>,
+    )
   }
 
   private async streamResponseWithFallback(
     client: OpenAI,
     body: ResponseCreateParamsStreaming,
-    request: LLMRequestStreaming,
+    _request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>> {
-    try {
-      return await this.toStream(
-        (await client.responses.create(body, {
-          signal: options?.signal,
-        })) as AsyncIterable<ResponseStreamEvent>,
-      )
-    } catch (error) {
-      if (!this.isBadRequest(error)) {
-        throw error
-      }
-      return this.chatAdapter.streamResponse(client, request, options)
-    }
+    return this.toStream(
+      (await client.responses.create(body, {
+        signal: options?.signal,
+      })) as AsyncIterable<ResponseStreamEvent>,
+    )
   }
 
   private async toStream(

--- a/src/core/llm/chatgptOAuthResponsesAdapter.test.ts
+++ b/src/core/llm/chatgptOAuthResponsesAdapter.test.ts
@@ -99,6 +99,43 @@ describe('ChatGPTOAuthResponsesAdapter', () => {
     expect(request.tools).toEqual([{ type: 'web_search_preview' }])
   })
 
+  it('keeps standard Responses sampling and output limit fields by default', () => {
+    const request = adapter.buildRequest({
+      model: 'gpt-5.4',
+      stream: true,
+      max_tokens: 256,
+      temperature: 0.4,
+      top_p: 0.9,
+      messages: [{ role: 'user', content: 'Hello' }],
+    })
+
+    expect(request.max_output_tokens).toBe(256)
+    expect(request.temperature).toBe(0.4)
+    expect(request.top_p).toBe(0.9)
+  })
+
+  it('omits Codex-unsupported fields from generated and extra request params', () => {
+    const requestWithExtraParams = Object.assign(
+      {
+        model: 'gpt-5.3-codex-spark',
+        stream: true,
+        max_tokens: 256,
+        temperature: 0.4,
+        top_p: 0.9,
+        messages: [{ role: 'user' as const, content: 'Hello' }],
+      },
+      { max_output_tokens: 512 },
+    )
+
+    const request = adapter.buildRequest(requestWithExtraParams, {
+      profile: 'codex',
+    })
+
+    expect(request).not.toHaveProperty('max_output_tokens')
+    expect(request).not.toHaveProperty('temperature')
+    expect(request).not.toHaveProperty('top_p')
+  })
+
   it('parses non-streaming responses into chat completion shape', () => {
     const response = {
       id: 'resp_1',

--- a/src/core/llm/chatgptOAuthResponsesAdapter.ts
+++ b/src/core/llm/chatgptOAuthResponsesAdapter.ts
@@ -33,6 +33,7 @@ import {
 import { getToolCallArgumentsText } from '../../types/tool-call.types'
 
 type ChatGPTOAuthRequest = ResponseCreateParams & Record<string, unknown>
+export type ChatGPTOAuthRequestProfile = 'responses' | 'codex'
 
 type StreamState = {
   toolIndexByItemId: Map<string, number>
@@ -346,7 +347,9 @@ const getFinishReason = (
 export class ChatGPTOAuthResponsesAdapter {
   buildRequest(
     request: LLMRequestNonStreaming | LLMRequestStreaming,
+    options?: { profile?: ChatGPTOAuthRequestProfile },
   ): ChatGPTOAuthRequest {
+    const isCodexProfile = options?.profile === 'codex'
     const instructions = toInstructions(request.messages)
     const body: ChatGPTOAuthRequest = {
       model: request.model,
@@ -356,12 +359,15 @@ export class ChatGPTOAuthResponsesAdapter {
       ),
       tools: toTools(request.tools),
       tool_choice: toToolChoice(request.tool_choice),
-      max_output_tokens: request.max_tokens,
-      temperature: request.temperature,
-      top_p: request.top_p,
       parallel_tool_calls: true,
       stream: request.stream === true,
       store: false,
+    }
+
+    if (!isCodexProfile) {
+      body.max_output_tokens = request.max_tokens
+      body.temperature = request.temperature
+      body.top_p = request.top_p
     }
 
     const requestRecord = request as Record<string, unknown>
@@ -394,7 +400,11 @@ export class ChatGPTOAuthResponsesAdapter {
         key === 'max_tokens' ||
         key === 'reasoning_effort' ||
         key === 'reasoningLevel' ||
-        key === 'stream'
+        key === 'stream' ||
+        (isCodexProfile &&
+          (key === 'max_output_tokens' ||
+            key === 'temperature' ||
+            key === 'top_p'))
       ) {
         continue
       }

--- a/src/core/llm/modelCatalogIdentifiers.ts
+++ b/src/core/llm/modelCatalogIdentifiers.ts
@@ -1,0 +1,29 @@
+const MODEL_IDENTIFIER_KEYS = ['id', 'slug', 'name', 'model'] as const
+
+export const extractModelIdentifier = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const record = value as Record<string, unknown>
+  for (const key of MODEL_IDENTIFIER_KEYS) {
+    const candidate = record[key]
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      return candidate
+    }
+  }
+  return null
+}
+
+const isHiddenModel = (value: unknown): boolean => {
+  if (!value || typeof value !== 'object') return false
+  return (value as Record<string, unknown>).visibility === 'hide'
+}
+
+export const collectModelIdentifiers = (values: unknown[]): string[] =>
+  values
+    .filter((entry) => !isHiddenModel(entry))
+    .map((entry) => extractModelIdentifier(entry))
+    .filter((id): id is string => Boolean(id))


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill this out so review can move quickly. -->

> 👋 Before opening this PR, please confirm you've read [CONTRIBUTING.md](../CONTRIBUTING.md) — it covers what we welcome, the AI-assisted PR policy, and PR size guidelines. PRs that ignore those guidelines may be closed without detailed review.

## Summary

ChatGPT OAuth provider health check and model list fetch fail against the codex endpoint. Health check sends max_output_tokens which codex rejects; the Chat Completions fallback sends the wrong body shape to the Responses endpoint.. model list fetch silently falls back to stale hardcoded defaults because the /models endpoint requires client_version and returns slug (not id).

## Linked issue / discussion

None — discovered during manual testing of gpt-5.5 and gpt-5.3-codex models on ChatGPT OAuth.

## Type of change

<!-- Pick the one that fits best. -->

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs / comments
- [ ] 🎨 Style / CSS only
- [ ] 🧪 Tests only
- [ ] 🔧 Build / tooling / chore

## Size

- [ ] S (< 100 lines)
- [x] M (100–500 lines)
- [ ] L (500–2,000 lines)
- [ ] XL (> 2,000 lines)

## AI assistance disclosure

- [ ] No AI-generated code in this PR
- [x] AI was used to write part or all of this PR

If you checked the second box, please confirm:

- [x] I understand what changed and why, and I can explain any part of the diff if asked during review.

## Why this approach

The codex endpoint (chatgpt.com/backend-api/codex/responses) is stricter than the standard OpenAI Responses API — it rejects max_output_tokens, temperature, and top_p as unsupported parameters. The health check hardcoded max_tokens: 16 which the adapter mapped to max_output_tokens; removing it is safe because the probe aborts after the first token anyway.

The Chat Completions fallback could never succeed: rewriteCodexUrl rewrites /chat/completions back to /responses, so a Chat Completions body always hit the Responses endpoint. Removed rather than fixed — codex has no Chat Completions endpoint.

For model fetch, the /models endpoint requires a client_version query param. Rather than hardcoding a version, the fetch tries without it first, then retries with the plugin's baked version. The codex endpoint returns slug instead of id for model identifiers, and includes hidden models (visibility: "hide") that shouldn't appear in the UI.

## Screenshots / recordings

## Pre-submit checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] `npm run type:check` passes
- [x] `npm run lint:check` passes (or `npm run lint:fix` was run)
- [x] `npm test` passes
- [x] I tested this manually in Obsidian
- [ ] If CSS changed: I edited `src/styles/**`, ran `npm run styles:build`, and committed the regenerated `styles.css`
- [ ] If schema changed: I ran `npx drizzle-kit generate` and `npm run migrate:compile`, and committed the results
