### PR TITLE
[auto-triage] Keep agent select menus in popout windows (#432)

### DIFF
--- a/src/components/common/SimpleSelect.tsx
+++ b/src/components/common/SimpleSelect.tsx
@@ -1,6 +1,6 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { Check, ChevronDown, ChevronUp } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 
 export type SimpleSelectOption = {
   value: string
@@ -45,6 +45,7 @@ export function SimpleSelect({
   contentClassName,
 }: SimpleSelectProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
   const flattenedOptions = useMemo(() => {
     if (groupedOptions && groupedOptions.length > 0) {
       return groupedOptions.flatMap((group) => group.options)
@@ -59,6 +60,8 @@ export function SimpleSelect({
   return (
     <DropdownMenu.Root open={isOpen} onOpenChange={(open) => setIsOpen(open)}>
       <DropdownMenu.Trigger
+        ref={triggerRef}
+        type="button"
         className="yolo-simple-select__trigger"
         disabled={disabled}
       >
@@ -70,7 +73,9 @@ export function SimpleSelect({
         </div>
       </DropdownMenu.Trigger>
 
-      <DropdownMenu.Portal>
+      <DropdownMenu.Portal
+        container={triggerRef.current?.ownerDocument?.body ?? undefined}
+      >
         <DropdownMenu.Content
           className={
             contentClassName


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## Summary
- Route the shared `SimpleSelect` Radix portal through the trigger element's `ownerDocument.body`, so menus opened from an Obsidian popout stay in that popout window.
- Mark the trigger as `type="button"` while touching the shared control.

## Codex Analysis
- The failing agent model selector and per-tool access selector both use `SimpleSelect`.
- `SimpleSelect` used `DropdownMenu.Portal` without a container, which falls back to the main document and matches the reported popout-window behavior.
- The skills tab uses a different UI path, which matches the issue report that those dropdowns are unaffected.

## Checks
- `npm run type:check`
- `npx prettier --check src/components/common/SimpleSelect.tsx`

Fixes #432