### PR TITLE
[auto-triage] Keep message navigator available in narrow panes (#453)

### DIFF
--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -6419,6 +6419,7 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
         activeMessageId={activeNavigatorMessageId}
         itemLabel={getMessageNavigatorItemLabel}
         onSelect={handleNavigateToUserMessage}
+        scrollContainerRef={chatMessagesRef}
       />
     ) : undefined
 

--- a/src/components/chat-view/MessageNavigator.tsx
+++ b/src/components/chat-view/MessageNavigator.tsx
@@ -1,5 +1,8 @@
 import cx from 'clsx'
-import { memo, useCallback, useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
+
+const SCROLL_INDICATOR_HIDE_DELAY_MS = 800
 
 export type MessageNavigatorAnchor = {
   id: string
@@ -12,6 +15,7 @@ type MessageNavigatorProps = {
   activeMessageId: string | null
   itemLabel: (index: number, label: string) => string
   onSelect: (messageId: string) => void
+  scrollContainerRef: RefObject<HTMLElement>
 }
 
 function MessageNavigator({
@@ -19,8 +23,12 @@ function MessageNavigator({
   activeMessageId,
   itemLabel,
   onSelect,
+  scrollContainerRef,
 }: MessageNavigatorProps) {
   const itemRefs = useRef<Record<string, HTMLButtonElement | null>>({})
+  const scrollIdleTimerRef = useRef<number | null>(null)
+  const isScrollingRef = useRef(false)
+  const [isScrolling, setIsScrolling] = useState(false)
 
   const scrollActiveItemIntoView = useCallback(() => {
     if (!activeMessageId) {
@@ -44,13 +52,49 @@ function MessageNavigator({
     scrollActiveItemIntoView()
   }, [scrollActiveItemIntoView])
 
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current
+    if (!scrollContainer) {
+      return
+    }
+
+    const handleScroll = () => {
+      if (!isScrollingRef.current) {
+        isScrollingRef.current = true
+        setIsScrolling(true)
+      }
+
+      if (scrollIdleTimerRef.current !== null) {
+        window.clearTimeout(scrollIdleTimerRef.current)
+      }
+      scrollIdleTimerRef.current = window.setTimeout(() => {
+        scrollIdleTimerRef.current = null
+        isScrollingRef.current = false
+        setIsScrolling(false)
+      }, SCROLL_INDICATOR_HIDE_DELAY_MS)
+    }
+
+    scrollContainer.addEventListener('scroll', handleScroll, { passive: true })
+    return () => {
+      scrollContainer.removeEventListener('scroll', handleScroll)
+      if (scrollIdleTimerRef.current !== null) {
+        window.clearTimeout(scrollIdleTimerRef.current)
+        scrollIdleTimerRef.current = null
+      }
+      isScrollingRef.current = false
+    }
+  }, [scrollContainerRef])
+
   if (anchors.length === 0) {
     return null
   }
 
   return (
     <nav
-      className="yolo-message-navigator"
+      className={cx(
+        'yolo-message-navigator',
+        isScrolling && 'is-scrolling',
+      )}
       onMouseEnter={scrollActiveItemIntoView}
     >
       <div className="yolo-message-navigator__rail">

--- a/src/components/chat-view/MessageNavigator.tsx
+++ b/src/components/chat-view/MessageNavigator.tsx
@@ -91,10 +91,7 @@ function MessageNavigator({
 
   return (
     <nav
-      className={cx(
-        'yolo-message-navigator',
-        isScrolling && 'is-scrolling',
-      )}
+      className={cx('yolo-message-navigator', isScrolling && 'is-scrolling')}
       onMouseEnter={scrollActiveItemIntoView}
     >
       <div className="yolo-message-navigator__rail">

--- a/src/styles/chat/input.css
+++ b/src/styles/chat/input.css
@@ -1450,7 +1450,22 @@ body.is-mobile .yolo-chat-container--mobile-keyboard-managed {
 
 @container yolo-chat-conversation (max-width: 850px) {
   .yolo-message-navigator {
-    display: none;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 18px;
+  }
+
+  .yolo-message-navigator__rail {
+    width: 18px;
+    padding-inline: 2px;
+    opacity: 0;
+  }
+
+  .yolo-message-navigator__panel {
+    right: 8px;
+    width: min(300px, calc(100cqw - 28px), calc(100vw - 48px));
+    max-height: min(440px, calc(100% - var(--size-4-3) * 2));
   }
 }
 

--- a/src/styles/chat/input.css
+++ b/src/styles/chat/input.css
@@ -1451,8 +1451,9 @@ body.is-mobile .yolo-chat-container--mobile-keyboard-managed {
 @container yolo-chat-conversation (max-width: 850px) {
   .yolo-message-navigator {
     top: 0;
-    right: 0;
+    right: auto;
     bottom: 0;
+    left: 0;
     width: 18px;
   }
 
@@ -1462,8 +1463,29 @@ body.is-mobile .yolo-chat-container--mobile-keyboard-managed {
     opacity: 0;
   }
 
+  .yolo-message-navigator__bar {
+    width: 8px;
+    min-width: 8px;
+  }
+
+  .yolo-message-navigator__bar.is-active {
+    width: 12px;
+    min-width: 12px;
+  }
+
+  .yolo-message-navigator.is-scrolling .yolo-message-navigator__rail {
+    opacity: 0.65;
+  }
+
+  .yolo-message-navigator:hover .yolo-message-navigator__rail,
+  .yolo-message-navigator:focus-within .yolo-message-navigator__rail {
+    opacity: 0;
+    pointer-events: auto;
+  }
+
   .yolo-message-navigator__panel {
-    right: 8px;
+    right: auto;
+    left: 8px;
     width: min(300px, calc(100cqw - 28px), calc(100vw - 48px));
     max-height: min(440px, calc(100% - var(--size-4-3) * 2));
   }

--- a/styles.css
+++ b/styles.css
@@ -10211,7 +10211,22 @@ body.is-mobile .yolo-chat-container--mobile-keyboard-managed {
 
 @container yolo-chat-conversation (max-width: 850px) {
   .yolo-message-navigator {
-    display: none;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 18px;
+  }
+
+  .yolo-message-navigator__rail {
+    width: 18px;
+    padding-inline: 2px;
+    opacity: 0;
+  }
+
+  .yolo-message-navigator__panel {
+    right: 8px;
+    width: min(300px, calc(100cqw - 28px), calc(100vw - 48px));
+    max-height: min(440px, calc(100% - var(--size-4-3) * 2));
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -10212,8 +10212,9 @@ body.is-mobile .yolo-chat-container--mobile-keyboard-managed {
 @container yolo-chat-conversation (max-width: 850px) {
   .yolo-message-navigator {
     top: 0;
-    right: 0;
+    right: auto;
     bottom: 0;
+    left: 0;
     width: 18px;
   }
 
@@ -10223,8 +10224,29 @@ body.is-mobile .yolo-chat-container--mobile-keyboard-managed {
     opacity: 0;
   }
 
+  .yolo-message-navigator__bar {
+    width: 8px;
+    min-width: 8px;
+  }
+
+  .yolo-message-navigator__bar.is-active {
+    width: 12px;
+    min-width: 12px;
+  }
+
+  .yolo-message-navigator.is-scrolling .yolo-message-navigator__rail {
+    opacity: 0.65;
+  }
+
+  .yolo-message-navigator:hover .yolo-message-navigator__rail,
+  .yolo-message-navigator:focus-within .yolo-message-navigator__rail {
+    opacity: 0;
+    pointer-events: auto;
+  }
+
   .yolo-message-navigator__panel {
-    right: 8px;
+    right: auto;
+    left: 8px;
     width: min(300px, calc(100cqw - 28px), calc(100vw - 48px));
     max-height: min(440px, calc(100% - var(--size-4-3) * 2));
   }


### PR DESCRIPTION
<!-- claude-routine:obsidian-yolo-triage:v1 -->

## 改动摘要
- 窄聊天容器不再直接隐藏对话锚点导航器。
- 在 850px 以下的聊天容器里，将导航器收敛为右边缘 18px hover 热区。
- 约束弹出面板宽度和高度，避免在侧边栏里撑出视口。

## Codex 分析要点
- #453 描述的侧边栏不可切换锚点，与现有 `@container yolo-chat-conversation (max-width: 850px)` 下 `.yolo-message-navigator { display: none; }` 一致。
- 组件本身已有 hover 展开面板和点击跳转逻辑，因此修复边界可以收敛在响应式 CSS。
- 保留 `@media (max-width: 768px)` 的移动端隐藏行为，避免在真正小屏上引入 hover-only 控件。

## 校验
- [x] `npm run type:check`
- [x] `npm run styles:build`

关联 issue: https://github.com/Lapis0x0/obsidian-yolo/issues/453