### PR TITLE
fix(learning/i18n): add missing en/zh/it keys that rendered Chinese fallbacks

### DIFF
--- a/modules/bundled.json
+++ b/modules/bundled.json
@@ -34,7 +34,7 @@
       "manifestUrl": "https://github.com/Lapis0x0/obsidian-yolo/releases/download/module-learning-v0.1.2-dev.0/module.json",
       "manifest": {
         "byteSize": 1910,
-        "sha256": "668f900862bb9130bd403af4a5cddfa97679048eb30a900ceb4d4d0c9bc0b57d"
+        "sha256": "42453016db8c00258193c80172f1f9ad3f77d4d31b08093bce376d9e9b4785a9"
       }
     }
   ]

--- a/modules/learning/src/i18n/en.ts
+++ b/modules/learning/src/i18n/en.ts
@@ -22,6 +22,9 @@ export const en = {
     cancel: 'Not now',
   },
   common: {
+    back: 'Back',
+    edit: 'Edit',
+    retry: 'Retry',
     cancel: 'Cancel',
     close: 'Close',
     delete: 'Delete',
@@ -199,6 +202,12 @@ export const en = {
     },
   },
   outlineBuilder: {
+    chapterRequired: 'At least one valid chapter is required',
+    generatingPoint: 'Generating',
+    knowledgeComplete: 'Knowledge points generated',
+    newChapter: 'New chapter',
+    newChapterContract:
+      'Describe the scope, boundaries, and estimated knowledge points for this chapter.',
     estimatedKnowledgePoints: 'Estimated knowledge points',
     failed: 'Generation failed',
     failedDescription: 'Unable to continue generation. Please try again.',
@@ -233,6 +242,7 @@ export const en = {
     generating: 'Generating...',
   },
   outline: {
+    resizeSidebar: 'Resize outline sidebar',
     emptyBody: 'This knowledge point has no content yet',
     emptyProject:
       'This project has no knowledge points yet. The outline will appear here once generation completes.',

--- a/modules/learning/src/i18n/it.ts
+++ b/modules/learning/src/i18n/it.ts
@@ -22,6 +22,9 @@ export const it = {
     cancel: 'Non ora',
   },
   common: {
+    back: 'Indietro',
+    edit: 'Modifica',
+    retry: 'Riprova',
     cancel: 'Annulla',
     close: 'Chiudi',
     delete: 'Elimina',
@@ -202,6 +205,12 @@ export const it = {
     },
   },
   outlineBuilder: {
+    chapterRequired: 'È necessario almeno un capitolo valido',
+    generatingPoint: 'Generazione in corso',
+    knowledgeComplete: 'Punti di conoscenza generati',
+    newChapter: 'Nuovo capitolo',
+    newChapterContract:
+      'Descrivi ambito, confini e punti di conoscenza stimati di questo capitolo.',
     estimatedKnowledgePoints: 'Punti di conoscenza stimati',
     failed: 'Generazione non riuscita',
     failedDescription: 'Impossibile continuare la generazione. Riprova.',
@@ -236,6 +245,7 @@ export const it = {
     generating: 'Generazione...',
   },
   outline: {
+    resizeSidebar: 'Ridimensiona barra laterale struttura',
     emptyBody: 'Questo punto di conoscenza non ha ancora contenuto',
     emptyProject:
       'Questo progetto non ha ancora punti di conoscenza. La scaletta apparirà qui al termine della generazione.',

--- a/modules/learning/src/i18n/zh.ts
+++ b/modules/learning/src/i18n/zh.ts
@@ -22,6 +22,9 @@ export const zh = {
     cancel: '暂不进入',
   },
   common: {
+    back: '返回',
+    edit: '编辑',
+    retry: '重试',
     cancel: '取消',
     close: '关闭',
     delete: '删除',
@@ -195,6 +198,11 @@ export const zh = {
     },
   },
   outlineBuilder: {
+    chapterRequired: '至少需要一个有效章节',
+    generatingPoint: '正在生成',
+    knowledgeComplete: '知识点生成完成',
+    newChapter: '新章节',
+    newChapterContract: '说明本章覆盖范围、边界和预计知识点。',
     estimatedKnowledgePoints: '预计知识点',
     failed: '生成失败',
     failedDescription: '无法继续生成，请重试。',
@@ -228,6 +236,7 @@ export const zh = {
     generating: '生成中...',
   },
   outline: {
+    resizeSidebar: '调整大纲侧栏宽度',
     emptyBody: '这个知识点还没有正文内容',
     emptyProject: '这个项目还没有知识点。生成完成后会在这里显示大纲。',
     noPointSelected: '请选择一个知识点',


### PR DESCRIPTION
## Problem

In the modularized Learning Mode (`modules/learning`, shipped as `learning/v0.1.1`), several UI strings are called via `t('key', '中文 fallback')` where the key is missing from **all** locale files. `t()` then returns the inline Chinese fallback, so English and Italian users see Chinese (and Chinese users see it only by coincidence). The most visible one is the "编辑" (Edit) button on each knowledge point; the batch-generation status "正在生成" (Generating) also surfaces during outline/knowledge-point generation.

Reproduced by resolving every `t(...)` key used under `modules/learning/src` (accounting for the runtime `learning.` prefix stripping) against `en.ts`: 9 keys are absent from en/zh/it.

## Fix

Add the 9 missing keys to `en.ts`, `zh.ts`, and `it.ts`:

- `common.back`, `common.edit`, `common.retry`
- `outline.resizeSidebar`
- `outlineBuilder.chapterRequired`, `outlineBuilder.generatingPoint`, `outlineBuilder.knowledgeComplete`, `outlineBuilder.newChapter`, `outlineBuilder.newChapterContract`

English and Italian translations added; the Chinese values match the previous inline fallbacks, so Chinese output is unchanged.

## Validation

- `npx jest modules/learning/src/i18n` passes.
- `npx tsc --noEmit -p modules/learning/tsconfig.json` passes.
- Re-running the key-resolution scan afterward: 0 keys missing with a Chinese fallback (was 9).

Small, translation-only change. Happy to adjust any wording.
