### PR TITLE
[auto-triage] Keep attachments visible above input overlays (#489)

### DIFF
--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -6647,27 +6647,6 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
           bottomSpacerHeight={inputOverlayHeight}
           footerContent={
             <>
-              {(settings.chatOptions.mentionDisplayMode ?? 'inline') ===
-                'badge' &&
-                displayMentionablesForInput.length > 0 && (
-                  <div className="yolo-chat-user-input-files">
-                    {displayMentionablesForInput.map((mentionable) => {
-                      const mentionableKey = getMentionableKey(
-                        serializeMentionable(mentionable),
-                      )
-                      return (
-                        <MentionableBadge
-                          key={mentionableKey}
-                          mentionable={mentionable}
-                          onDelete={() =>
-                            handleMentionableDeleteFromAll(mentionable)
-                          }
-                          onClick={() => {}}
-                        />
-                      )
-                    })}
-                  </div>
-                )}
               <div className="yolo-chat-input-wrapper">
                 <div
                   ref={setInputOverlayElement}
@@ -6772,6 +6751,27 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
                     queuedMessageCount={queuedUserMessages.length}
                   />
                 </div>
+                {(settings.chatOptions.mentionDisplayMode ?? 'inline') ===
+                  'badge' &&
+                  displayMentionablesForInput.length > 0 && (
+                    <div className="yolo-chat-user-input-files">
+                      {displayMentionablesForInput.map((mentionable) => {
+                        const mentionableKey = getMentionableKey(
+                          serializeMentionable(mentionable),
+                        )
+                        return (
+                          <MentionableBadge
+                            key={mentionableKey}
+                            mentionable={mentionable}
+                            onDelete={() =>
+                              handleMentionableDeleteFromAll(mentionable)
+                            }
+                            onClick={() => {}}
+                          />
+                        )
+                      })}
+                    </div>
+                  )}
                 <ChatUserInput
                   key={inputMessage.id}
                   ref={handleMainInputRef}


### PR DESCRIPTION
## Summary

- Nest the badge-mode attachment row inside the input wrapper.
- Keep queued-message and todo overlays anchored above the full input area, so they no longer cover attachment badges.

## Analysis

The overlay is absolutely positioned above `.yolo-chat-input-wrapper`, while attachment badges were rendered as the immediately preceding sibling. The overlay therefore occupied the same space as badges. Making the badges normal-flow children of the wrapper includes their height in the overlay anchor without introducing separate positioning or measurement logic.

## Validation

- `npm run type:check`
- `npx jest src/components/chat-view/inputOverlayReserve.test.ts --runInBand`
- `npm run lint:check` (passes with six pre-existing warnings in `modules/learning`)

Fixes #489.