### PR TITLE
[auto-triage] Keep Live Preview table selections visible (#442)

### DIFF
--- a/src/features/editor/selection-highlight/selectionHighlightController.ts
+++ b/src/features/editor/selection-highlight/selectionHighlightController.ts
@@ -225,9 +225,6 @@ export class SelectionHighlightController {
       selectionHighlightField,
       EditorView.theme({
         [`&.${HIDE_NATIVE_SELECTION_CLASS}`]: {
-          '& ::selection, & *::selection': {
-            background: 'transparent !important',
-          },
           '& .cm-selectionLayer': {
             display: 'none',
           },

--- a/src/styles/selection/selection-chat.css
+++ b/src/styles/selection/selection-chat.css
@@ -23,20 +23,9 @@
   z-index: 2;
 }
 
-/* Suppress native CM + browser selection when our persisted layer paints it.
-   Obsidian sets both .cm-selectionLayer and ::selection on .markdown-source-view.
-   Scope to .cm-selectionLayer only — our markers also use cm-selectionBackground
-   inside .yolo-selection-highlight-layer and must stay visible. */
-.markdown-source-view.mod-cm6 .cm-editor.yolo-hide-native-selection ::selection,
-.markdown-source-view.mod-cm6
-  .cm-editor.yolo-hide-native-selection
-  *::selection,
-.cm-editor.yolo-hide-native-selection ::selection,
-.cm-editor.yolo-hide-native-selection *::selection {
-  background: transparent !important;
-  background-color: transparent !important;
-}
-
+/* Suppress CodeMirror's native selection layer when our persisted layer paints
+   it. Keep browser ::selection intact so Live Preview widgets such as tables
+   can still show their own selected cells/text. */
 .markdown-source-view.mod-cm6
   .cm-editor.yolo-hide-native-selection
   .cm-selectionLayer,

--- a/styles.css
+++ b/styles.css
@@ -21509,20 +21509,9 @@ body.yolo-quick-ask-global-interaction * {
   z-index: 2;
 }
 
-/* Suppress native CM + browser selection when our persisted layer paints it.
-   Obsidian sets both .cm-selectionLayer and ::selection on .markdown-source-view.
-   Scope to .cm-selectionLayer only — our markers also use cm-selectionBackground
-   inside .yolo-selection-highlight-layer and must stay visible. */
-
-.markdown-source-view.mod-cm6 .cm-editor.yolo-hide-native-selection ::selection,
-.markdown-source-view.mod-cm6
-  .cm-editor.yolo-hide-native-selection
-  *::selection,
-.cm-editor.yolo-hide-native-selection ::selection,
-.cm-editor.yolo-hide-native-selection *::selection {
-  background: transparent !important;
-  background-color: transparent !important;
-}
+/* Suppress CodeMirror's native selection layer when our persisted layer paints
+   it. Keep browser ::selection intact so Live Preview widgets such as tables
+   can still show their own selected cells/text. */
 
 .markdown-source-view.mod-cm6
   .cm-editor.yolo-hide-native-selection


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要

- 移除 `yolo-hide-native-selection` 对整棵 `.cm-editor` 的 `::selection` 透明化规则。
- 保留对 CodeMirror `.cm-selectionLayer` / `.cm-selection` 的抑制，让 YOLO 的持久化高亮层仍然避免普通文本双层高亮。
- 重新生成 `styles.css`。

## Codex 分析要点

Issue #442 后续确认是在 Obsidian 1.12.7 的实时预览模式复现，并且关闭 Cursor Chat 后仍会出现。代码里 `selectionHighlightController` 是全局 editor extension，不只依赖 Cursor Chat 开关；当存在同步/固定 selection highlight 时，它会给编辑器加 `yolo-hide-native-selection`。

原 CSS/CodeMirror theme 不只隐藏了 CodeMirror 的 selection layer，还把 `.cm-editor *::selection` 设为透明。Obsidian Live Preview 表格使用自己的表格 selection/DOM 表现，容易被这条浏览器选区透明化规则误伤，导致表格内容实际被选中但看不到选中样式。

这次修复把边界收窄到 CodeMirror 原生 selection layer，避免影响 Live Preview widget/table 的浏览器选区绘制。

## 校验

- `npm run type:check`
- `npm test -- src/features/editor/selection-highlight/selectionHighlightController.test.ts`
- `npm run styles:build`

## 关联

- Fixes #442
