### PR TITLE
[auto-triage] Restrict initial Learning card-generation tools (#494)

### DIFF
--- a/modules/bundled.json
+++ b/modules/bundled.json
@@ -34,7 +34,7 @@
       "manifestUrl": "https://github.com/Lapis0x0/obsidian-yolo/releases/download/module-learning-v0.1.2-dev.0/module.json",
       "manifest": {
         "byteSize": 1910,
-        "sha256": "4f05bac4445aede0d6bdcc4ba6f5cccc5a15125b508a10d9a20e20014a1c4042"
+        "sha256": "f3ce87cec266e98316b989fdb68b32b3248baa8555a6911667b1946b786b1a24"
       }
     }
   ]

--- a/modules/learning/src/generation/cardGenerator.test.ts
+++ b/modules/learning/src/generation/cardGenerator.test.ts
@@ -289,16 +289,18 @@ describe('generateCardsForChapter streaming', () => {
       if (retryWithExternalEdit) expect(written).toContain('user edit')
       expect(written).not.toMatch(/[\u4e00-\u9fff]/)
       expect(create).toHaveBeenCalledTimes(preexistingRollbackShell ? 0 : 1)
-      expect(stream).toHaveBeenCalledWith(
+      expect(requests[0]).toEqual(
         expect.objectContaining({
           modelId: 'learning-model',
-          capability: 'edit-vault',
+          capability: 'readonly-vault',
         }),
       )
       if (retryWithExternalEdit) {
         const retryRequest = requests[1] as {
+          capability: string
           messages: Array<{ promptContent?: string }>
         }
+        expect(retryRequest.capability).toBe('edit-vault')
         expect(retryRequest.messages.at(-1)?.promptContent).toContain(
           'The following cards are incorrectly formatted',
         )

--- a/modules/learning/src/generation/cardGenerator.ts
+++ b/modules/learning/src/generation/cardGenerator.ts
@@ -16,6 +16,7 @@ import {
 import type {
   LearningGenerationActivity,
   LearningGenerationAssistantMessage,
+  LearningGenerationCapability,
   LearningGenerationHost,
   LearningGenerationMessage,
   LearningGenerationUserMessage,
@@ -145,6 +146,7 @@ export async function generateCardsForChapter({
   const runStream = async (
     request: { prompt: string } | { messages: LearningGenerationMessage[] },
     consumeCards = false,
+    capability: LearningGenerationCapability,
   ): Promise<{ text: string; error?: Error; aborted?: true }> => {
     let accumulated = ''
     let completedText = ''
@@ -154,7 +156,7 @@ export async function generateCardsForChapter({
         ...request,
         modelId,
         systemPromptOverride: CARD_GENERATOR_PROMPT,
-        capability: 'edit-vault',
+        capability,
         workspaceScope: cardWorkspaceScope,
         activity,
         abortSignal,
@@ -190,7 +192,11 @@ export async function generateCardsForChapter({
     id: `card-gen-${chapterIndex}-req-1`,
     promptContent: prompt,
   }
-  const firstRun = await runStream({ messages: [firstUserMessage] }, true)
+  const firstRun = await runStream(
+    { messages: [firstUserMessage] },
+    true,
+    'readonly-vault',
+  )
   if (firstRun.aborted) {
     throw (
       firstRun.error ??
@@ -255,9 +261,13 @@ export async function generateCardsForChapter({
       }
       let retryAborted = false
       try {
-        const retryRun = await runStream({
-          messages: [firstUserMessage, assistant, retry],
-        })
+        const retryRun = await runStream(
+          {
+            messages: [firstUserMessage, assistant, retry],
+          },
+          false,
+          'edit-vault',
+        )
         retryAborted = retryRun.aborted === true
         if (retryRun.error) throw retryRun.error
       } catch (error) {


### PR DESCRIPTION
## Summary

- Grant the initial card-generation pass read-only Vault access instead of write access.
- Preserve Vault-write access only for the follow-up correction pass, after the host has created `cards.md`.
- Add regression coverage for the two capability boundaries and regenerate the bundled Learning manifest hash.

## Analysis

The initial pass is specified to stream Markdown for host-side parsing and explicitly forbids `fs_edit`, but it was nevertheless invoked with `edit-vault`, exposing `fs_edit`. The report reproduces the no-drafts result across providers and identifies this extra write tool as the only material capability difference from the successful outline and knowledge-point passes. The initial pass can still read scoped reference material; only the correction pass needs to edit the already-created card file.

## Validation

- `npx jest modules/learning/src/generation/cardGenerator.test.ts --runInBand`
- `npm run module:typecheck`
- `npm run type:check`
- `npm run module:build`

Resolves the minimal confirmed permission mismatch from #494.

Original issue: #494