### PR TITLE
[auto-triage] Handle missing Responses content in quick rewrite (#451)

### DIFF
--- a/src/core/llm/chatgptOAuthResponsesAdapter.test.ts
+++ b/src/core/llm/chatgptOAuthResponsesAdapter.test.ts
@@ -518,6 +518,55 @@ describe('ChatGPTOAuthResponsesAdapter', () => {
     expect(parsed.choices[0].message).not.toHaveProperty('reasoning')
   })
 
+  it('ignores message output items without content in non-streaming responses', () => {
+    const response = {
+      id: 'resp_3',
+      created_at: 789,
+      model: 'gpt-5.4',
+      status: 'completed',
+      error: null,
+      incomplete_details: null,
+      instructions: null,
+      metadata: null,
+      output_text: 'Done',
+      parallel_tool_calls: true,
+      temperature: null,
+      tool_choice: 'auto',
+      tools: [],
+      top_p: null,
+      max_output_tokens: null,
+      previous_response_id: null,
+      reasoning: null,
+      store: false,
+      truncation: 'disabled',
+      user: null,
+      usage: null,
+      output: [
+        {
+          id: 'msg_empty',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+        },
+        {
+          id: 'msg_text',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [
+            {
+              type: 'output_text',
+              text: 'Done',
+            },
+          ],
+        },
+      ],
+    } as unknown as Response
+
+    const parsed = adapter.parseResponse(response)
+    expect(parsed.choices[0].message.content).toBe('Done')
+  })
+
   it('handles response.output_item.done for reasoning items without summary', () => {
     const state = adapter.createStreamState()
     const event = {

--- a/src/core/llm/chatgptOAuthResponsesAdapter.ts
+++ b/src/core/llm/chatgptOAuthResponsesAdapter.ts
@@ -439,7 +439,9 @@ export class ChatGPTOAuthResponsesAdapter {
       )
       .flatMap(getReasoningSummaryTexts)
       .join('\n')
-    const contentParts = messages.flatMap((message) => message.content)
+    const contentParts = messages.flatMap((message) =>
+      Array.isArray(message.content) ? message.content : [],
+    )
     const text = contentParts
       .map((part) => {
         if (part.type === 'output_text') {
@@ -456,7 +458,7 @@ export class ChatGPTOAuthResponsesAdapter {
         if (part.type !== 'output_text') {
           return []
         }
-        return part.annotations
+        return part.annotations ?? []
       })
       .map(toAnnotation)
       .filter((annotation): annotation is Annotation => Boolean(annotation))


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要
- 让 ChatGPT OAuth Responses adapter 在解析非流式 response 时跳过缺失 `content` 的 message output item。
- 对 `output_text.annotations` 做空值兜底，避免同一路径因可选字段继续崩溃。
- 增加回归测试覆盖缺失 `content` 的 message item。

## Codex 分析要点
- #451 截图中的报错为 `TypeError: Cannot read properties of undefined (reading 'type')`，栈落在 `parseResponse`。
- 快捷改写走 Quick Ask edit 模式，最终会调用 LLM adapter 解析非流式编辑计划响应。
- 现有实现直接 `flatMap(message.content)`；当 Responses 返回某个 `message` item 不带 `content` 时，后续读取 `part.type` 会抛出该错误。
- 修复限定在 Responses response 解析防御，不改变请求构造、模型选择或 Quick Ask/edit 业务流程。

## 校验
- [x] `npm run type:check`
- [x] `npm test -- src/core/llm/chatgptOAuthResponsesAdapter.test.ts`

## 关联
- Fixes https://github.com/Lapis0x0/obsidian-yolo/issues/451
