### PR TITLE
feat(cli-runtime): 建立平行运行时共享合约

### DIFF
--- a/src/core/cli-runtime/actions.ts
+++ b/src/core/cli-runtime/actions.ts
@@ -1,0 +1,33 @@
+import type { ConversationRef } from './types'
+
+export type ChatRuntimeToolAction = {
+  conversation: ConversationRef
+  toolCallId: string
+}
+
+export type ChatRuntimeApprovalAction = ChatRuntimeToolAction & {
+  allowForConversation?: boolean
+}
+
+export type ChatRuntimeQuestionAction = ChatRuntimeToolAction & {
+  payload: unknown
+}
+
+export type ChatRuntimeActionResult =
+  | { kind: 'handled' }
+  | { kind: 'stale' }
+
+export interface ChatRuntimeActions {
+  cancelRun(conversation: ConversationRef): void
+  approveTool(
+    action: ChatRuntimeApprovalAction,
+  ): Promise<ChatRuntimeActionResult>
+  rejectTool(action: ChatRuntimeToolAction): ChatRuntimeActionResult
+  abortTool(
+    action: ChatRuntimeToolAction,
+  ): Promise<ChatRuntimeActionResult>
+  answerQuestion(
+    action: ChatRuntimeQuestionAction,
+  ): Promise<ChatRuntimeActionResult>
+  cancelQuestion(action: ChatRuntimeToolAction): ChatRuntimeActionResult
+}

--- a/src/core/cli-runtime/desktop.test.ts
+++ b/src/core/cli-runtime/desktop.test.ts
@@ -1,0 +1,27 @@
+import { Platform } from 'obsidian'
+
+import { assertCliRuntimeAvailable, isCliRuntimeAvailable } from './desktop'
+
+describe('CLI runtime desktop gate', () => {
+  const originalIsDesktop = Platform.isDesktop
+
+  afterEach(() => {
+    Platform.isDesktop = originalIsDesktop
+  })
+
+  it('rejects provider initialization on mobile', () => {
+    Platform.isDesktop = false
+
+    expect(isCliRuntimeAvailable()).toBe(false)
+    expect(() => assertCliRuntimeAvailable('codex')).toThrow(
+      /only available on desktop/,
+    )
+  })
+
+  it('allows provider initialization on desktop', () => {
+    Platform.isDesktop = true
+
+    expect(isCliRuntimeAvailable()).toBe(true)
+    expect(() => assertCliRuntimeAvailable('claude-code')).not.toThrow()
+  })
+})

--- a/src/core/cli-runtime/desktop.ts
+++ b/src/core/cli-runtime/desktop.ts
@@ -1,0 +1,11 @@
+import { Platform } from 'obsidian'
+
+import type { CliRuntimeId } from './types'
+
+export const isCliRuntimeAvailable = (): boolean => Platform.isDesktop
+
+export const assertCliRuntimeAvailable = (runtimeId: CliRuntimeId): void => {
+  if (!isCliRuntimeAvailable()) {
+    throw new Error(`${runtimeId} CLI runtime is only available on desktop.`)
+  }
+}

--- a/src/core/cli-runtime/index.ts
+++ b/src/core/cli-runtime/index.ts
@@ -1,0 +1,4 @@
+export * from './actions'
+export * from './desktop'
+export * from './session-index'
+export * from './types'

