### PR TITLE
[auto-triage] Disclose loaded skills in the chat timeline (#501)

### DIFF
--- a/src/components/chat-view/ToolMessage.test.ts
+++ b/src/components/chat-view/ToolMessage.test.ts
@@ -43,6 +43,7 @@ import type { ToolLabels } from './ToolMessage'
 import ToolMessage, {
   areToolCallItemPropsEqual,
   getHeadlineDisplayInfo,
+  getToolSuccessIconKind,
   getToolResultDisplayText,
 } from './ToolMessage'
 
@@ -279,6 +280,82 @@ describe('ToolMessage rendering', () => {
         } satisfies ToolCallResponse,
       }),
     ).toBe(false)
+  })
+})
+
+describe('ToolMessage success icon helpers', () => {
+  it('uses a wrench for successful skill reads', () => {
+    expect(
+      getToolSuccessIconKind({
+        request: {
+          name: 'yolo_local__fs_read',
+        },
+        response: {
+          status: ToolCallResponseStatus.Success,
+          data: {
+            type: 'text',
+            text: '',
+            metadata: {
+              fsReadOperation: {
+                type: 'full',
+                isPdf: false,
+                skillNames: ['obsidian-output-format'],
+              },
+            },
+          },
+        },
+      }),
+    ).toBe('skill')
+  })
+
+  it('keeps the success check for ordinary file reads', () => {
+    expect(
+      getToolSuccessIconKind({
+        request: {
+          name: 'yolo_local__fs_read',
+        },
+        response: {
+          status: ToolCallResponseStatus.Success,
+          data: {
+            type: 'text',
+            text: '',
+            metadata: {
+              fsReadOperation: { type: 'full', isPdf: false },
+            },
+          },
+        },
+      }),
+    ).toBe('default')
+  })
+
+  it('uses a terminal icon for terminal commands', () => {
+    expect(
+      getToolSuccessIconKind({
+        request: {
+          name: 'yolo_local__terminal_command',
+        },
+      }),
+    ).toBe('terminal')
+  })
+
+  it('keeps the success check for other builtin tools', () => {
+    expect(
+      getToolSuccessIconKind({
+        request: {
+          name: 'yolo_local__fs_search',
+        },
+      }),
+    ).toBe('default')
+  })
+
+  it('keeps the success check for non-builtin tools', () => {
+    expect(
+      getToolSuccessIconKind({
+        request: {
+          name: 'custom_server__fs_search',
+        },
+      }),
+    ).toBe('default')
   })
 })
 

