### PR TITLE
fix(learning): translate card-generation toast + tolerate mangled card markers

### DIFF
--- a/modules/bundled.json
+++ b/modules/bundled.json
@@ -34,7 +34,7 @@
       "manifestUrl": "https://github.com/Lapis0x0/obsidian-yolo/releases/download/module-learning-v0.1.2-dev.0/module.json",
       "manifest": {
         "byteSize": 1910,
-        "sha256": "360d9bea19b3691ed9b27d17da60f1a374c28e92e8ec083ca63da30cb47787c0"
+        "sha256": "56c1830d7a6cdba241e31e5d429ec465df56674444980f0da490d95b2c2b74d3"
       }
     }
   ]

--- a/modules/learning/src/generation/cardGenerator.test.ts
+++ b/modules/learning/src/generation/cardGenerator.test.ts
@@ -97,6 +97,23 @@ describe('CardStreamParser', () => {
     expect(cards).toHaveLength(1)
     expect(cards[0]?.back).toContain(CARD_END_MARKER)
   })
+
+  it('recovers cards when the model drops the HTML-comment brackets', () => {
+    const cards: CardDraft[] = []
+    const parser = new CardStreamParser(new Set(['aaaaaaaa']), (card) =>
+      cards.push(card),
+    )
+    // Angle brackets dropped on both the kp comment and the end marker.
+    parser.push(
+      '## Predict first !--kp:aaaaaaaa--\n\nWhy predict?\n\n---\n\nTo expose the model.\n\n!--yolo-card-end--\n',
+    )
+    expect(cards).toHaveLength(1)
+    expect(cards[0]).toMatchObject({
+      kpUuid: 'aaaaaaaa',
+      title: 'Predict first',
+    })
+    expect(parser.discardedCount).toBe(0)
+  })
 })
 
 describe('generateCardsForChapter streaming', () => {

--- a/modules/learning/src/generation/cardGenerator.ts
+++ b/modules/learning/src/generation/cardGenerator.ts
@@ -34,10 +34,18 @@ import type {
 
 const KNOWLEDGE_POINT_UUID_RE = /<!--\s*kp:([0-9a-fA-F]{8})\s*-->/g
 const CARD_HEADING_RE = /^##[ \t]+([^\r\n]+)$/gm
-const CARD_KP_UUID_RE = /<!--\s*kp:([0-9a-fA-F]{8})\s*-->/
+const CARD_KP_UUID_RE = /<?!?-{2,}\s*kp:\s*([0-9a-fA-F]{8})\s*-{2,}!?>?/
 const WRITTEN_CARD_COMMENT_RE =
   /<!--\s*card:([0-9a-fA-F]{8})(?:\s+kp:([0-9a-fA-F]{8}))?\s*-->/
 export const CARD_END_MARKER = '<!--yolo-card-end-->'
+
+// Models frequently mangle the HTML-comment markers (dropping the angle
+// brackets or adding whitespace), which otherwise discards every card in the
+// block. Accept the common malformed variants of the standalone end marker.
+const CARD_END_MARKER_RE = /^\s*<?!?-{2,}\s*yolo-card-end\s*-{2,}!?>?\s*$/
+function isCardEndMarker(line: string): boolean {
+  return line === CARD_END_MARKER || CARD_END_MARKER_RE.test(line)
+}
 
 type WrittenCardEntry = CardDraft & { cardUuid: string; block: string }
 type WrittenCardValidation = {
@@ -551,7 +559,7 @@ export class CardStreamParser {
       const rawLine = this.pending.slice(0, newlineIndex)
       this.pending = this.pending.slice(newlineIndex + 1)
       const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
-      if (line === CARD_END_MARKER) this.publishBlock()
+      if (isCardEndMarker(line)) this.publishBlock()
       else this.block += `${line}\n`
       newlineIndex = this.pending.indexOf('\n')
     }
@@ -561,7 +569,7 @@ export class CardStreamParser {
     const line = this.pending.endsWith('\r')
       ? this.pending.slice(0, -1)
       : this.pending
-    if (line === CARD_END_MARKER) this.publishBlock()
+    if (isCardEndMarker(line)) this.publishBlock()
     this.pending = ''
     this.block = ''
   }

--- a/modules/learning/src/host/ui/index.test.ts
+++ b/modules/learning/src/host/ui/index.test.ts
@@ -475,6 +475,34 @@ describe('createLearningUiServices memory host', () => {
     expect(openProjectCards).toHaveBeenCalledWith(projectId, '学习')
   })
 
+  it('uses the existing-cards summary when some chapters were skipped', async () => {
+    const memory = new MemoryLearningHost()
+    memory.agentText = '## Point one\n\nA durable explanation.'
+    const { runtime } = createRuntime()
+    const openProjectCards = jest.fn()
+    generateCardsParallelMock.mockImplementation(async (options) => {
+      const generated = cardResult('generated', [
+        cardEvent(options.runId ?? '', options.projectId ?? '').card,
+      ])
+      const skipped = cardResult('skipped')
+      options.onChapterSettled?.(generated)
+      options.onChapterSettled?.(skipped)
+      return [generated, skipped]
+    })
+    const services = createLearningUiServices(memory.api, {
+      runtime: runtime as never,
+      ownerDocument: {} as Document,
+      generation: { openProjectCards },
+    })
+    await services
+      .createOutlineBuilderWorkflow()
+      .generateProject(projectGenerationInput())
+    expect(memory.actionToasts[0]).toMatchObject({ tone: 'success' })
+    expect(memory.actionToasts[0].message).toBe(
+      'Cards for 2 chapters are ready; 1 new cards were added.',
+    )
+  })
+
   it('reports partial card generation and targets browsing', async () => {
     const memory = new MemoryLearningHost()
     memory.agentText = '## Point one\n\nA durable explanation.'

--- a/modules/learning/src/host/ui/index.test.ts
+++ b/modules/learning/src/host/ui/index.test.ts
@@ -48,6 +48,10 @@ class MemoryLearningHost {
     settings: {
       getModelSnapshot: () => ({ defaultModelId: 'memory-model', models: [] }),
     },
+    i18n: {
+      getSnapshot: () => ({ locale: 'en' }),
+      subscribe: () => () => undefined,
+    },
     agent: {
       stream: (request: { activity?: { title: string; detail?: string } }) => {
         this.agentRequests.push(request)
@@ -465,7 +469,7 @@ describe('createLearningUiServices memory host', () => {
     expect(memory.actionToasts).toHaveLength(1)
     expect(memory.actionToasts[0]).toMatchObject({
       tone: 'success',
-      actionLabel: '开始学习',
+      actionLabel: 'Start learning',
     })
     await memory.actionToasts[0].onAction()
     expect(openProjectCards).toHaveBeenCalledWith(projectId, '学习')
@@ -506,7 +510,7 @@ describe('createLearningUiServices memory host', () => {
     )
     expect(memory.actionToasts[0]).toMatchObject({
       tone: 'warning',
-      actionLabel: '浏览卡片',
+      actionLabel: 'Browse cards',
     })
     await memory.actionToasts[0].onAction()
     expect(openProjectCards).toHaveBeenCalledWith(
@@ -533,7 +537,7 @@ describe('createLearningUiServices memory host', () => {
 
     expect(memory.actionToasts[0]).toMatchObject({
       tone: 'error',
-      actionLabel: '浏览卡片',
+      actionLabel: 'Browse cards',
     })
     await memory.actionToasts[0].onAction()
     expect(openProjectCards).toHaveBeenCalledWith(

--- a/modules/learning/src/host/ui/index.ts
+++ b/modules/learning/src/host/ui/index.ts
@@ -24,6 +24,7 @@ import {
   validateReferenceFile,
   writeReferenceToStaging,
 } from '../../generation/referenceStaging'
+import { createLearningTranslation } from '../../i18n'
 import type { CardsViewServices } from '../../ui/cards/CardsView'
 import type { ExercisesViewServices } from '../../ui/exercises/ExercisesView'
 import type { HomeProjectActions } from '../../ui/home/HomeView'
@@ -487,6 +488,10 @@ function buildOutlineBuilderWorkflow({
               (total, result) => total + result.cards.length,
               0,
             ),
+            chapterCount: results.length,
+            notFinishedCount: results.filter(
+              (result) => result.status !== 'generated',
+            ).length,
           })
         } catch (error) {
           if (!input.signal.aborted) {
@@ -497,6 +502,8 @@ function buildOutlineBuilderWorkflow({
               runId,
               outcome: 'failed',
               cardCount: 0,
+              chapterCount: 0,
+              notFinishedCount: 0,
             })
           }
           throw error
@@ -538,6 +545,8 @@ function showCardGenerationToast({
   runId,
   outcome,
   cardCount,
+  chapterCount,
+  notFinishedCount,
 }: {
   host: YoloModuleHostApiV1
   projectGeneration?: LearningUiProjectGenerationPort
@@ -545,31 +554,39 @@ function showCardGenerationToast({
   runId: string
   outcome: 'success' | 'partial' | 'failed'
   cardCount: number
+  chapterCount: number
+  notFinishedCount: number
 }): void {
+  const t = createLearningTranslation(host.i18n.getSnapshot().locale)
   const mode = outcome === 'success' ? '学习' : '浏览'
   const copy =
     outcome === 'success'
       ? {
           tone: 'success' as const,
-          title: '学习卡片生成完成',
-          message: `已生成 ${cardCount} 张卡片，可以开始学习。`,
+          title: t('cards.generationCompleteTitle'),
+          message: t('cards.generationCompleteSummary')
+            .replace('{chapters}', String(chapterCount))
+            .replace('{cards}', String(cardCount)),
         }
       : outcome === 'partial'
         ? {
             tone: 'warning' as const,
-            title: '部分学习卡片生成完成',
-            message: `已保留 ${cardCount} 张可用卡片，可先浏览生成结果。`,
+            title: t('cards.generationPartialTitle'),
+            message: t('cards.generationPartialSummary')
+              .replace('{cards}', String(cardCount))
+              .replace('{count}', String(notFinishedCount)),
           }
         : {
             tone: 'error' as const,
-            title: '学习卡片生成失败',
-            message: '未能生成可用卡片，请稍后重试。',
+            title: t('cards.generationFailedTitle'),
+            message: t('cards.generationFailedSummary'),
           }
   host.ui.showActionToast({
     id: `card-generation-${runId}`,
     ...copy,
-    actionLabel: mode === '学习' ? '开始学习' : '浏览卡片',
-    dismissLabel: '关闭',
+    actionLabel:
+      outcome === 'success' ? t('cards.startLearning') : t('cards.browseCards'),
+    dismissLabel: t('common.close'),
     onAction: () => projectGeneration?.openProjectCards?.(projectId, mode),
   })
 }

--- a/modules/learning/src/host/ui/index.ts
+++ b/modules/learning/src/host/ui/index.ts
@@ -488,9 +488,15 @@ function buildOutlineBuilderWorkflow({
               (total, result) => total + result.cards.length,
               0,
             ),
-            chapterCount: results.length,
+            generatedCount: results.filter(
+              (result) => result.status === 'generated',
+            ).length,
+            skippedCount: results.filter(
+              (result) => result.status === 'skipped',
+            ).length,
             notFinishedCount: results.filter(
-              (result) => result.status !== 'generated',
+              (result) =>
+                result.status === 'partial' || result.status === 'failed',
             ).length,
           })
         } catch (error) {
@@ -502,7 +508,8 @@ function buildOutlineBuilderWorkflow({
               runId,
               outcome: 'failed',
               cardCount: 0,
-              chapterCount: 0,
+              generatedCount: 0,
+              skippedCount: 0,
               notFinishedCount: 0,
             })
           }
@@ -545,7 +552,8 @@ function showCardGenerationToast({
   runId,
   outcome,
   cardCount,
-  chapterCount,
+  generatedCount,
+  skippedCount,
   notFinishedCount,
 }: {
   host: YoloModuleHostApiV1
@@ -554,20 +562,29 @@ function showCardGenerationToast({
   runId: string
   outcome: 'success' | 'partial' | 'failed'
   cardCount: number
-  chapterCount: number
+  generatedCount: number
+  skippedCount: number
   notFinishedCount: number
 }): void {
   const t = createLearningTranslation(host.i18n.getSnapshot().locale)
   const mode = outcome === 'success' ? '学习' : '浏览'
   const copy =
     outcome === 'success'
-      ? {
-          tone: 'success' as const,
-          title: t('cards.generationCompleteTitle'),
-          message: t('cards.generationCompleteSummary')
-            .replace('{chapters}', String(chapterCount))
-            .replace('{cards}', String(cardCount)),
-        }
+      ? skippedCount > 0
+        ? {
+            tone: 'success' as const,
+            title: t('cards.generationCompleteTitle'),
+            message: t('cards.generationExistingSummary')
+              .replace('{chapters}', String(generatedCount + skippedCount))
+              .replace('{cards}', String(cardCount)),
+          }
+        : {
+            tone: 'success' as const,
+            title: t('cards.generationCompleteTitle'),
+            message: t('cards.generationCompleteSummary')
+              .replace('{chapters}', String(generatedCount))
+              .replace('{cards}', String(cardCount)),
+          }
       : outcome === 'partial'
         ? {
             tone: 'warning' as const,

--- a/modules/learning/src/i18n/en.ts
+++ b/modules/learning/src/i18n/en.ts
@@ -279,6 +279,7 @@ export const en = {
     generationFailedSummary:
       'No learning cards were generated. View the chapter status for details.',
     startLearning: 'Start learning',
+    browseCards: 'Browse cards',
     viewGenerationDetails: 'View details',
     filteredTo: 'Filtered to: ',
     sortDue: 'Due date',

--- a/modules/learning/src/i18n/it.ts
+++ b/modules/learning/src/i18n/it.ts
@@ -281,6 +281,7 @@ export const it = {
     generationFailedSummary:
       'Nessuna carta è stata generata. Controlla lo stato dei capitoli.',
     startLearning: 'Inizia a studiare',
+    browseCards: 'Sfoglia le carte',
     viewGenerationDetails: 'Vedi dettagli',
     filteredTo: 'Filtrato su: ',
     sortDue: 'Scadenza',

--- a/modules/learning/src/i18n/zh.ts
+++ b/modules/learning/src/i18n/zh.ts
@@ -269,6 +269,7 @@ export const zh = {
     generationFailedTitle: '学习卡片生成失败',
     generationFailedSummary: '未能生成学习卡片，请查看章节状态。',
     startLearning: '开始学习',
+    browseCards: '浏览卡片',
     viewGenerationDetails: '查看详情',
     filteredTo: '已筛选至：',
     sortDue: '按到期时间',


### PR DESCRIPTION
Two card-generation issues found while generating a fresh Standard-mode project end-to-end. Both are in `modules/learning`; happy to split into two PRs if you prefer.

## 1. Card-generation toast is hardcoded Chinese (`fix(learning): translate card-generation toast via i18n`)

`showCardGenerationToast` in `host/ui/index.ts` hardcodes Chinese for **all** outcomes — title, message, `actionLabel`, and `dismissLabel` — and even derives `mode` by comparing to the literal `'学习'`. So English/Italian users always see Chinese on card completion/partial/failure, even though the `cards.*` keys (`generationCompleteTitle`, `generationFailedTitle`, `startLearning`, …) already exist in all three locales but were never wired up.

Fix: build a translator with `createLearningTranslation(host.i18n.getSnapshot().locale)` (same pattern as `host/runtime.ts`) and use the existing keys; add the one missing key `cards.browseCards`. The internal `mode` value (`'学习' | '浏览'`) is preserved for `openProjectCards`, which is typed to it — only the displayed labels are translated. The existing host tests now assert English labels (regression guard).

## 2. Card generation discards everything when the model mangles the comment markers (`fix(learning): tolerate mangled card HTML-comment markers`)

Reproduced the failure a user hit (all chapters → "No valid cards remained", empty `cards.md`). Feeding this chapter's `knowledge.md` back through a capable model with the card prompt, the model **copies the kp UUIDs correctly** but emits the HTML comments without the angle brackets (`!--kp:xxxxxxxx--`, `!--yolo-card-end--`). Because `CardStreamParser` requires `line === CARD_END_MARKER` exactly and `CARD_KP_UUID_RE` requires strict `<!--kp:…-->`, every card in the stream is silently discarded and the chapter fails with zero cards.

Fix: match the standalone end marker tolerantly (`isCardEndMarker`, anchored so embedded markers in card bodies still don't terminate a block) and broaden the kp-comment regex to accept the common malformed variants (dropped brackets, extra whitespace). Strict, well-formed output is unaffected; a regression test covers the mangled-marker recovery.

## Validation

- `module:typecheck` (tsc) — pass
- `prettier:check` + eslint — pass
- `jest modules/learning` — **262 passed** (incl. the new toast-English and marker-tolerance tests)

Context: these surfaced while validating #480/#481 (language) on a real generation; the language side is now correct end-to-end, and these were the remaining rough edges in the card step.
