### PR TITLE
[auto-triage] Target the last active note for chat insertion (#488)

### DIFF
--- a/src/components/chat-view/AssistantToolMessageGroupActions.tsx
+++ b/src/components/chat-view/AssistantToolMessageGroupActions.tsx
@@ -12,8 +12,8 @@ import { Notice, htmlToMarkdown } from 'obsidian'
 import type { ReactNode, Ref } from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { useApp } from '../../contexts/app-context'
 import { useLanguage } from '../../contexts/language-context'
+import { usePlugin } from '../../contexts/plugin-context'
 import {
   AssistantToolMessageGroup,
   ChatAssistantMessage,
@@ -25,7 +25,6 @@ import {
   hasLLMDebugCacheForTraceIds,
   hasLLMDebugMetadataForMessages,
 } from './LLMDebugButton'
-import { getMarkdownInsertionTarget } from './markdownInsertionTarget'
 import { getToolMessageContent } from './ToolMessage'
 
 function ActionIconButton({
@@ -111,7 +110,7 @@ function CopyButton({ messages }: { messages: AssistantToolMessageGroup }) {
 }
 
 function InsertButton({ messages }: { messages: AssistantToolMessageGroup }) {
-  const app = useApp()
+  const plugin = usePlugin()
   const { t } = useLanguage()
   const buttonRef = useRef<HTMLButtonElement | null>(null)
   const content = useMemo(() => {
@@ -179,10 +178,7 @@ function InsertButton({ messages }: { messages: AssistantToolMessageGroup }) {
       return
     }
 
-    const markdownView = getMarkdownInsertionTarget(
-      app.workspace,
-      buttonRef.current?.ownerDocument,
-    )
+    const markdownView = plugin.getMarkdownInsertionTarget()
 
     if (!markdownView) {
       new Notice(t('chat.insertUnavailable', 'No active markdown editor found'))

--- a/src/components/chat-view/AssistantToolMessageGroupActions.tsx
+++ b/src/components/chat-view/AssistantToolMessageGroupActions.tsx
@@ -8,7 +8,7 @@ import {
   RotateCcw,
   Trash2,
 } from 'lucide-react'
-import { MarkdownView, Notice, htmlToMarkdown } from 'obsidian'
+import { Notice, htmlToMarkdown } from 'obsidian'
 import type { ReactNode, Ref } from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
@@ -25,6 +25,7 @@ import {
   hasLLMDebugCacheForTraceIds,
   hasLLMDebugMetadataForMessages,
 } from './LLMDebugButton'
+import { getMarkdownInsertionTarget } from './markdownInsertionTarget'
 import { getToolMessageContent } from './ToolMessage'
 
 function ActionIconButton({
@@ -178,24 +179,10 @@ function InsertButton({ messages }: { messages: AssistantToolMessageGroup }) {
       return
     }
 
-    const activeMarkdownView = app.workspace.getActiveViewOfType(MarkdownView)
-    const recentLeaf = app.workspace.getMostRecentLeaf()
-    const recentMarkdownView =
-      recentLeaf?.view instanceof MarkdownView ? recentLeaf.view : null
-    const fallbackMarkdownView = (() => {
-      if (activeMarkdownView || recentMarkdownView) {
-        return null
-      }
-      const markdownLeaves = app.workspace.getLeavesOfType('markdown')
-      const visibleLeaf =
-        markdownLeaves.find((leaf) => {
-          const el = (leaf.view as { containerEl?: HTMLElement }).containerEl
-          return el ? isElementVisible(el) : true
-        }) ?? markdownLeaves[0]
-      return visibleLeaf?.view instanceof MarkdownView ? visibleLeaf.view : null
-    })()
-    const markdownView =
-      activeMarkdownView ?? recentMarkdownView ?? fallbackMarkdownView
+    const markdownView = getMarkdownInsertionTarget(
+      app.workspace,
+      buttonRef.current?.ownerDocument,
+    )
 
     if (!markdownView) {
       new Notice(t('chat.insertUnavailable', 'No active markdown editor found'))
@@ -223,14 +210,6 @@ function InsertButton({ messages }: { messages: AssistantToolMessageGroup }) {
       <Import size={12} />
     </ActionIconButton>
   )
-}
-
-function isElementVisible(el: HTMLElement): boolean {
-  const maybeIsShown = (el as HTMLElement & { isShown?: unknown }).isShown
-  if (typeof maybeIsShown === 'function') {
-    return maybeIsShown.call(el) as boolean
-  }
-  return el.offsetParent !== null || el.getClientRects().length > 0
 }
 
 export default function AssistantToolMessageGroupActions({

--- a/src/components/chat-view/markdownInsertionTarget.test.ts
+++ b/src/components/chat-view/markdownInsertionTarget.test.ts
@@ -1,0 +1,118 @@
+jest.mock('obsidian', () => ({
+  MarkdownView: class MarkdownView {},
+}))
+
+import { MarkdownView } from 'obsidian'
+import type { TFile, Workspace } from 'obsidian'
+
+import { getMarkdownInsertionTarget } from './markdownInsertionTarget'
+
+type InsertionWorkspace = Pick<
+  Workspace,
+  'getActiveViewOfType' | 'getLeavesOfType'
+> & { lastActiveFile?: TFile | null }
+
+function createMarkdownView({
+  path,
+  ownerDocument,
+  visible = true,
+}: {
+  path: string
+  ownerDocument: Document
+  visible?: boolean
+}): MarkdownView {
+  return Object.assign(Object.create(MarkdownView.prototype), {
+    file: { path },
+    containerEl: {
+      ownerDocument,
+      isShown: () => visible,
+    },
+  }) as MarkdownView
+}
+
+function createWorkspace({
+  lastActivePath,
+  views,
+  activeView = null,
+}: {
+  lastActivePath: string | null
+  views: MarkdownView[]
+  activeView?: MarkdownView | null
+}): InsertionWorkspace {
+  return {
+    lastActiveFile: lastActivePath ? { path: lastActivePath } : null,
+    getLeavesOfType: () => views.map((view) => ({ view })),
+    getActiveViewOfType: () => activeView,
+  } as unknown as InsertionWorkspace
+}
+
+describe('getMarkdownInsertionTarget', () => {
+  it('uses the visible view for the last active file instead of the first markdown leaf', () => {
+    const mainWindow = {} as Document
+    const popoutWindow = {} as Document
+    const firstMainView = createMarkdownView({
+      path: 'main.md',
+      ownerDocument: mainWindow,
+    })
+    const lastActivePopoutView = createMarkdownView({
+      path: 'popout.md',
+      ownerDocument: popoutWindow,
+    })
+
+    const target = getMarkdownInsertionTarget(
+      createWorkspace({
+        lastActivePath: 'popout.md',
+        views: [firstMainView, lastActivePopoutView],
+      }),
+      popoutWindow,
+    )
+
+    expect(target).toBe(lastActivePopoutView)
+  })
+
+  it('prefers the last active file view in the chat window when it is open in multiple windows', () => {
+    const mainWindow = {} as Document
+    const popoutWindow = {} as Document
+    const mainView = createMarkdownView({
+      path: 'shared.md',
+      ownerDocument: mainWindow,
+    })
+    const popoutView = createMarkdownView({
+      path: 'shared.md',
+      ownerDocument: popoutWindow,
+    })
+
+    const target = getMarkdownInsertionTarget(
+      createWorkspace({
+        lastActivePath: 'shared.md',
+        views: [mainView, popoutView],
+      }),
+      popoutWindow,
+    )
+
+    expect(target).toBe(popoutView)
+  })
+
+  it('does not insert into an unrelated visible note when the last active view is hidden', () => {
+    const mainWindow = {} as Document
+    const hiddenLastActiveView = createMarkdownView({
+      path: 'last-active.md',
+      ownerDocument: mainWindow,
+      visible: false,
+    })
+    const unrelatedVisibleView = createMarkdownView({
+      path: 'unrelated.md',
+      ownerDocument: mainWindow,
+    })
+
+    const target = getMarkdownInsertionTarget(
+      createWorkspace({
+        lastActivePath: 'last-active.md',
+        views: [unrelatedVisibleView, hiddenLastActiveView],
+      }),
+      mainWindow,
+    )
+
+    expect(target).toBeNull()
+  })
+})

--- a/src/components/chat-view/markdownInsertionTarget.test.ts
+++ b/src/components/chat-view/markdownInsertionTarget.test.ts
@@ -3,116 +3,103 @@ jest.mock('obsidian', () => ({
 }))
 
 import { MarkdownView } from 'obsidian'
-import type { TFile, Workspace } from 'obsidian'
+import type { Workspace, WorkspaceLeaf } from 'obsidian'
 
-import { getMarkdownInsertionTarget } from './markdownInsertionTarget'
+import { MarkdownInsertionTargetTracker } from './markdownInsertionTarget'
 
 type InsertionWorkspace = Pick<
   Workspace,
   'getActiveViewOfType' | 'getLeavesOfType'
-> & { lastActiveFile?: TFile | null }
+>
 
 function createMarkdownView({
   path,
-  ownerDocument,
   visible = true,
 }: {
   path: string
-  ownerDocument: Document
   visible?: boolean
 }): MarkdownView {
   return Object.assign(Object.create(MarkdownView.prototype), {
     file: { path },
     containerEl: {
-      ownerDocument,
       isShown: () => visible,
     },
   }) as MarkdownView
 }
 
+function createLeaf(view: unknown): WorkspaceLeaf {
+  return { view } as WorkspaceLeaf
+}
+
 function createWorkspace({
-  lastActivePath,
-  views,
+  leaves,
   activeView = null,
 }: {
-  lastActivePath: string | null
-  views: MarkdownView[]
+  leaves: WorkspaceLeaf[]
   activeView?: MarkdownView | null
 }): InsertionWorkspace {
   return {
-    lastActiveFile: lastActivePath ? { path: lastActivePath } : null,
-    getLeavesOfType: () => views.map((view) => ({ view })),
+    getLeavesOfType: () => leaves,
     getActiveViewOfType: () => activeView,
   } as unknown as InsertionWorkspace
 }
 
-describe('getMarkdownInsertionTarget', () => {
-  it('uses the visible view for the last active file instead of the first markdown leaf', () => {
-    const mainWindow = {} as Document
-    const popoutWindow = {} as Document
-    const firstMainView = createMarkdownView({
-      path: 'main.md',
-      ownerDocument: mainWindow,
+describe('MarkdownInsertionTargetTracker', () => {
+  it('captures the exact active markdown leaf', () => {
+    const firstView = createMarkdownView({ path: 'shared.md' })
+    const activeView = createMarkdownView({ path: 'shared.md' })
+    const workspace = createWorkspace({
+      leaves: [createLeaf(firstView), createLeaf(activeView)],
+      activeView,
     })
-    const lastActivePopoutView = createMarkdownView({
-      path: 'popout.md',
-      ownerDocument: popoutWindow,
-    })
+    const tracker = new MarkdownInsertionTargetTracker(workspace)
 
-    const target = getMarkdownInsertionTarget(
-      createWorkspace({
-        lastActivePath: 'popout.md',
-        views: [firstMainView, lastActivePopoutView],
-      }),
-      popoutWindow,
-    )
+    tracker.captureCurrentLeaf()
 
-    expect(target).toBe(lastActivePopoutView)
+    expect(tracker.getTarget()).toBe(activeView)
   })
 
-  it('prefers the last active file view in the chat window when it is open in multiple windows', () => {
-    const mainWindow = {} as Document
-    const popoutWindow = {} as Document
-    const mainView = createMarkdownView({
-      path: 'shared.md',
-      ownerDocument: mainWindow,
-    })
-    const popoutView = createMarkdownView({
-      path: 'shared.md',
-      ownerDocument: popoutWindow,
-    })
-
-    const target = getMarkdownInsertionTarget(
-      createWorkspace({
-        lastActivePath: 'shared.md',
-        views: [mainView, popoutView],
-      }),
-      popoutWindow,
+  it('keeps the last markdown leaf when the chat leaf becomes active', () => {
+    const markdownView = createMarkdownView({ path: 'popout.md' })
+    const markdownLeaf = createLeaf(markdownView)
+    const tracker = new MarkdownInsertionTargetTracker(
+      createWorkspace({ leaves: [markdownLeaf] }),
     )
 
-    expect(target).toBe(popoutView)
+    tracker.trackActiveLeaf(markdownLeaf)
+    tracker.trackActiveLeaf(createLeaf({ type: 'chat' }))
+
+    expect(tracker.getTarget()).toBe(markdownView)
   })
 
-  it('does not insert into an unrelated visible note when the last active view is hidden', () => {
-    const mainWindow = {} as Document
-    const hiddenLastActiveView = createMarkdownView({
-      path: 'last-active.md',
-      ownerDocument: mainWindow,
+  it('does not use another leaf for the same file after the target closes', () => {
+    const closedView = createMarkdownView({ path: 'shared.md' })
+    const closedLeaf = createLeaf(closedView)
+    const remainingView = createMarkdownView({ path: 'shared.md' })
+    const remainingLeaf = createLeaf(remainingView)
+    const leaves = [closedLeaf, remainingLeaf]
+    const tracker = new MarkdownInsertionTargetTracker(
+      createWorkspace({ leaves }),
+    )
+
+    tracker.trackActiveLeaf(closedLeaf)
+    leaves.splice(leaves.indexOf(closedLeaf), 1)
+
+    expect(tracker.getTarget()).toBeNull()
+  })
+
+  it('does not return a hidden markdown view', () => {
+    const hiddenView = createMarkdownView({
+      path: 'hidden.md',
       visible: false,
     })
-    const unrelatedVisibleView = createMarkdownView({
-      path: 'unrelated.md',
-      ownerDocument: mainWindow,
-    })
-
-    const target = getMarkdownInsertionTarget(
-      createWorkspace({
-        lastActivePath: 'last-active.md',
-        views: [unrelatedVisibleView, hiddenLastActiveView],
-      }),
-      mainWindow,
+    const hiddenLeaf = createLeaf(hiddenView)
+    const tracker = new MarkdownInsertionTargetTracker(
+      createWorkspace({ leaves: [hiddenLeaf] }),
     )
 
-    expect(target).toBeNull()
+    tracker.trackActiveLeaf(hiddenLeaf)
+
+    expect(tracker.getTarget()).toBeNull()
   })
 })

--- a/src/components/chat-view/markdownInsertionTarget.ts
+++ b/src/components/chat-view/markdownInsertionTarget.ts
@@ -1,55 +1,47 @@
 import { MarkdownView } from 'obsidian'
-import type { TFile, Workspace } from 'obsidian'
+import type { Workspace, WorkspaceLeaf } from 'obsidian'
 
 type InsertionWorkspace = Pick<
   Workspace,
   'getActiveViewOfType' | 'getLeavesOfType'
-> & {
-  lastActiveFile?: TFile | null
-}
+>
 
-export function getMarkdownInsertionTarget(
-  workspace: InsertionWorkspace,
-  ownerDocument: Document | null | undefined,
-): MarkdownView | null {
-  const lastActiveFile = workspace.lastActiveFile
-  const matchingViews = lastActiveFile
-    ? workspace
-        .getLeavesOfType('markdown')
-        .map((leaf) => leaf.view)
-        .filter(
-          (view): view is MarkdownView =>
-            view instanceof MarkdownView &&
-            view.file?.path === lastActiveFile.path &&
-            isMarkdownViewVisible(view),
-        )
-    : []
+export class MarkdownInsertionTargetTracker {
+  private lastActiveMarkdownLeaf: WorkspaceLeaf | null = null
 
-  const sameWindowView = matchingViews.find(
-    (view) => view.containerEl.ownerDocument === ownerDocument,
-  )
-  if (sameWindowView) {
-    return sameWindowView
+  constructor(private readonly workspace: InsertionWorkspace) {}
+
+  captureCurrentLeaf(): void {
+    const activeView = this.workspace.getActiveViewOfType(MarkdownView)
+    if (!activeView) {
+      return
+    }
+
+    const activeLeaf = this.workspace
+      .getLeavesOfType('markdown')
+      .find((leaf) => leaf.view === activeView)
+    this.trackActiveLeaf(activeLeaf ?? null)
   }
 
-  if (matchingViews.length > 0) {
-    return matchingViews[0]
+  trackActiveLeaf(leaf: WorkspaceLeaf | null): void {
+    if (leaf?.view instanceof MarkdownView) {
+      this.lastActiveMarkdownLeaf = leaf
+    }
   }
 
-  const activeMarkdownView = workspace.getActiveViewOfType(MarkdownView)
-  return activeMarkdownView && isMarkdownViewVisible(activeMarkdownView)
-    ? activeMarkdownView
-    : null
-}
+  getTarget(): MarkdownView | null {
+    const trackedLeaf = this.lastActiveMarkdownLeaf
+    if (!trackedLeaf) {
+      return null
+    }
 
-function isMarkdownViewVisible(view: MarkdownView): boolean {
-  const { containerEl } = view
-  const maybeIsShown = (containerEl as HTMLElement & { isShown?: unknown })
-    .isShown
-  if (typeof maybeIsShown === 'function') {
-    return maybeIsShown.call(containerEl) as boolean
+    const openLeaf = this.workspace
+      .getLeavesOfType('markdown')
+      .find((leaf) => leaf === trackedLeaf)
+    if (!(openLeaf?.view instanceof MarkdownView)) {
+      return null
+    }
+
+    return openLeaf.view.containerEl.isShown() ? openLeaf.view : null
   }
-  return (
-    containerEl.offsetParent !== null || containerEl.getClientRects().length > 0
-  )
 }

--- a/src/components/chat-view/markdownInsertionTarget.ts
+++ b/src/components/chat-view/markdownInsertionTarget.ts
@@ -1,0 +1,55 @@
+import { MarkdownView } from 'obsidian'
+import type { TFile, Workspace } from 'obsidian'
+
+type InsertionWorkspace = Pick<
+  Workspace,
+  'getActiveViewOfType' | 'getLeavesOfType'
+> & {
+  lastActiveFile?: TFile | null
+}
+
+export function getMarkdownInsertionTarget(
+  workspace: InsertionWorkspace,
+  ownerDocument: Document | null | undefined,
+): MarkdownView | null {
+  const lastActiveFile = workspace.lastActiveFile
+  const matchingViews = lastActiveFile
+    ? workspace
+        .getLeavesOfType('markdown')
+        .map((leaf) => leaf.view)
+        .filter(
+          (view): view is MarkdownView =>
+            view instanceof MarkdownView &&
+            view.file?.path === lastActiveFile.path &&
+            isMarkdownViewVisible(view),
+        )
+    : []
+
+  const sameWindowView = matchingViews.find(
+    (view) => view.containerEl.ownerDocument === ownerDocument,
+  )
+  if (sameWindowView) {
+    return sameWindowView
+  }
+
+  if (matchingViews.length > 0) {
+    return matchingViews[0]
+  }
+
+  const activeMarkdownView = workspace.getActiveViewOfType(MarkdownView)
+  return activeMarkdownView && isMarkdownViewVisible(activeMarkdownView)
+    ? activeMarkdownView
+    : null
+}
+
+function isMarkdownViewVisible(view: MarkdownView): boolean {
+  const { containerEl } = view
+  const maybeIsShown = (containerEl as HTMLElement & { isShown?: unknown })
+    .isShown
+  if (typeof maybeIsShown === 'function') {
+    return maybeIsShown.call(containerEl) as boolean
+  }
+  return (
+    containerEl.offsetParent !== null || containerEl.getClientRects().length > 0
+  )
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import {
   type ActionToastOptions,
   mountActionToast,
 } from './components/ActionToast'
+import { MarkdownInsertionTargetTracker } from './components/chat-view/markdownInsertionTarget'
 import { ConfirmModal } from './components/modals/ConfirmModal'
 import { mountUpdateToast } from './components/UpdateToast'
 import { CHAT_VIEW_TYPE } from './constants'
@@ -278,6 +279,8 @@ export default class YoloPlugin extends Plugin {
   private selectionChatCommandsFingerprint: string | null = null
   private chatViewNavigator: ChatViewNavigator | null = null
   private chatLeafSessionManager: ChatLeafSessionManager | null = null
+  private markdownInsertionTargetTracker: MarkdownInsertionTargetTracker | null =
+    null
   private newTabEmptyStateEnhancer: NewTabEmptyStateEnhancer | null = null
   private ragAutoUpdateService: RagAutoUpdateService | null = null
   private ragCoordinator: RagCoordinator | null = null
@@ -381,6 +384,10 @@ export default class YoloPlugin extends Plugin {
       this.chatLeafSessionManager = new ChatLeafSessionManager(this.app)
     }
     return this.chatLeafSessionManager
+  }
+
+  getMarkdownInsertionTarget(): MarkdownView | null {
+    return this.markdownInsertionTargetTracker?.getTarget() ?? null
   }
 
   private publishManagedModulePathChange(): void {
@@ -2404,10 +2411,16 @@ export default class YoloPlugin extends Plugin {
 
     // removed templates JSON migration
 
+    this.markdownInsertionTargetTracker = new MarkdownInsertionTargetTracker(
+      this.app.workspace,
+    )
+    this.markdownInsertionTargetTracker.captureCurrentLeaf()
+
     // Handle tab completion trigger
     this.registerEvent(
       this.app.workspace.on('active-leaf-change', (leaf) => {
         try {
+          this.markdownInsertionTargetTracker?.trackActiveLeaf(leaf)
           if (leaf?.view instanceof ChatView) {
             this.getChatLeafSessionManager().touchLeafActive(leaf)
           }
@@ -2476,6 +2489,7 @@ export default class YoloPlugin extends Plugin {
     this.selectionChatController?.destroy()
     this.selectionChatController = null
     this.chatViewNavigator = null
+    this.markdownInsertionTargetTracker = null
     this.newTabEmptyStateEnhancer = null
     this.inlineSuggestionController?.clearInlineSuggestion()
     this.inlineSuggestionController?.destroy()


### PR DESCRIPTION
## Summary

- track the exact last active Markdown leaf across chat activation
- verify the tracked leaf is still open and visible before inserting
- remove file-name and same-window heuristics that can select the wrong cursor

## Analysis

Clicking a chat action makes the ChatView active, so the insertion target cannot be recovered with `getActiveViewOfType(MarkdownView)`. File identity is also insufficient when the same note is open in multiple leaves. The revised implementation records the exact Markdown leaf from the public `active-leaf-change` event and keeps it when a non-Markdown leaf becomes active. Before editing, it verifies that the same leaf is still open and visible; otherwise insertion remains unavailable instead of writing to another note or cursor.

## Validation

- `npx jest src/components/chat-view/markdownInsertionTarget.test.ts --runInBand`
- `npm run type:check`
- `npm run lint:check` (passes with 6 pre-existing warnings in `modules/learning`)
- `git diff --check`

Fixes #488