### PR TITLE
fix(chatgpt-oauth): 3-segment client_version for codex /models

### DIFF
--- a/src/core/llm/chatgptOAuthModelCatalog.test.ts
+++ b/src/core/llm/chatgptOAuthModelCatalog.test.ts
@@ -30,13 +30,13 @@ describe('listChatGPTOAuthModels', () => {
       accessToken: 'access-token',
       accountId: 'account-id',
       headers: { 'X-Custom': 'value' },
-      clientVersion: '1.5.12.7',
+      clientVersion: '1.5.12',
     })
 
     expect(models).toEqual(['gpt-5.3-codex-spark', 'gpt-5.5'])
     expect(requestUrlMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'https://chatgpt.com/backend-api/codex/models',
+        url: 'https://chatgpt.com/backend-api/codex/models?client_version=1.5.12',
         headers: expect.objectContaining({
           Accept: 'application/json',
           Authorization: 'Bearer access-token',
@@ -48,37 +48,57 @@ describe('listChatGPTOAuthModels', () => {
     )
   })
 
-  it('retries the same models endpoint with client_version after an empty response', async () => {
-    requestUrlMock
-      .mockResolvedValueOnce({
-        status: 200,
-        json: { data: [] },
-        text: '',
-      } as never)
-      .mockResolvedValueOnce({
-        status: 200,
-        json: { models: [{ slug: 'gpt-5.4' }] },
-        text: '',
-      } as never)
+  it('truncates 4-segment version to 3-segment semver', async () => {
+    requestUrlMock.mockResolvedValue({
+      status: 200,
+      json: { models: [{ slug: 'gpt-5.4' }] },
+      text: '',
+    } as never)
 
     const models = await listChatGPTOAuthModels({
-      baseUrl: 'https://chatgpt.com/backend-api/codex',
       accessToken: 'access-token',
-      clientVersion: '1.5.12.7 beta',
+      clientVersion: '1.5.12.8',
     })
 
     expect(models).toEqual(['gpt-5.4'])
-    expect(requestUrlMock).toHaveBeenNthCalledWith(
-      1,
+    expect(requestUrlMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'https://chatgpt.com/backend-api/codex/models',
+        url: 'https://chatgpt.com/backend-api/codex/models?client_version=1.5.12',
       }),
     )
-    expect(requestUrlMock).toHaveBeenNthCalledWith(
-      2,
+  })
+
+  it('passes 3-segment version unchanged', async () => {
+    requestUrlMock.mockResolvedValue({
+      status: 200,
+      json: { models: [{ slug: 'gpt-5.5' }] },
+      text: '',
+    } as never)
+
+    await listChatGPTOAuthModels({
+      accessToken: 'access-token',
+      clientVersion: '2.0.0',
+    })
+
+    expect(requestUrlMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'https://chatgpt.com/backend-api/codex/models?client_version=1.5.12.7%20beta',
+        url: 'https://chatgpt.com/backend-api/codex/models?client_version=2.0.0',
       }),
     )
+  })
+
+  it('throws when the endpoint returns an error', async () => {
+    requestUrlMock.mockResolvedValue({
+      status: 400,
+      json: { error: { message: 'Invalid client_version format' } },
+      text: '',
+    } as never)
+
+    await expect(
+      listChatGPTOAuthModels({
+        accessToken: 'access-token',
+        clientVersion: '1.0.0',
+      }),
+    ).rejects.toThrow('Failed to fetch models')
   })
 })

--- a/src/core/llm/chatgptOAuthModelCatalog.ts
+++ b/src/core/llm/chatgptOAuthModelCatalog.ts
@@ -30,25 +30,18 @@ const collectModelsFromJson = (json: unknown): string[] => {
   return buckets
 }
 
