### PR TITLE
[auto-triage] Fix split chat placement in popout windows (#434)

### DIFF
--- a/src/features/chat/chatViewNavigator.test.ts
+++ b/src/features/chat/chatViewNavigator.test.ts
@@ -49,6 +49,7 @@ describe('ChatViewNavigator', () => {
       touchLeafInteracted?: jest.Mock
       revealLeaf?: jest.Mock
       getRightLeaf?: () => WorkspaceLeaf
+      getLeaf?: jest.Mock
     } = {},
   ) => {
     const sessionManager = {
@@ -68,6 +69,11 @@ describe('ChatViewNavigator', () => {
         overrides.getRightLeaf ??
         (() => {
           throw new Error('getRightLeaf should not be called in this test')
+        }),
+      getLeaf:
+        overrides.getLeaf ??
+        jest.fn(() => {
+          throw new Error('getLeaf should not be called in this test')
         }),
     }
 
@@ -229,5 +235,38 @@ describe('ChatViewNavigator', () => {
         currentConversationId: 'conversation-1',
       },
     })
+  })
+
+  it('asks Obsidian for a split leaf when opening a new split chat', async () => {
+    const setViewState = jest.fn().mockImplementation(function setViewState() {
+      this.view = new (MockChatView as unknown as new () => object)()
+      return Promise.resolve()
+    })
+    const newLeaf = {
+      setViewState,
+    } as unknown as WorkspaceLeaf
+    const getLeaf = jest.fn(() => newLeaf)
+    const setPendingPayload = jest.fn()
+    const registerLeaf = jest.fn()
+    const plugin = createPlugin({
+      resolveTargetLeaf: () => null,
+      setPendingPayload,
+      registerLeaf,
+      revealLeaf: jest.fn().mockResolvedValue(undefined),
+      getLeaf,
+    })
+
+    const navigator = new ChatViewNavigator({ plugin })
+
+    await navigator.openChatInSplit(true)
+
+    expect(getLeaf).toHaveBeenCalledWith('split')
+    expect(setPendingPayload).toHaveBeenCalledWith(
+      newLeaf,
+      expect.objectContaining({
+        placement: 'split',
+      }),
+    )
+    expect(registerLeaf).toHaveBeenCalledWith(newLeaf, 'split')
   })
 })

--- a/src/features/chat/chatViewNavigator.ts
+++ b/src/features/chat/chatViewNavigator.ts
@@ -391,15 +391,8 @@ export class ChatViewNavigator {
     switch (placement) {
       case 'sidebar':
         return this.plugin.app.workspace.getRightLeaf(false)
-      case 'split': {
-        const workspace = this.plugin.app.workspace
-        const baseLeaf =
-          workspace.getMostRecentLeaf(workspace.rootSplit) ??
-          workspace.getActiveViewOfType(MarkdownView)?.leaf ??
-          workspace.getLeaf(false)
-
-        return workspace.createLeafBySplit(baseLeaf, 'vertical')
-      }
+      case 'split':
+        return this.plugin.app.workspace.getLeaf('split')
       case 'tab':
         return this.plugin.app.workspace.getLeaf('tab')
       case 'window':


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## Summary
- Use Obsidian's `workspace.getLeaf("split")` for chat split placement instead of anchoring on `rootSplit`.
- Add a focused navigator test that verifies the new split chat path asks Obsidian for a `split` leaf and preserves the `split` placement payload.

## Codex analysis
- The previous implementation selected `getMostRecentLeaf(workspace.rootSplit)` before calling `createLeafBySplit`, so commands invoked from a popout could still be anchored to the main window.
- `getLeaf("split")` delegates the split target to Obsidian's active workspace context, which matches the reported popout behavior while keeping the change local to split chat creation.

## Checks
- [x] `npm run type:check`
- [x] `npm test -- --runTestsByPath src/features/chat/chatViewNavigator.test.ts`
- [x] `npx prettier --check src/features/chat/chatViewNavigator.ts src/features/chat/chatViewNavigator.test.ts`

Closes #434