### PR TITLE
[auto-triage] Mute repeated update toast dismissals (#422)

### DIFF
--- a/src/core/update/updateDismissal.test.ts
+++ b/src/core/update/updateDismissal.test.ts
@@ -1,0 +1,45 @@
+import {
+  dismissUpdateVersion,
+  isUpdateVersionMuted,
+} from './updateDismissal'
+
+describe('update dismissal state', () => {
+  it('soft-dismisses a version the first time it is closed', () => {
+    const result = dismissUpdateVersion(
+      { softDismissedUpdateVersion: '', mutedUpdateVersion: '' },
+      '1.2.3',
+    )
+
+    expect(result).toEqual({
+      softDismissedUpdateVersion: '1.2.3',
+      mutedUpdateVersion: '',
+    })
+    expect(isUpdateVersionMuted(result, '1.2.3')).toBe(false)
+  })
+
+  it('mutes the same version when it is closed after a soft dismissal', () => {
+    const result = dismissUpdateVersion(
+      { softDismissedUpdateVersion: '1.2.3', mutedUpdateVersion: '' },
+      '1.2.3',
+    )
+
+    expect(result).toEqual({
+      softDismissedUpdateVersion: '1.2.3',
+      mutedUpdateVersion: '1.2.3',
+    })
+    expect(isUpdateVersionMuted(result, '1.2.3')).toBe(true)
+  })
+
+  it('does not carry an older soft dismissal onto a newer version', () => {
+    const result = dismissUpdateVersion(
+      { softDismissedUpdateVersion: '1.2.3', mutedUpdateVersion: '1.2.3' },
+      '1.2.4',
+    )
+
+    expect(result).toEqual({
+      softDismissedUpdateVersion: '1.2.4',
+      mutedUpdateVersion: '1.2.3',
+    })
+    expect(isUpdateVersionMuted(result, '1.2.4')).toBe(false)
+  })
+})

--- a/src/core/update/updateDismissal.ts
+++ b/src/core/update/updateDismissal.ts
@@ -1,0 +1,33 @@
+type UpdateDismissalState = {
+  softDismissedUpdateVersion: string
+  mutedUpdateVersion: string
+}
+
+export function isUpdateVersionSoftDismissed(
+  state: UpdateDismissalState,
+  version: string,
+): boolean {
+  return state.softDismissedUpdateVersion === version
+}
+
+export function isUpdateVersionMuted(
+  state: UpdateDismissalState,
+  version: string,
+): boolean {
+  return state.mutedUpdateVersion === version
+}
+
+export function dismissUpdateVersion(
+  state: UpdateDismissalState,
+  version: string,
+): UpdateDismissalState {
+  const wasSoftDismissed = isUpdateVersionSoftDismissed(state, version)
+
+  return {
+    ...state,
+    softDismissedUpdateVersion: version,
+    mutedUpdateVersion: wasSoftDismissed
+      ? version
+      : state.mutedUpdateVersion,
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,11 @@ import {
   checkForUpdate,
   normalizePluginVersion,
 } from './core/update/updateChecker'
+import {
+  dismissUpdateVersion as resolveDismissedUpdateVersion,
+  isUpdateVersionMuted,
+  isUpdateVersionSoftDismissed,
+} from './core/update/updateDismissal'
 import { DatabaseManager } from './database/DatabaseManager'
 import { PGLiteAbortedException } from './database/exception'
 import { ChatManager } from './database/json/chat/ChatManager'
@@ -3010,17 +3015,23 @@ ${validationResult.error.issues.map((v) => v.message).join('\n')}`)
   }
 
   isUpdateVersionSoftDismissed(version: string): boolean {
-    return this.settings.softDismissedUpdateVersion === version
+    return isUpdateVersionSoftDismissed(this.settings, version)
+  }
+
+  isUpdateVersionMuted(version: string): boolean {
+    return isUpdateVersionMuted(this.settings, version)
   }
 
   async dismissUpdateVersion(version: string): Promise<void> {
     await this.setSettings({
       ...this.settings,
-      softDismissedUpdateVersion: version,
+      ...resolveDismissedUpdateVersion(this.settings, version),
     })
     // setSettings can no-op (e.g. external settings conflict). Only hide the
     // toast when the dismissal state actually persisted, so the user can retry.
-    const persisted = this.isUpdateVersionSoftDismissed(version)
+    const persisted =
+      this.isUpdateVersionSoftDismissed(version) ||
+      this.isUpdateVersionMuted(version)
     if (persisted) {
       this.updateCheckResult = null
       this.notifyUpdateCheckListeners()
@@ -3035,6 +3046,9 @@ ${validationResult.error.issues.map((v) => v.message).join('\n')}`)
     void (async () => {
       const fetched = await checkForUpdate(this.manifest.version)
       if (fetched?.hasUpdate) {
+        if (this.isUpdateVersionMuted(fetched.latestVersion)) {
+          return
+        }
         this.updateCheckResult = fetched
         this.notifyUpdateCheckListeners()
         await this.refreshPluginUpdateStaging(fetched.latestVersion)


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->
## 改动摘要
- 补上已存在但未被使用的 `mutedUpdateVersion` 行为：同一版本更新提示第一次关闭后下次启动仍可再提示一次，第二次关闭后静音该版本。
- 检查到已静音版本时不再展示更新 toast；更高版本仍会重新提示。
- 把更新提示关闭状态抽成小的纯函数并补单元测试。

## Codex 分析要点
- 设置 schema 和 v66→v67 migration 已经声明了 `softDismissedUpdateVersion` / `mutedUpdateVersion` 的两阶段语义。
- 当前实现只写入并检查 `softDismissedUpdateVersion`，所以用户关闭后重新打开 Obsidian 仍会反复看到同一版本提示。
- 这是局部实现漏接，不需要改变发布版本号或更新机制。

## 校验
- `npm run type:check`
- `npm test -- --runTestsByPath src/core/update/updateDismissal.test.ts`

## 关联
- Fixes #422