### PR TITLE
fix(learning): render knowledge map — give module mount root a height

### DIFF
--- a/modules/bundled.json
+++ b/modules/bundled.json
@@ -34,7 +34,7 @@
       "manifestUrl": "https://github.com/Lapis0x0/obsidian-yolo/releases/download/module-learning-v0.1.2-dev.0/module.json",
       "manifest": {
         "byteSize": 1910,
-        "sha256": "42453016db8c00258193c80172f1f9ad3f77d4d31b08093bce376d9e9b4785a9"
+        "sha256": "360d9bea19b3691ed9b27d17da60f1a374c28e92e8ec083ca63da30cb47787c0"
       }
     }
   ]

--- a/modules/learning/src/styles/shell.css
+++ b/modules/learning/src/styles/shell.css
@@ -8,6 +8,15 @@
 
 /* ── Root / page shell ──────────────────────────────────────────────────── */
 
+.yolo-learning-module-root {
+  /* The React mount root must fill .view-content. Without an explicit
+     height it is display:block / height:auto and collapses to content
+     height, which starves the flex chain
+     (workspace-main -> graph-root -> graph-canvas) so the knowledge-map
+     canvas resolves to 0px height and the map renders blank. See #482. */
+  height: 100%;
+}
+
 .yolo-learning-root {
   height: 100%;
   position: relative;


### PR DESCRIPTION
## Problem

Learning Mode's **Knowledge map** renders a blank canvas: the header correctly reads `N knowledge points · 0 relations`, but no topic/chapter/kp nodes are drawn. Reported in #482.

## Root cause (measured, not inferred)

The nodes exist and are positioned — the SVG just has **zero height**, so `overflow:hidden` on the canvas clips everything.

Measured the live DOM in the shipped `learning/v0.1.1` module (7-chapter / 140-KP project, "Things" theme). Walking from `.view-content` down to the graph canvas:

| element | `clientHeight` | display / height |
|---|---|---|
| `.view-content` | **1196** | block, 1196px |
| `.yolo-learning-module-root` | **131** | block, **height:auto** |
| `.yolo-learning-root` | 131 | block, height:100% |
| `.yolo-learning-page` | 131 | block, height:100% |
| `.yolo-learning-workspace-shell` | 131 | flex, height:100% |
| `.yolo-learning-workspace-main` | 52 | flex, flex:1 1 auto |
| `.yolo-learning-graph-root` | 32 (= header) | flex, flex:1 1 auto |
| `.yolo-learning-graph-canvas` | **0** | flex, flex:1 1 auto |
| `.yolo-learning-graph-svg` | **0** | absolute, height:100% |

`.yolo-learning-root`, `.yolo-learning-page`, and `.yolo-learning-workspace-shell` already carry `height:100%`, but they resolve their percentage against **`.yolo-learning-module-root`** (created in `index.tsx`), which has **no CSS rule** — so it defaults to `display:block; height:auto` and collapses to content height (131px). That single un-sized element caps the entire chain, so the `flex:1 1 auto` canvas gets 0px while the intrinsically-sized header still paints — exactly the "counts show, canvas blank" symptom.

This is the zero-size / host-style-collision branch (per the analysis in #482), not a node-position/fit-to-view issue: the sim runs fine in the `clientHeight || 420` fallback, and once the height is 0 the `ResizeObserver` guard (`contentRect.height <= 0 → return`) never re-fits. It is environment/theme-dependent because it hinges on `.view-content` being `display:block` rather than a flex column.

## Fix

Give the mount root a definite height so the chain fills `.view-content`:

```css
.yolo-learning-module-root { height: 100%; }
```

## Verification

Injecting exactly this rule into the running module:

- `.yolo-learning-module-root` 131 → **1152**
- `.yolo-learning-graph-root` 32 → **1053**
- `.yolo-learning-graph-canvas` / `-svg` 0 → **1022**
- all 148 nodes render immediately; the `ResizeObserver` reheats the sim on the 0→1022 resize.

One-line, CSS-only, no behavior change. Fixes the map half of #482.
