### PR TITLE
fix(learning): translate remaining hardcoded Chinese (delete dialog, activity titles, upload errors)

### DIFF
--- a/modules/bundled.json
+++ b/modules/bundled.json
@@ -34,7 +34,7 @@
       "manifestUrl": "https://github.com/Lapis0x0/obsidian-yolo/releases/download/module-learning-v0.1.2-dev.0/module.json",
       "manifest": {
         "byteSize": 1910,
-        "sha256": "56c1830d7a6cdba241e31e5d429ec465df56674444980f0da490d95b2c2b74d3"
+        "sha256": "efdf3cefa50a9b8eda2a9b98c06fb38bdc87479fecc802051b73664c28a23e40"
       }
     }
   ]

--- a/modules/learning/src/generation/referenceStaging.ts
+++ b/modules/learning/src/generation/referenceStaging.ts
@@ -1,18 +1,27 @@
 import { normalizeLearningVaultPath } from '../domain/learningVaultReadApi'
 import type { LearningVaultWriteApi } from '../domain/learningVaultWriteApi'
+import type { LearningTranslation } from '../i18n'
 
 export type StagedReference = { name: string; vaultPath: string }
 
 const MAX_FILE_SIZE = 20 * 1024 * 1024
 const ALLOWED_EXTENSIONS = ['.pdf', '.docx', '.doc', '.md', '.markdown', '.txt']
 