--- a/src/core/cli-runtime/session-index.test.ts
+++ b/src/core/cli-runtime/session-index.test.ts
@@ -1,0 +1,46 @@
+import {
+  CLI_SESSION_INDEX_SCHEMA_VERSION,
+  cliSessionIndexDocumentSchema,
+  createCliSessionIndexEntry,
+  getCliSessionIndexKey,
+  toCliSessionRef,
+} from './session-index'
+
+describe('CLI session index contract', () => {
+  it('uses runtime and native session id as the stable identity', () => {
+    expect(
+      getCliSessionIndexKey({
+        runtimeId: 'codex',
+        nativeSessionId: 'thread/with spaces',
+      }),
+    ).toBe('codex:thread%2Fwith%20spaces')
+  })
+
+  it('keeps paths as mutable hints outside the stable key', () => {
+    const entry = createCliSessionIndexEntry({
+      runtimeId: 'claude-code',
+      nativeSessionId: 'session-1',
+      sessionPathHint: '/old/path.jsonl',
+      assistantId: 'assistant-1',
+      lastOpenedAt: 123,
+    })
+
+    expect(getCliSessionIndexKey(entry)).toBe('claude-code:session-1')
+    expect(toCliSessionRef(entry)).toEqual({
+      runtimeId: 'claude-code',
+      nativeSessionId: 'session-1',
+      sessionPathHint: '/old/path.jsonl',
+    })
+  })
+
+  it('rejects malformed persisted documents at the boundary', () => {
+    expect(() =>
+      cliSessionIndexDocumentSchema.parse({
+        schemaVersion: CLI_SESSION_INDEX_SCHEMA_VERSION,
+        sessions: {
+          broken: { runtimeId: 'other', nativeSessionId: '' },
+        },
+      }),
+    ).toThrow()
+  })
+})

--- a/src/core/cli-runtime/session-index.ts
+++ b/src/core/cli-runtime/session-index.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod'
+
+import type { CliRuntimeId, CliSessionRef } from './types'
+
+export const CLI_SESSION_INDEX_SCHEMA_VERSION = 1 as const
+
+const cliRuntimeIdSchema = z.enum(['claude-code', 'codex'])
+
+export const cliSessionIndexEntrySchema = z.object({
+  runtimeId: cliRuntimeIdSchema,
+  nativeSessionId: z.string().min(1),
+  sessionPathHint: z.string().min(1).optional(),
+  assistantId: z.string().min(1).optional(),
+  lastOpenedAt: z.number().nonnegative().optional(),
+  isPinned: z.boolean().optional(),
+  pinnedAt: z.number().nonnegative().optional(),
+})
+
+export type CliSessionIndexEntry = z.infer<typeof cliSessionIndexEntrySchema>
+
+export const cliSessionIndexDocumentSchema = z.object({
+  schemaVersion: z.literal(CLI_SESSION_INDEX_SCHEMA_VERSION),
+  sessions: z.record(z.string(), cliSessionIndexEntrySchema),
+})
+
+export type CliSessionIndexDocument = z.infer<
+  typeof cliSessionIndexDocumentSchema
+>
+
+export const EMPTY_CLI_SESSION_INDEX: CliSessionIndexDocument = {
+  schemaVersion: CLI_SESSION_INDEX_SCHEMA_VERSION,
+  sessions: {},
+}
+
+export const getCliSessionIndexKey = ({
+  runtimeId,
+  nativeSessionId,
+}: Pick<CliSessionRef, 'runtimeId' | 'nativeSessionId'>): string =>
+  `${runtimeId}:${encodeURIComponent(nativeSessionId)}`
+
+export const toCliSessionRef = (
+  entry: CliSessionIndexEntry,
+): CliSessionRef => ({
+  runtimeId: entry.runtimeId,
+  nativeSessionId: entry.nativeSessionId,
+  ...(entry.sessionPathHint
+    ? { sessionPathHint: entry.sessionPathHint }
+    : {}),
+})
+
+export const createCliSessionIndexEntry = ({
+  runtimeId,
+  nativeSessionId,
+  ...overlay
+}: {
+  runtimeId: CliRuntimeId
+  nativeSessionId: string
+} & Omit<CliSessionIndexEntry, 'runtimeId' | 'nativeSessionId'>) =>
+  cliSessionIndexEntrySchema.parse({
+    runtimeId,
+    nativeSessionId,
+    ...overlay,
+  })
+
+export interface CliSessionIndexStore {
+  list(): Promise<CliSessionIndexEntry[]>
+  get(ref: CliSessionRef): Promise<CliSessionIndexEntry | null>
+  upsert(entry: CliSessionIndexEntry): Promise<void>
+  remove(ref: CliSessionRef): Promise<boolean>
+}