-const getModelUrlCandidates = (rawBaseUrl?: string): string[] => {
+const toSemver = (version: string): string => {
+  const parts = version.split('.')
+  return parts.length > 3 ? parts.slice(0, 3).join('.') : version
+}
+
+const getModelUrl = (rawBaseUrl?: string, clientVersion?: string): string => {
   const base = (rawBaseUrl?.trim() || DEFAULT_CODEX_BASE_URL).replace(
     /\/+$/,
     '',
   )
-  const baseWithoutVersion = base.replace(/\/v\d+$/, '')
-  return Array.from(
-    new Set([
-      `${base}/models`,
-      `${baseWithoutVersion}/models`,
-      `${base}/responses/models`,
-      `${baseWithoutVersion}/responses/models`,
-    ]),
-  )
-}
-
-const appendClientVersion = (url: string, clientVersion: string): string => {
-  const sep = url.includes('?') ? '&' : '?'
-  return `${url}${sep}client_version=${encodeURIComponent(clientVersion)}`
+  const ver = toSemver(clientVersion || '1.0.0')
+  return `${base}/models?client_version=${encodeURIComponent(ver)}`
 }
 
 const fetchModelsFromUrl = async (
@@ -87,29 +80,7 @@ export async function listChatGPTOAuthModels({
     ...(accountId ? { 'ChatGPT-Account-Id': accountId } : {}),
     ...(headers ?? {}),
   }
-  let lastErr: unknown = null
-
-  for (const url of getModelUrlCandidates(baseUrl)) {
-    try {
-      const models = await fetchModelsFromUrl(url, oauthHeaders)
-      return Array.from(new Set(models)).sort()
-    } catch (error) {
-      lastErr = error
-    }
-
-    try {
-      const models = await fetchModelsFromUrl(
-        appendClientVersion(url, clientVersion),
-        oauthHeaders,
-      )
-      return Array.from(new Set(models)).sort()
-    } catch (error) {
-      lastErr = error
-    }
-  }
-
-  if (lastErr instanceof Error) {
-    throw lastErr
-  }
-  throw new Error('Failed to fetch ChatGPT OAuth models from all endpoints')
+  const url = getModelUrl(baseUrl, clientVersion)
+  const models = await fetchModelsFromUrl(url, oauthHeaders)
+  return Array.from(new Set(models)).sort()
 }

--- a/src/core/llm/chatgptOAuthResponsesAdapter.test.ts
+++ b/src/core/llm/chatgptOAuthResponsesAdapter.test.ts
@@ -136,6 +136,126 @@ describe('ChatGPTOAuthResponsesAdapter', () => {
     expect(request).not.toHaveProperty('top_p')
   })
 
+  describe('buildRequest reasoning passthrough', () => {
+    const minimalRequest = (overrides: Record<string, unknown> = {}) =>
+      ({
+        model: 'gpt-5.5',
+        stream: false,
+        messages: [{ role: 'user', content: 'Hello' }],
+        ...overrides,
+      }) as Parameters<typeof adapter.buildRequest>[0]
+
+    it('passes reasoning effort "none" through for default profile', () => {
+      const request = adapter.buildRequest(
+        minimalRequest({ reasoning: { effort: 'none', summary: 'auto' } }),
+      )
+
+      expect(request.reasoning).toEqual({ effort: 'none', summary: 'auto' })
+    })
+
+    it('passes reasoning effort "none" through for codex profile', () => {
+      const request = adapter.buildRequest(
+        minimalRequest({ reasoning: { effort: 'none', summary: 'auto' } }),
+        { profile: 'codex' },
+      )
+
+      expect(request.reasoning).toEqual({ effort: 'none', summary: 'auto' })
+    })
+
+    it('maps reasoning_effort shorthand to reasoning object with summary', () => {
+      const request = adapter.buildRequest(
+        minimalRequest({ reasoning_effort: 'medium' }),
+      )
+
+      expect(request.reasoning).toEqual({ effort: 'medium', summary: 'auto' })
+      expect(request.include).toEqual(['reasoning.encrypted_content'])
+    })
+
+    it.each(['low', 'medium', 'high'] as const)(
+      'passes reasoning effort "%s" through for both profiles',
+      (effort) => {
+        const defaultProfile = adapter.buildRequest(
+          minimalRequest({ reasoning: { effort } }),
+        )
+        const codexProfile = adapter.buildRequest(
+          minimalRequest({ reasoning: { effort } }),
+          { profile: 'codex' },
+        )
+
+        expect(defaultProfile.reasoning).toEqual({ effort })
+        expect(codexProfile.reasoning).toEqual({ effort })
+        expect(defaultProfile.include).toEqual(['reasoning.encrypted_content'])
+        expect(codexProfile.include).toEqual(['reasoning.encrypted_content'])
+      },
+    )
+
+    it('omits reasoning and include when no reasoning config is provided', () => {
+      const request = adapter.buildRequest(minimalRequest())
+
+      expect(request).not.toHaveProperty('reasoning')
+      expect(request).not.toHaveProperty('include')
+    })
+
+    it('sets include when reasoning_effort shorthand is "none"', () => {
+      const request = adapter.buildRequest(
+        minimalRequest({ reasoning_effort: 'none' }),
+      )
+
+      expect(request.reasoning).toEqual({ effort: 'none', summary: 'auto' })
+      expect(request.include).toEqual(['reasoning.encrypted_content'])
+    })
+  })
+
+  describe('buildRequest codex profile field stripping', () => {
+    const codexRequest = (overrides: Record<string, unknown> = {}) =>
+      adapter.buildRequest(
+        Object.assign(
+          {
+            model: 'gpt-5.5',
+            stream: true,
+            max_tokens: 256,
+            temperature: 0.7,
+            top_p: 0.9,
+            messages: [{ role: 'user' as const, content: 'Hello' }],
+          },
+          overrides,
+        ),
+        { profile: 'codex' },
+      )
+
+    it('strips max_output_tokens, temperature, top_p for codex profile', () => {
+      const request = codexRequest()
+
+      expect(request).not.toHaveProperty('max_output_tokens')
+      expect(request).not.toHaveProperty('temperature')
+      expect(request).not.toHaveProperty('top_p')
+    })
+
+    it('preserves max_output_tokens, temperature, top_p for default profile', () => {
+      const request = adapter.buildRequest({
+        model: 'gpt-5.5',
+        stream: true,
+        max_tokens: 256,
+        temperature: 0.7,
+        top_p: 0.9,
+        messages: [{ role: 'user', content: 'Hello' }],
+      })
+
+      expect(request.max_output_tokens).toBe(256)
+      expect(request.temperature).toBe(0.7)
+      expect(request.top_p).toBe(0.9)
+    })
+
+    it('does not strip reasoning fields for codex profile', () => {
+      const request = codexRequest({
+        reasoning: { effort: 'high', summary: 'auto' },
+      })
+
+      expect(request.reasoning).toEqual({ effort: 'high', summary: 'auto' })
+      expect(request.include).toEqual(['reasoning.encrypted_content'])
+    })
+  })
+
   it('parses non-streaming responses into chat completion shape', () => {
     const response = {
       id: 'resp_1',


### PR DESCRIPTION
## Summary

Codex `/models` endpoint requires `client_version` as a mandatory 3-segment semver query param. Plugin version is 4-segment (`1.5.12.8`), causing 400 rejection. `toSemver()` truncates to 3 segments. Multi-URL fallback loop and dead `/responses/models` candidates removed.

Adds adapter `buildRequest` regression tests covering reasoning effort passthrough (`none`/`low`/`medium`/`high`) and codex profile field-stripping isolation.

## Linked issue / discussion

Follows up on #419 — extraction to `chatgptOAuthModelCatalog.ts` inherited the `client_version` issue.

## Type of change

- [x] 🐛 Bug fix

## Size

- [x] S (< 100 lines)

## AI assistance disclosure

- [x] AI was used to write part or all of this PR
- [x] I understand what changed and why, and I can explain any part of the diff if asked during review.

## Why this approach

The codex `/models` endpoint validates `client_version` as 3-segment semver. The plugin's `BAKED_PLUGIN_VERSION` is 4-segment, so every catalog fetch failed. `toSemver()` slices to 3 segments.

The reasoning `none` suppression from the prior revision has been removed. @Lapis0x1 and @Lapis0x0 confirmed the codex endpoint accepts `reasoning.effort: "none"` — the original premise was wrong. Regression tests now lock the correct passthrough behavior for both codex and default profiles.

## Pre-submit checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/Lapis0x0/obsidian-yolo/blob/main/CONTRIBUTING.md)
- [x] `npm run type:check` passes
- [x] `npm run lint:check` passes (or `npm run lint:fix` was run)
- [x] `npm test` passes
- [x] I tested this manually in Obsidian
- [ ] If CSS changed: N/A
- [ ] If schema changed: N/A