-export function validateReferenceFile(file: File): string | null {
+export function validateReferenceFile(
+  file: File,
+  t?: LearningTranslation,
+): string | null {
   const ext = file.name.toLowerCase().match(/\.[^.]+$/)?.[0] ?? ''
   if (!ALLOWED_EXTENSIONS.includes(ext)) {
-    return `不支持的文件类型：${ext}（支持 PDF、Word、Markdown、文本）`
+    return t
+      ? t('generation.unsupportedFileType').replace('{ext}', ext)
+      : `Unsupported file type: ${ext} (PDF, Word, Markdown, text supported)`
   }
   if (file.size > MAX_FILE_SIZE) {
-    return `文件过大：${(file.size / 1024 / 1024).toFixed(1)}MB（上限 20MB）`
+    const size = (file.size / 1024 / 1024).toFixed(1)
+    return t
+      ? t('generation.fileTooLarge').replace('{size}', size)
+      : `File too large: ${size}MB (max 20MB)`
   }
   return null
 }

--- a/modules/learning/src/generation/referenceStaging.ts
+++ b/modules/learning/src/generation/referenceStaging.ts
@@ -9,19 +9,15 @@ const ALLOWED_EXTENSIONS = ['.pdf', '.docx', '.doc', '.md', '.markdown', '.txt']
 
 export function validateReferenceFile(
   file: File,
-  t?: LearningTranslation,
+  t: LearningTranslation,
 ): string | null {
   const ext = file.name.toLowerCase().match(/\.[^.]+$/)?.[0] ?? ''
   if (!ALLOWED_EXTENSIONS.includes(ext)) {
-    return t
-      ? t('generation.unsupportedFileType').replace('{ext}', ext)
-      : `Unsupported file type: ${ext} (PDF, Word, Markdown, text supported)`
+    return t('generation.unsupportedFileType').replace('{ext}', ext)
   }
   if (file.size > MAX_FILE_SIZE) {
     const size = (file.size / 1024 / 1024).toFixed(1)
-    return t
-      ? t('generation.fileTooLarge').replace('{size}', size)
-      : `File too large: ${size}MB (max 20MB)`
+    return t('generation.fileTooLarge').replace('{size}', size)
   }
   return null
 }

--- a/modules/learning/src/host/runtime.ts
+++ b/modules/learning/src/host/runtime.ts
@@ -3,7 +3,7 @@ import { LearningRuntime } from '../domain/runtime/learningRuntime'
 import type { LearningRuntimePorts } from '../domain/runtime/ports'
 import { LearningSrsStore } from '../domain/srs/srsStore'
 import { LearningStatsService } from '../domain/stats/learningStatsService'
-import { createLearningTranslation } from '../i18n'
+import { type LearningTranslation, createLearningTranslation } from '../i18n'
 
 import { createHostLearningBackgroundPort } from './background'
 import { createOwnerLearningLifecyclePorts } from './lifecycle'
@@ -30,7 +30,7 @@ export type HostLearningRuntimeAdapter = Readonly<{
 
 export function createHostLearningTranslation(
   host: Pick<YoloModuleHostApiV1, 'i18n'>,
-): (keyPath: string, fallback: string) => string {
+): LearningTranslation {
   return (keyPath, fallback) =>
     createLearningTranslation(host.i18n.getSnapshot().locale)(keyPath, fallback)
 }

--- a/modules/learning/src/host/ui/index.test.ts
+++ b/modules/learning/src/host/ui/index.test.ts
@@ -342,7 +342,7 @@ describe('createLearningUiServices memory host', () => {
     expect(onOutline).toHaveBeenCalled()
     expect(onProgress).toHaveBeenCalled()
     expect(memory.agentRequests[0]?.activity).toEqual({
-      title: '正在生成学习项目大纲',
+      title: 'Generating outline',
       detail: 'Adapters',
     })
   })
@@ -397,7 +397,7 @@ describe('createLearningUiServices memory host', () => {
       memory.api.vault.readText(knowledge?.path ?? ''),
     ).resolves.toContain('## Point one <!--kp:')
     expect(memory.agentRequests[0]?.activity).toEqual({
-      title: '正在生成学习项目',
+      title: 'Generating knowledge points',
       detail: 'Chapter one',
     })
     expect(memory.agentRequests).toHaveLength(2)
@@ -461,7 +461,7 @@ describe('createLearningUiServices memory host', () => {
         runId,
         projectId,
         activity: expect.objectContaining({
-          title: '正在生成学习卡片',
+          title: 'Generating cards',
           detail: 'Generated',
         }),
       }),

--- a/modules/learning/src/host/ui/index.test.ts
+++ b/modules/learning/src/host/ui/index.test.ts
@@ -20,6 +20,7 @@ type HostTextSnapshot = NonNullable<
 
 class MemoryLearningHost {
   contentRoot = 'First/learning'
+  locale = 'en'
   agentText = JSON.stringify({
     projectName: 'Memory project',
     projectGoal: 'Test adapters',
@@ -49,7 +50,7 @@ class MemoryLearningHost {
       getModelSnapshot: () => ({ defaultModelId: 'memory-model', models: [] }),
     },
     i18n: {
-      getSnapshot: () => ({ locale: 'en' }),
+      getSnapshot: () => ({ locale: this.locale }),
       subscribe: () => () => undefined,
     },
     agent: {
@@ -345,6 +346,30 @@ describe('createLearningUiServices memory host', () => {
       title: 'Generating outline',
       detail: 'Adapters',
     })
+  })
+
+  it('uses the current locale when a long-lived workflow starts', async () => {
+    const memory = new MemoryLearningHost()
+    const { runtime } = createRuntime()
+    const services = createLearningUiServices(memory.api, {
+      runtime: runtime as never,
+      ownerDocument: {} as Document,
+      generation: { generateCards: false },
+    })
+    memory.locale = 'zh-CN'
+
+    await services.outlineBuilderWorkflow.generateOutline({
+      topic: 'Adapters',
+      level: 'familiar',
+      goal: 'Ship',
+      signal: new AbortController().signal,
+      onOutline: jest.fn(),
+      onProgress: jest.fn(),
+    })
+
+    expect(memory.agentRequests[0]?.activity?.title).toBe(
+      '正在生成学习项目大纲',
+    )
   })
 
   it('writes a project from the knowledge generation stream', async () => {

--- a/modules/learning/src/host/ui/index.ts
+++ b/modules/learning/src/host/ui/index.ts
@@ -24,7 +24,6 @@ import {
   validateReferenceFile,
   writeReferenceToStaging,
 } from '../../generation/referenceStaging'
-import { createLearningTranslation } from '../../i18n'
 import type { CardsViewServices } from '../../ui/cards/CardsView'
 import type { ExercisesViewServices } from '../../ui/exercises/ExercisesView'
 import type { HomeProjectActions } from '../../ui/home/HomeView'
@@ -32,7 +31,10 @@ import type { LearningWorkspaceGenerationEvents } from '../../ui/LearningWorkspa
 import type { OutlineBuilderWorkflow } from '../../ui/outline/OutlineBuilder'
 import type { OutlineViewHost } from '../../ui/outline/OutlineView'
 import type { WizardReferenceHost } from '../../ui/wizard/Wizard'
-import type { HostLearningRuntimeAdapter } from '../runtime'
+import {
+  type HostLearningRuntimeAdapter,
+  createHostLearningTranslation,
+} from '../runtime'
 
 type Runtime = HostLearningRuntimeAdapter['runtime']
 
@@ -91,6 +93,7 @@ export function createLearningUiServices(
   host: YoloModuleHostApiV1,
   options: CreateLearningUiServicesOptions,
 ): LearningUiServices {
+  const t = createHostLearningTranslation(host)
   const vault = createHostLearningVaultReadApi(host.vault)
   const hostWriter = createHostLearningVaultWriteApi(host.vault)
   const cardFiles = new LearningCardFileStore(vault, hostWriter)
@@ -154,7 +157,6 @@ export function createLearningUiServices(
       }
     },
     confirmDelete: (project, onConfirm) => {
-      const t = createLearningTranslation(host.i18n.getSnapshot().locale)
       void host.ui
         .confirm({
           title: t('home.deleteConfirmTitle'),
@@ -188,11 +190,7 @@ export function createLearningUiServices(
       await host.vault.ensureFolder(path)
       return path
     },
-    validateFile: (file) =>
-      validateReferenceFile(
-        file,
-        createLearningTranslation(host.i18n.getSnapshot().locale),
-      ),
+    validateFile: (file) => validateReferenceFile(file, t),
     writeFile: async (stagingDir, file) => {
       assertPathInRoot(stagingDir, getLearningBaseDir(), '_staging')
       return writeReferenceToStaging(
@@ -317,7 +315,7 @@ function buildOutlineBuilderWorkflow({
   events?: LearningWorkspaceGenerationEvents
 }): OutlineBuilderWorkflow {
   const vault = generationHost.vault
-  const t = createLearningTranslation(host.i18n.getSnapshot().locale)
+  const t = createHostLearningTranslation(host)
   const writer: ProjectWriterPort = {
     ensureFolder: (path) => host.vault.ensureFolder(path),
     listChildNames: async (path) =>
@@ -581,7 +579,7 @@ function showCardGenerationToast({
   skippedCount: number
   notFinishedCount: number
 }): void {
-  const t = createLearningTranslation(host.i18n.getSnapshot().locale)
+  const t = createHostLearningTranslation(host)
   const mode = outcome === 'success' ? '学习' : '浏览'
   const copy =
     outcome === 'success'

--- a/modules/learning/src/host/ui/index.ts
+++ b/modules/learning/src/host/ui/index.ts
@@ -154,12 +154,16 @@ export function createLearningUiServices(
       }
     },
     confirmDelete: (project, onConfirm) => {
+      const t = createLearningTranslation(host.i18n.getSnapshot().locale)
       void host.ui
         .confirm({
-          title: '删除学习项目？',
-          message: `“${project.topic}”及其复习数据将移入回收站。`,
-          ctaText: '删除',
-          cancelText: '取消',
+          title: t('home.deleteConfirmTitle'),
+          message: t('home.deleteConfirmMessage').replace(
+            '{project}',
+            project.topic,
+          ),
+          ctaText: t('common.delete'),
+          cancelText: t('common.cancel'),
         })
         .then((confirmed) => {
           if (confirmed) onConfirm()
@@ -184,7 +188,11 @@ export function createLearningUiServices(
       await host.vault.ensureFolder(path)
       return path
     },
-    validateFile: validateReferenceFile,
+    validateFile: (file) =>
+      validateReferenceFile(
+        file,
+        createLearningTranslation(host.i18n.getSnapshot().locale),
+      ),
     writeFile: async (stagingDir, file) => {
       assertPathInRoot(stagingDir, getLearningBaseDir(), '_staging')
       return writeReferenceToStaging(
@@ -309,6 +317,7 @@ function buildOutlineBuilderWorkflow({
   events?: LearningWorkspaceGenerationEvents
 }): OutlineBuilderWorkflow {
   const vault = generationHost.vault
+  const t = createLearningTranslation(host.i18n.getSnapshot().locale)
   const writer: ProjectWriterPort = {
     ensureFolder: (path) => host.vault.ensureFolder(path),
     listChildNames: async (path) =>
@@ -339,7 +348,10 @@ function buildOutlineBuilderWorkflow({
         })),
         workspaceScope,
         abortSignal: input.signal,
-        activity: generationActivity('正在生成学习项目大纲', input.topic),
+        activity: generationActivity(
+          t('generation.outlineActivity'),
+          input.topic,
+        ),
         onOutline: input.onOutline,
         onProgress: () => input.onProgress(),
       })
@@ -394,7 +406,10 @@ function buildOutlineBuilderWorkflow({
               workspaceScope,
               referenceDir,
               abortSignal: input.signal,
-              activity: generationActivity('正在生成学习项目', chapter.title),
+              activity: generationActivity(
+                t('generation.knowledgePointsActivity'),
+                chapter.title,
+              ),
               onProgress: (_delta, fullText) => {
                 input.onChapterProgress({
                   chapterIndex,
@@ -463,7 +478,7 @@ function buildOutlineBuilderWorkflow({
             workspaceScope,
             abortSignal: input.signal,
             activity: generationActivity(
-              '正在生成学习卡片',
+              t('generation.cardsActivity'),
               input.projectName || input.topic,
             ),
             runId,

--- a/modules/learning/src/i18n/en.ts
+++ b/modules/learning/src/i18n/en.ts
@@ -9,6 +9,14 @@ export const en = {
     generationModelDescription:
       'Used to generate outlines, knowledge points, and cards. This selection is independent of the current assistant.',
   },
+  generation: {
+    outlineActivity: 'Generating outline',
+    knowledgePointsActivity: 'Generating knowledge points',
+    cardsActivity: 'Generating cards',
+    unsupportedFileType:
+      'Unsupported file type: {ext} (PDF, Word, Markdown, text supported)',
+    fileTooLarge: 'File too large: {size}MB (max 20MB)',
+  },
   background: {
     reviewTitle: 'YOLO Learning',
     reviewDetail: '{count} cards to review',

--- a/modules/learning/src/i18n/it.ts
+++ b/modules/learning/src/i18n/it.ts
@@ -9,6 +9,14 @@ export const it = {
     generationModelDescription:
       'Usato per generare scalette, punti di conoscenza e schede. Questa scelta è indipendente dall’assistente corrente.',
   },
+  generation: {
+    outlineActivity: 'Generazione della struttura',
+    knowledgePointsActivity: 'Generazione dei punti di conoscenza',
+    cardsActivity: 'Generazione delle carte',
+    unsupportedFileType:
+      'Tipo di file non supportato: {ext} (supportati PDF, Word, Markdown, testo)',
+    fileTooLarge: 'File troppo grande: {size}MB (limite 20MB)',
+  },
   background: {
     reviewTitle: 'YOLO Learning',
     reviewDetail: '{count} carte da ripassare',

--- a/modules/learning/src/i18n/zh.ts
+++ b/modules/learning/src/i18n/zh.ts
@@ -9,6 +9,14 @@ export const zh = {
     generationModelDescription:
       '用于生成大纲、知识点和卡片；此选择独立于当前助理模型。',
   },
+  generation: {
+    outlineActivity: '正在生成学习项目大纲',
+    knowledgePointsActivity: '正在生成学习项目',
+    cardsActivity: '正在生成学习卡片',
+    unsupportedFileType:
+      '不支持的文件类型：{ext}（支持 PDF、Word、Markdown、文本）',
+    fileTooLarge: '文件过大：{size}MB（上限 20MB）',
+  },
   background: {
     reviewTitle: 'YOLO Learning',
     reviewDetail: '{count} 张卡片待复习',


### PR DESCRIPTION
While auditing the Learning module for hardcoded Chinese after the card-toast fix (#486), I found three more user-facing strings that bypass i18n, so English/Italian users see Chinese:

1. **Delete-project confirm dialog** (`host/ui/index.ts`) — `title` / `message` / `ctaText` / `cancelText` were hardcoded (`删除学习项目？`, …). Routed through `t()` using the existing `home.deleteConfirmTitle` / `home.deleteConfirmMessage` (`{project}`) and `common.delete` / `common.cancel`.
2. **Generation activity titles** — `正在生成学习项目大纲` / `正在生成学习项目` / `正在生成学习卡片`, shown in the activity indicator during outline / knowledge-point / card generation. Added a `generation.*` namespace (`outlineActivity`, `knowledgePointsActivity`, `cardsActivity`) in en/zh/it and wired the call sites through `t()`.
3. **Reference upload validation** (`generation/referenceStaging.ts`) — the "unsupported file type" and "file too large" errors were hardcoded. `validateReferenceFile` now takes an optional translator (`generation.unsupportedFileType {ext}`, `generation.fileTooLarge {size}`) with an English fallback when none is supplied, and the host service passes one in.

The Chinese wording is preserved verbatim as the `zh` values, so Chinese output is unchanged; Italian is translated to match.

**Validation:** `module:typecheck`, `prettier:check`, eslint, and `jest modules/learning` (262 tests) all pass. The mock host gains an `i18n` stub and the three activity-title assertions now expect English.

**Note on overlap:** this and #486 both add `import { createLearningTranslation } from '../../i18n'` to `host/ui/index.ts`. Whichever merges first, I'll rebase the other to drop the duplicate import — happy to reorder or fold them together if you'd prefer.