--- a/src/core/cli-runtime/types.test.ts
+++ b/src/core/cli-runtime/types.test.ts
@@ -1,0 +1,15 @@
+import { isCliSessionRef } from './types'
+
+describe('CLI runtime conversation references', () => {
+  it('discriminates YOLO conversations from native CLI sessions', () => {
+    expect(
+      isCliSessionRef({ runtimeId: 'yolo', conversationId: 'chat-1' }),
+    ).toBe(false)
+    expect(
+      isCliSessionRef({
+        runtimeId: 'claude-code',
+        nativeSessionId: 'session-1',
+      }),
+    ).toBe(true)
+  })
+})

--- a/src/core/cli-runtime/types.ts
+++ b/src/core/cli-runtime/types.ts
@@ -1,0 +1,114 @@
+import type { ChatMessage } from '../../types/chat'
+import type { ContentPart } from '../../types/llm/request'
+
+export const CLI_RUNTIME_IDS = ['claude-code', 'codex'] as const
+
+export type CliRuntimeId = (typeof CLI_RUNTIME_IDS)[number]
+export type ChatRuntimeId = 'yolo' | CliRuntimeId
+
+export type YoloConversationRef = {
+  runtimeId: 'yolo'
+  conversationId: string
+}
+
+export type CliSessionRef = {
+  runtimeId: CliRuntimeId
+  nativeSessionId: string
+  sessionPathHint?: string
+}
+
+export type ConversationRef = YoloConversationRef | CliSessionRef
+
+export const isCliSessionRef = (
+  ref: ConversationRef,
+): ref is CliSessionRef => ref.runtimeId !== 'yolo'
+
+export type CliSessionMetadata = {
+  ref: CliSessionRef
+  title: string
+  preview?: string
+  createdAt?: number
+  updatedAt: number
+  cwd?: string
+  model?: string
+}
+
+export type CliSessionHydration = {
+  ref: CliSessionRef
+  messages: ChatMessage[]
+}
+
+export type CliAssistantBinding = {
+  assistantId?: string
+  systemPrompt: string
+  enabledSkillNames: string[]
+}
+
+export type CliRuntimeReadyInput = {
+  sessionRef?: CliSessionRef
+  assistant: CliAssistantBinding
+}
+
+export type CliTurnInput = {
+  sessionRef?: CliSessionRef
+  content: string | ContentPart[]
+}
+
+export type CliRuntimeRunState =
+  | 'idle'
+  | 'running'
+  | 'waiting_for_approval'
+  | 'waiting_for_user'
+  | 'completed'
+  | 'aborted'
+  | 'error'
+
+export type CliRuntimeEvent =
+  | {
+      type: 'session_bound'
+      ref: CliSessionRef
+    }
+  | {
+      type: 'message_upsert'
+      message: ChatMessage
+    }
+  | {
+      type: 'message_remove'
+      messageId: string
+    }
+  | {
+      type: 'run_state'
+      state: CliRuntimeRunState
+      error?: string
+    }
+
+export type CliApprovalDecision =
+  | 'approve_once'
+  | 'approve_for_session'
+  | 'reject'
+
+export type CliApprovalResponse = {
+  requestId: string
+  decision: CliApprovalDecision
+}
+
+export type CliQuestionResponse = {
+  requestId: string
+  answer: unknown
+}
+
+export type CliRuntimeEventListener = (event: CliRuntimeEvent) => void
+
+export interface CliRuntime {
+  readonly runtimeId: CliRuntimeId
+
+  listSessions(): Promise<CliSessionMetadata[]>
+  openSession(ref: CliSessionRef): Promise<CliSessionHydration>
+  ensureReady(input: CliRuntimeReadyInput): Promise<void>
+  sendTurn(input: CliTurnInput): Promise<void>
+  cancel(): Promise<void>
+  respondApproval(response: CliApprovalResponse): Promise<void>
+  respondQuestion(response: CliQuestionResponse): Promise<void>
+  subscribe(listener: CliRuntimeEventListener): () => void
+  dispose(): Promise<void>
+}


### PR DESCRIPTION
## Summary

- define discriminated YOLO/CLI conversation and session references
- add provider-neutral CLI runtime lifecycle and streaming events
- add runtime-aware UI action port and desktop capability gate
- add validated thin session-index schema and store interface

## Verification

- `npx jest src/core/cli-runtime --runInBand`
- `npm run type:check`