### PR TITLE
[auto-triage] Fix selection mentions in popout editors (#492)

### DIFF
--- a/src/components/selection/SelectionManager.test.ts
+++ b/src/components/selection/SelectionManager.test.ts
@@ -1,0 +1,34 @@
+import { SelectionManager } from './SelectionManager'
+
+describe('SelectionManager', () => {
+  test('listens for selections in the editor container document', () => {
+    const addEventListener = jest.fn()
+    const removeEventListener = jest.fn()
+    const popoutWindow = {
+      clearTimeout: jest.fn(),
+      setTimeout: jest.fn(),
+      getSelection: jest.fn(),
+    } as unknown as Window
+    const popoutDocument = {
+      addEventListener,
+      removeEventListener,
+      defaultView: popoutWindow,
+    } as unknown as Document
+    const editorContainer = {
+      ownerDocument: popoutDocument,
+    } as HTMLElement
+    const manager = new SelectionManager(editorContainer)
+
+    manager.init(jest.fn())
+    manager.destroy()
+
+    expect(addEventListener).toHaveBeenCalledWith(
+      'selectionchange',
+      expect.any(Function),
+    )
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'selectionchange',
+      expect.any(Function),
+    )
+  })
+})

--- a/src/components/selection/SelectionManager.ts
+++ b/src/components/selection/SelectionManager.ts
@@ -32,6 +32,8 @@ export class SelectionManager {
   private minSelectionLength = 6
   private debounceDelay = 150
   private editorContainer: HTMLElement | null = null
+  private readonly ownerDocument: Document
+  private readonly ownerWindow: Window
 
   constructor(
     editorContainer: HTMLElement,
@@ -42,6 +44,8 @@ export class SelectionManager {
     },
   ) {
     this.editorContainer = editorContainer
+    this.ownerDocument = editorContainer.ownerDocument
+    this.ownerWindow = this.ownerDocument.defaultView ?? window
     if (options) {
       this.isEnabled = options.enabled ?? true
       this.minSelectionLength = options.minSelectionLength ?? 6
@@ -51,15 +55,21 @@ export class SelectionManager {
 
   init(callback: (selection: SelectionInfo | null) => void): void {
     this.onSelectionChange = callback
-    document.addEventListener('selectionchange', this.handleSelectionChange)
+    this.ownerDocument.addEventListener(
+      'selectionchange',
+      this.handleSelectionChange,
+    )
   }
 
   destroy(): void {
     if (this.debounceTimer !== null) {
-      window.clearTimeout(this.debounceTimer)
+      this.ownerWindow.clearTimeout(this.debounceTimer)
       this.debounceTimer = null
     }
-    document.removeEventListener('selectionchange', this.handleSelectionChange)
+    this.ownerDocument.removeEventListener(
+      'selectionchange',
+      this.handleSelectionChange,
+    )
     this.onSelectionChange = null
     this.currentSelection = null
     this.lastRangeSnapshot = null
@@ -84,10 +94,10 @@ export class SelectionManager {
 
   private handleSelectionChange = (): void => {
     if (this.debounceTimer !== null) {
-      window.clearTimeout(this.debounceTimer)
+      this.ownerWindow.clearTimeout(this.debounceTimer)
     }
 
-    this.debounceTimer = window.setTimeout(() => {
+    this.debounceTimer = this.ownerWindow.setTimeout(() => {
       this.debounceTimer = null
       this.processSelection()
     }, this.debounceDelay)
@@ -98,7 +108,7 @@ export class SelectionManager {
       return
     }
 
-    const selection = window.getSelection()
+    const selection = this.ownerWindow.getSelection()
     if (!selection || selection.rangeCount === 0) {
       this.clearSelection()
       return


### PR DESCRIPTION
## Summary

- Bind selection events, timers, and `getSelection()` to the Markdown editor container's owning document/window.
- Add a regression test covering an editor hosted in a separate popout document.

## Analysis

The selection controller is already reinitialized when the active leaf changes. However, `SelectionManager` registered `selectionchange` and read the selection from the process-global main-window document. Obsidian popouts have their own document, so a selection in a popout editor never reached the manager.

## Verification

- `npx jest src/components/selection/SelectionManager.test.ts --runInBand`
- `npm run type:check`
- `npx eslint src/components/selection/SelectionManager.ts src/components/selection/SelectionManager.test.ts`
- `git diff --check`

Fixes #492