--- a/src/components/chat-view/ToolMessage.test.ts
+++ b/src/components/chat-view/ToolMessage.test.ts
@@ -330,6 +330,7 @@ describe('ToolMessage headline helpers', () => {
       fs_create_dir: 'Create folder',
       fs_move: 'Move path',
       terminal_command: 'Terminal command',
+      open_skill: 'Open skill',
     },
     writeActionLabels: {
       write: 'Write file',
@@ -463,6 +464,39 @@ describe('ToolMessage headline helpers', () => {
         labels,
       }).summaryText,
     ).toBe('docs/plan.md | 全文')
+  })
+
+  it('uses the skill name instead of the file-read transport for skill loads', () => {
+    expect(
+      getHeadlineDisplayInfo({
+        request: {
+          name: 'yolo_local__fs_read',
+          arguments: createCompleteToolCallArguments({
+            value: {
+              paths: ['YOLO/skills/release/SKILL.md'],
+            },
+          }),
+        },
+        response: {
+          status: ToolCallResponseStatus.Success,
+          data: {
+            type: 'text',
+            text: '',
+            metadata: {
+              fsReadOperation: {
+                type: 'full',
+                isPdf: false,
+                skillNames: ['release'],
+              },
+            },
+          },
+        },
+        labels,
+      }),
+    ).toEqual({
+      displayName: 'Open skill',
+      summaryText: 'release',
+    })
   })
 
   it('shows concrete paths for multi-path fs_read headlines', () => {

--- a/src/components/chat-view/ToolMessage.tsx
+++ b/src/components/chat-view/ToolMessage.tsx
@@ -1,6 +1,14 @@
 import cx from 'clsx'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
-import { Check, ChevronDown, ChevronRight, Loader2, X } from 'lucide-react'
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  SquareTerminal,
+  Wrench,
+  X,
+} from 'lucide-react'
 import { Notice } from 'obsidian'
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 
@@ -782,6 +790,39 @@ export const getHeadlineDisplayInfo = ({
   return displayInfo
 }
 
+type ToolSuccessIconKind = 'default' | 'skill' | 'terminal'
+
+export const getToolSuccessIconKind = ({
+  request,
+  response,
+}: {
+  request: ToolRequestLike
+  response?: ToolCallResponse
+}): ToolSuccessIconKind => {
+  let toolName: string
+  try {
+    const parsed = parseToolName(request.name)
+    if (parsed.serverName !== getLocalFileToolServerName()) {
+      return 'default'
+    }
+    toolName = parsed.toolName
+  } catch (error) {
+    if (!(error instanceof InvalidToolNameException)) {
+      throw error
+    }
+    return 'default'
+  }
+
+  if (
+    toolName === 'fs_read' &&
+    getFsReadOperationSummary({ response })?.skillNames?.length
+  ) {
+    return 'skill'
+  }
+
+  return toolName === 'terminal_command' ? 'terminal' : 'default'
+}
+
 const DELEGATE_SUMMARY_MAX_CHARS = 80
 
 const getDelegateSubagentSummary = ({
@@ -1296,6 +1337,10 @@ function ToolCallItem({
     terminalCommandResult && isTerminalCommandRequest(request)
       ? mapTerminalCommandResultStatus(terminalCommandResult.status)
       : response.status
+  const successIconKind = useMemo(
+    () => getToolSuccessIconKind({ request, response }),
+    [request, response],
+  )
   // 是否禁用"始终允许"按钮（某些高危工具每次必须人审）
   const isAlwaysAllowDisabled = useMemo(() => {
     try {
@@ -1417,7 +1462,10 @@ function ToolCallItem({
               transition={{ duration: motionDuration }}
               style={{ display: 'flex', alignItems: 'center' }}
             >
-              <StatusIcon status={effectiveStatus} />
+              <StatusIcon
+                status={effectiveStatus}
+                successIconKind={successIconKind}
+              />
             </motion.span>
           </AnimatePresence>
         </div>
@@ -1783,7 +1831,13 @@ function useToolCall(
   }
 }
 
-function StatusIcon({ status }: { status: ToolCallResponseStatus }) {
+function StatusIcon({
+  status,
+  successIconKind,
+}: {
+  status: ToolCallResponseStatus
+  successIconKind: ToolSuccessIconKind
+}) {
   switch (status) {
     case ToolCallResponseStatus.PendingApproval:
       return <span className="yolo-toolcall-status-dot" />
@@ -1794,6 +1848,19 @@ function StatusIcon({ status }: { status: ToolCallResponseStatus }) {
     case ToolCallResponseStatus.Running:
       return <Loader2 size={16} className="yolo-spinner" />
     case ToolCallResponseStatus.Success:
+      if (successIconKind === 'skill') {
+        return (
+          <Wrench size={16} className="yolo-toolcall-status-success-semantic" />
+        )
+      }
+      if (successIconKind === 'terminal') {
+        return (
+          <SquareTerminal
+            size={16}
+            className="yolo-toolcall-status-success-semantic"
+          />
+        )
+      }
       return (
         <span className="yolo-toolcall-status-success-ring">
           <Check size={11} className="yolo-toolcall-status-success-check" />

--- a/src/components/chat-view/ToolMessage.tsx
+++ b/src/components/chat-view/ToolMessage.tsx
@@ -188,6 +188,12 @@ export const getToolLabels = (t?: TranslateFn): ToolLabels => {
         'chat.toolCall.writeAction.delete_dir',
         DEFAULT_LOCAL_FILE_TOOL_DISPLAY_NAMES.fs_delete_dir,
       ),
+      // Skill bodies are read through fs_read, but expose their product-level
+      // meaning in the transcript rather than the transport implementation.
+      open_skill: translate(
+        'chat.toolCall.displayName.open_skill',
+        'Open skill',
+      ),
     },
     writeActionLabels: {
       write: translate(
@@ -746,10 +752,15 @@ export const getHeadlineDisplayInfo = ({
   }
 
   if (toolName === 'fs_read') {
-    const modeText = formatFsReadHeadlineMode(
-      getFsReadOperationSummary({ response }),
-      labels,
-    )
+    const operation = getFsReadOperationSummary({ response })
+    if (operation?.skillNames?.length) {
+      return {
+        displayName: labels.displayNames.open_skill || displayInfo.displayName,
+        summaryText: operation.skillNames.join(', '),
+      }
+    }
+
+    const modeText = formatFsReadHeadlineMode(operation, labels)
     if (!modeText) {
       return displayInfo
     }

--- a/src/core/mcp/localFileTools.test.ts
+++ b/src/core/mcp/localFileTools.test.ts
@@ -1427,6 +1427,11 @@ describe('local fs tool action helpers', () => {
         '5|# Hidden body',
       ].join('\n'),
     })
+    expect(result.metadata?.fsReadOperation).toEqual({
+      type: 'full',
+      isPdf: false,
+      skillNames: ['hidden-open'],
+    })
   })
 
   describe('fs_read image reading gating by chat model modalities', () => {

--- a/src/core/mcp/localFileTools.ts
+++ b/src/core/mcp/localFileTools.ts
@@ -3153,6 +3153,7 @@ export async function callLocalFileTool({
               error: string
             }
         > = []
+        const readSkillNames: string[] = []
 
         // Tool result attachments hoisted to a follow-up user message after
         // the tool block. Mostly image_url for rendered PDFs/images, but also
@@ -3214,6 +3215,7 @@ export async function callLocalFileTool({
               nextStartLine: sliced.nextStartLine,
               content: sliced.outputContent,
             })
+            readSkillNames.push(skillDocument.entry.name)
             continue
           }
 
@@ -3902,7 +3904,13 @@ export async function callLocalFileTool({
             return undefined
           }
           if (operation.type === 'full') {
-            return { type: 'full', isPdf }
+            return {
+              type: 'full',
+              isPdf,
+              ...(readSkillNames.length === paths.length
+                ? { skillNames: readSkillNames }
+                : {}),
+            }
           }
           const returnedRange = firstReadableResult.returnedRange
           if (
@@ -3916,6 +3924,9 @@ export async function callLocalFileTool({
             startLine: returnedRange.startLine,
             endLine: returnedRange.endLine,
             isPdf,
+            ...(readSkillNames.length === paths.length
+              ? { skillNames: readSkillNames }
+              : {}),
           }
         })()
 

--- a/src/styles/chat/message.css
+++ b/src/styles/chat/message.css
@@ -49,7 +49,7 @@
   padding: 2px var(--yolo-toolcall-header-padding-x);
   display: flex;
   align-items: center;
-  gap: var(--size-2-3);
+  gap: var(--size-2-2);
   border-radius: var(--radius-xs);
   cursor: pointer;
   user-select: none;
@@ -225,6 +225,11 @@
 
 .yolo-toolcall-status-success-check {
   stroke-width: 2.3;
+}
+
+.yolo-toolcall-status-success-semantic {
+  color: var(--interactive-accent);
+  stroke-width: 1.8;
 }
 
 .yolo-toolcall-footer {

--- a/src/types/tool-call.types.ts
+++ b/src/types/tool-call.types.ts
@@ -104,12 +104,22 @@ export type ToolFsReadOperationSummary =
   | {
       type: 'full'
       isPdf: boolean
+      /**
+       * Canonical names of skills read by this call. Present only when every
+       * requested path was a successfully resolved skill.
+       */
+      skillNames?: string[]
     }
   | {
       type: 'lines'
       startLine: number
       endLine: number
       isPdf: boolean
+      /**
+       * Canonical names of skills read by this call. Present only when every
+       * requested path was a successfully resolved skill.
+       */
+      skillNames?: string[]
     }
 
 export type ToolCallRequest = {

--- a/styles.css
+++ b/styles.css
@@ -13928,7 +13928,7 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
   padding: 2px var(--yolo-toolcall-header-padding-x);
   display: flex;
   align-items: center;
-  gap: var(--size-2-3);
+  gap: var(--size-2-2);
   border-radius: var(--radius-xs);
   cursor: pointer;
   user-select: none;
@@ -14104,6 +14104,11 @@ button.yolo-chat-user-input-file-badge-delete:focus-visible,
 
 .yolo-toolcall-status-success-check {
   stroke-width: 2.3;
+}
+
+.yolo-toolcall-status-success-semantic {
+  color: var(--interactive-accent);
+  stroke-width: 1.8;
 }
 
 .yolo-toolcall-footer {


### PR DESCRIPTION
## Summary

- Distinguish successful all-skill `fs_read` calls from ordinary file reads using canonical skill names resolved by the skill registry.
- Render those calls in the conversation timeline as “Open skill: <name>” instead of the transport-level “Read files”.
- Show dedicated success icons only for skill loading and terminal commands; keep the standard success check for other tools.
- Tighten the spacing between tool icons and their labels.

## Analysis

Skills are intentionally loaded through the shared `fs_read` tool, rather than a separate `open_skill` tool. The file tool already knows when a requested path resolves through the allowed skill registry, but that semantic information was previously discarded before rendering. Passing the canonical name in existing read-operation metadata keeps the model protocol and tool surface unchanged while making the user-visible action accurate.

The icon treatment stays deliberately selective: skill loading uses a wrench and terminal commands use a terminal icon, while ordinary file reads and other tools retain the existing success check to avoid visual noise in dense tool timelines.

## Validation

- `npm run type:check`
- `npx jest src/components/chat-view/ToolMessage.test.ts src/core/mcp/localFileTools.test.ts --runInBand` (144 tests passed for the original implementation)
- `npx jest src/components/chat-view/ToolMessage.test.ts --runInBand` (32 tests passed after the icon refinement)
- `npm run styles:build`
- `git diff --check`
- `npm run lint:check` remains blocked by four pre-existing errors outside this change in `InlineDiffReviewOverlay.ts`, `McpServerFormModal.tsx`, `mcpManager.selfHeal.test.ts`, and `mcpManager.test.ts`.

Refs #501
