### PR TITLE
[auto-triage] Explain vector database storage (#427)

### DIFF
--- a/src/components/settings/sections/RAGSection.tsx
+++ b/src/components/settings/sections/RAGSection.tsx
@@ -990,6 +990,13 @@ export function RAGSection({ app, plugin }: RAGSectionProps) {
             />
           </ObsidianSetting>
 
+          <div className="yolo-muted-note">
+            {t(
+              'settings.rag.vectorDbStorageHint',
+              '向量数据库会保存为 YOLO 文件夹下的 .yolo_vector_db.tar.gz，用于缓存知识库索引。大库可能占用较多空间；如使用同步盘，建议确认该文件是否需要同步。',
+            )}
+          </div>
+
           {!canUseIndexMaintenance && isRagEnabled && (
             <div className="yolo-muted-note">
               {t(

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1081,6 +1081,8 @@ export const en: TranslationKeys = {
       basicCardTitle: 'Knowledge base',
       basicCardDesc:
         'Control knowledge base indexing, the embedding model, and related maintenance actions.',
+      vectorDbStorageHint:
+        'The vector database is saved as .yolo_vector_db.tar.gz under the YOLO folder and caches the knowledge base index. Large vaults may use significant space; if you use a sync drive, check whether this file should be synced.',
       resourceCardTitle: 'PGlite Resources',
       resourceCardDesc:
         'Manage the database runtime resources required by the knowledge base.',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -962,6 +962,8 @@ export const it: TranslationKeys = {
       basicCardTitle: 'Knowledge base',
       basicCardDesc:
         "Controlla l'indicizzazione della knowledge base, il modello di embedding e le relative azioni di manutenzione.",
+      vectorDbStorageHint:
+        "Il database vettoriale viene salvato come .yolo_vector_db.tar.gz nella cartella YOLO e memorizza nella cache l'indice della knowledge base. I vault grandi possono occupare molto spazio; se usi una cartella sincronizzata, verifica se questo file debba essere sincronizzato.",
       resourceCardTitle: 'Risorse PGlite',
       resourceCardDesc:
         'Gestisce le risorse runtime del database necessarie alla base di conoscenza.',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -1001,6 +1001,8 @@ export const zh: TranslationKeys = {
       advanced: '高级设置',
       basicCardTitle: '知识库',
       basicCardDesc: '控制知识库索引的启用状态、嵌入模型与相关维护操作。',
+      vectorDbStorageHint:
+        '向量数据库会保存为 YOLO 文件夹下的 .yolo_vector_db.tar.gz，用于缓存知识库索引。大库可能占用较多空间；如使用同步盘，建议确认该文件是否需要同步。',
       resourceCardTitle: 'PGlite 资源',
       resourceCardDesc: '管理知识库运行所需的数据库运行时资源。',
       scopeCardTitle: '索引范围',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -845,6 +845,7 @@ export type TranslationKeys = {
       advanced?: string
       basicCardTitle?: string
       basicCardDesc?: string
+      vectorDbStorageHint?: string
       resourceCardTitle?: string
       resourceCardDesc?: string
       scopeCardTitle?: string


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要
- 在知识库设置卡片中增加说明，解释 `.yolo_vector_db.tar.gz` 是知识库索引的向量数据库缓存。
- 提醒大库可能占用较多空间，并提示使用同步盘时确认是否需要同步该文件。
- 补齐 zh/en/it 文案和 i18n 类型定义。

## Codex 分析要点
- #427 里“界面看不到相关说明”是一个边界清楚的小增强，适合先用最小 UI 文案降低误删和同步空间困惑。
- 代码当前只维护一个规范路径 `YOLO/.yolo_vector_db.tar.gz`；用户看到多个类似文件，更可能是同步盘冲突副本/历史副本，而不是 YOLO 主动维护多个向量库文件。
- 空间膨胀、卡顿和大库持久化瓶颈与 #408 的长期数据库存储问题相关，这个 PR 不假装解决底层性能问题。

## 校验
- [x] `npm run type:check`

## 关联
- 原 issue: https://github.com/Lapis0x0/obsidian-yolo/issues/427
- 相关长期问题: https://github.com/Lapis0x0/obsidian-yolo/issues/408
