### PR TITLE
[auto-triage] Fix mobile chat input newlines (#499)

### DIFF
--- a/src/components/chat-view/chat-input/plugins/on-enter/OnEnterPlugin.test.ts
+++ b/src/components/chat-view/chat-input/plugins/on-enter/OnEnterPlugin.test.ts
@@ -1,0 +1,89 @@
+jest.mock('obsidian', () => ({
+  Platform: { isMacOS: false, isMobile: false },
+}))
+
+jest.mock('@lexical/react/LexicalComposerContext', () => ({
+  useLexicalComposerContext: jest.fn(),
+}))
+
+jest.mock('react', () => ({
+  useEffect: (effect: () => void) => effect(),
+}))
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { Platform } from 'obsidian'
+
+import OnEnterPlugin from './OnEnterPlugin'
+
+type EnterHandler = (event: KeyboardEvent) => boolean
+
+function getEnterHandler({
+  onEnter = jest.fn(),
+  onVaultChat,
+}: {
+  onEnter?: jest.Mock
+  onVaultChat?: jest.Mock
+} = {}): EnterHandler {
+  let handler: EnterHandler | undefined
+  const editor = {
+    registerCommand: jest.fn((_command, callback: EnterHandler) => {
+      handler = callback
+      return jest.fn()
+    }),
+  }
+
+  ;(useLexicalComposerContext as jest.Mock).mockReturnValue([editor])
+  OnEnterPlugin({ onEnter, onVaultChat })
+
+  if (!handler) {
+    throw new Error('Enter handler was not registered')
+  }
+
+  return handler
+}
+
+function createEnterEvent({ shiftKey = false } = {}): {
+  event: KeyboardEvent
+  preventDefault: jest.Mock
+} {
+  const preventDefault = jest.fn()
+
+  return {
+    event: {
+      shiftKey,
+      ctrlKey: false,
+      metaKey: false,
+      preventDefault,
+      stopPropagation: jest.fn(),
+    } as unknown as KeyboardEvent,
+    preventDefault,
+  }
+}
+
+describe('OnEnterPlugin', () => {
+  beforeEach(() => {
+    ;(Platform as { isMobile: boolean }).isMobile = false
+    jest.clearAllMocks()
+  })
+
+  it('submits a plain Enter on desktop', () => {
+    const onEnter = jest.fn()
+    const handler = getEnterHandler({ onEnter })
+    const { event, preventDefault } = createEnterEvent()
+
+    expect(handler(event)).toBe(true)
+    expect(onEnter).toHaveBeenCalledWith(event)
+    expect(preventDefault).toHaveBeenCalled()
+  })
+
+  it('lets a plain Enter create a newline on mobile', () => {
+    ;(Platform as { isMobile: boolean }).isMobile = true
+    const onEnter = jest.fn()
+    const handler = getEnterHandler({ onEnter })
+    const { event, preventDefault } = createEnterEvent()
+
+    expect(handler(event)).toBe(false)
+    expect(onEnter).not.toHaveBeenCalled()
+    expect(preventDefault).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/chat-view/chat-input/plugins/on-enter/OnEnterPlugin.tsx
+++ b/src/components/chat-view/chat-input/plugins/on-enter/OnEnterPlugin.tsx
@@ -26,7 +26,7 @@ export default function OnEnterPlugin({
           onVaultChat()
           return true
         }
-        if (evt.shiftKey) {
+        if (Platform.isMobile || evt.shiftKey) {
           return false
         }
         evt.preventDefault()


### PR DESCRIPTION
## 摘要

- 移动端聊天输入框的普通 Enter 现在交给 Lexical 插入换行，不再触发发送。
- 桌面端保留 Enter 发送、Shift+Enter 换行；现有 Ctrl/Cmd+Shift+Enter 打开 Vault Chat 的显式快捷键不变。
- 添加覆盖桌面发送与移动端换行的回归测试。

## 分析依据

主聊天和 Quick Ask 共用 `OnEnterPlugin`。此前该插件只放行 Shift+Enter，因而移动输入法的普通 Enter 会被拦截并调用提交回调。移动端没有可依赖的 Shift 修饰键，因此按平台放行普通 Enter 是覆盖共享输入路径的最小改动。

## 校验

- `npx jest src/components/chat-view/chat-input/plugins/on-enter/OnEnterPlugin.test.ts --runInBand`
- `npm run type:check`
- `npx eslint src/components/chat-view/chat-input/plugins/on-enter/OnEnterPlugin.tsx src/components/chat-view/chat-input/plugins/on-enter/OnEnterPlugin.test.ts`
- `npm run lint:check` 未通过：现有 `src/components/apply-view/InlineDiffReviewOverlay.ts:129` 使用已弃用的 `caretRangeFromPoint`，与本 PR 无关。

原 issue: #499