### PR TITLE
feat(cli-runtime): 接入 Codex app-server

### DIFF
--- a/src/core/cli-runtime/codex/index.ts
+++ b/src/core/cli-runtime/codex/index.ts
@@ -1,0 +1,5 @@
+export * from './mapping'
+export * from './process'
+export * from './protocol'
+export * from './runtime'
+export * from './transport'

--- a/src/core/cli-runtime/codex/mapping.test.ts
+++ b/src/core/cli-runtime/codex/mapping.test.ts
@@ -1,0 +1,57 @@
+import { ToolCallResponseStatus } from '../../../types/tool-call.types'
+
+import { mapCodexItem, mapCodexTurns } from './mapping'
+
+describe('Codex message mapping', () => {
+  it('hydrates native user and assistant items into YOLO messages', () => {
+    const messages = mapCodexTurns([
+      {
+        id: 'turn-1',
+        status: 'completed',
+        error: null,
+        items: [
+          {
+            type: 'userMessage',
+            id: 'user-1',
+            content: [{ type: 'text', text: 'hello', text_elements: [] }],
+          },
+          { type: 'agentMessage', id: 'agent-1', text: 'hi' },
+        ],
+      },
+    ])
+
+    expect(messages).toMatchObject([
+      { role: 'user', promptContent: 'hello' },
+      { role: 'assistant', content: 'hi' },
+    ])
+  })
+
+  it('maps command execution into a reusable tool request/result pair', () => {
+    const messages = mapCodexItem({
+      type: 'commandExecution',
+      id: 'command-1',
+      command: 'pwd',
+      cwd: '/vault',
+      status: 'completed',
+      aggregatedOutput: '/vault',
+      exitCode: 0,
+      durationMs: 1,
+    })
+
+    expect(messages[0]).toMatchObject({
+      role: 'assistant',
+      toolCallRequests: [{ id: 'command-1', name: 'codex_command_execution' }],
+    })
+    expect(messages[1]).toMatchObject({
+      role: 'tool',
+      toolCalls: [
+        {
+          response: {
+            status: ToolCallResponseStatus.Success,
+            data: { text: '/vault' },
+          },
+        },
+      ],
+    })
+  })
+})

--- a/src/core/cli-runtime/codex/mapping.ts
+++ b/src/core/cli-runtime/codex/mapping.ts
@@ -1,0 +1,169 @@
+import type {
+  ChatAssistantMessage,
+  ChatMessage,
+  ChatToolMessage,
+  ChatUserMessage,
+} from '../../../types/chat'
+import {
+  ToolCallResponseStatus,
+  createCompleteToolCallArguments,
+  type ToolCallRequest,
+  type ToolCallResponse,
+} from '../../../types/tool-call.types'
+
+import type { CodexThreadItem, CodexTurn, CodexUserInput } from './protocol'
+
+const stringify = (value: unknown): string => {
+  if (typeof value === 'string') return value
+  if (value === undefined || value === null) return ''
+  return JSON.stringify(value, null, 2)
+}
+
+const userInputText = (content: CodexUserInput[]): string =>
+  content
+    .map((part) => (part.type === 'text' ? part.text : `[Image: ${part.url}]`))
+    .join('\n\n')
+
+const toResponse = (
+  item: { status: string },
+  output: string,
+): ToolCallResponse => {
+  const status = item.status.toLowerCase()
+  if (status.includes('fail') || status.includes('error')) {
+    return { status: ToolCallResponseStatus.Error, error: output || status }
+  }
+  if (
+    status.includes('progress') ||
+    status.includes('running') ||
+    status.includes('pending')
+  ) {
+    return { status: ToolCallResponseStatus.Running }
+  }
+  return {
+    status: ToolCallResponseStatus.Success,
+    data: { type: 'text', text: output },
+  }
+}
+
+const toolPair = ({
+  request,
+  response,
+}: {
+  request: ToolCallRequest
+  response: ToolCallResponse
+}): [ChatAssistantMessage, ChatToolMessage] => [
+  {
+    role: 'assistant',
+    id: `codex-request-${request.id}`,
+    content: '',
+    toolCallRequests: [request],
+    metadata: { generationState: 'completed' },
+  },
+  {
+    role: 'tool',
+    id: `codex-result-${request.id}`,
+    toolCalls: [{ request, response }],
+  },
+]
+
+export const mapCodexItem = (item: CodexThreadItem): ChatMessage[] => {
+  if (item.type === 'userMessage') {
+    const message: ChatUserMessage = {
+      role: 'user',
+      id: `codex-user-${item.id}`,
+      content: null,
+      promptContent: userInputText(item.content),
+      mentionables: [],
+    }
+    return [message]
+  }
+  if (item.type === 'agentMessage') {
+    return [
+      {
+        role: 'assistant',
+        id: `codex-assistant-${item.id}`,
+        content: item.text,
+        metadata: { generationState: 'completed' },
+      },
+    ]
+  }
+  if (item.type === 'reasoning') {
+    return [
+      {
+        role: 'assistant',
+        id: `codex-reasoning-${item.id}`,
+        content: '',
+        reasoning: [...item.summary, ...item.content].join('\n\n'),
+        metadata: { generationState: 'completed' },
+      },
+    ]
+  }
+  if (item.type === 'commandExecution') {
+    const request: ToolCallRequest = {
+      id: item.id,
+      name: 'codex_command_execution',
+      arguments: createCompleteToolCallArguments({
+        value: { command: item.command, cwd: item.cwd },
+      }),
+    }
+    const output = item.aggregatedOutput ?? ''
+    return toolPair({ request, response: toResponse(item, output) })
+  }
+  if (item.type === 'fileChange') {
+    const request: ToolCallRequest = {
+      id: item.id,
+      name: 'codex_file_change',
+      arguments: createCompleteToolCallArguments({
+        value: { changes: item.changes },
+      }),
+    }
+    return toolPair({
+      request,
+      response: toResponse(item, stringify(item.changes)),
+    })
+  }
+  if (item.type === 'mcpToolCall') {
+    const request: ToolCallRequest = {
+      id: item.id,
+      name: `codex_mcp__${item.server}__${item.tool}`,
+      arguments: createCompleteToolCallArguments({
+        value:
+          item.arguments && typeof item.arguments === 'object'
+            ? (item.arguments as Record<string, unknown>)
+            : { value: item.arguments },
+      }),
+    }
+    return toolPair({
+      request,
+      response: toResponse(item, stringify(item.result ?? item.error)),
+    })
+  }
+  return []
+}
+
+export const mapCodexTurns = (turns: CodexTurn[]): ChatMessage[] =>
+  turns.flatMap((turn) => turn.items.flatMap(mapCodexItem))
+
+export const buildPendingToolMessages = ({
+  requestId,
+  toolCallId,
+  name,
+  argumentsValue,
+  responseStatus,
+}: {
+  requestId: string | number
+  toolCallId: string
+  name: string
+  argumentsValue: Record<string, unknown>
+  responseStatus:
+    | ToolCallResponseStatus.PendingApproval
+    | ToolCallResponseStatus.AwaitingUserInput
+}): [ChatAssistantMessage, ChatToolMessage] => {
+  const request: ToolCallRequest = {
+    id: toolCallId,
+    name,
+    arguments: createCompleteToolCallArguments({ value: argumentsValue }),
+    metadata: { argumentDiagnostics: { deliveryMode: `codex:${requestId}` } },
+  }
+  return toolPair({ request, response: { status: responseStatus } })
+}

--- a/src/core/cli-runtime/codex/process.ts
+++ b/src/core/cli-runtime/codex/process.ts
@@ -1,0 +1,162 @@
+import type { ChildProcess } from 'node:child_process'
+
+import { loadDesktopNodeModule } from '../../../utils/platform/desktopNodeModule'
+import { assertCliRuntimeAvailable } from '../desktop'
+
+export type CodexProcessExitListener = (
+  code: number | null,
+  signal: NodeJS.Signals | null,
+) => void
+
+export interface CodexProcessLike {
+  write(line: string): void
+  onLine(listener: (line: string) => void): () => void
+  onExit(listener: CodexProcessExitListener): () => void
+  getStderrSnapshot(): string
+  shutdown(): Promise<void>
+}
+
+export type CodexProcessOptions = {
+  command?: string
+  cwd: string
+  env?: Record<string, string>
+}
+
+type SpawnSpec = {
+  command: string
+  args: string[]
+  killProcessTree: boolean
+  windowsVerbatimArguments: boolean
+}
+
+const quoteWindowsShellArgument = (value: string): string => {
+  if (!value.length) return '""'
+  if (!/[\s"&<>|{}^=;!'+,`~()%@[\]]/u.test(value)) return value
+  return `"${value.replace(/"/g, '""')}"`
+}
+
+const resolveSpawnSpec = (command: string): SpawnSpec => {
+  const args = ['app-server', '--listen', 'stdio://']
+  if (process.platform !== 'win32' || !command.toLowerCase().endsWith('.cmd')) {
+    return {
+      command,
+      args,
+      killProcessTree: false,
+      windowsVerbatimArguments: false,
+    }
+  }
+
+  const shellCommand = [command, ...args]
+    .map(quoteWindowsShellArgument)
+    .join(' ')
+  return {
+    command: process.env.ComSpec || process.env.comspec || 'cmd.exe',
+    args: ['/d', '/s', '/c', `"${shellCommand}"`],
+    killProcessTree: true,
+    windowsVerbatimArguments: true,
+  }
+}
+
+const getProcessEnv = async (
+  customEnv?: Record<string, string>,
+): Promise<Record<string, string>> => {
+  const { shellEnvSync } = await import('shell-env')
+  return {
+    ...Object.fromEntries(
+      Object.entries(process.env).filter(
+        (entry): entry is [string, string] => entry[1] !== undefined,
+      ),
+    ),
+    ...shellEnvSync(),
+    ...customEnv,
+  }
+}
+
+export class CodexAppServerProcess implements CodexProcessLike {
+  private readonly lineListeners = new Set<(line: string) => void>()
+  private readonly exitListeners = new Set<CodexProcessExitListener>()
+  private stderr = ''
+  private stdoutBuffer = ''
+
+  private constructor(
+    private readonly child: ChildProcess,
+    private readonly spawnSpec: SpawnSpec,
+    private readonly spawn: typeof import('node:child_process').spawn,
+  ) {
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      this.stdoutBuffer += Buffer.isBuffer(chunk)
+        ? chunk.toString('utf8')
+        : String(chunk)
+      this.flushLines()
+    })
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk)
+      this.stderr = `${this.stderr}${text}`.slice(-8192)
+    })
+    child.on('close', (code, signal) => {
+      for (const listener of this.exitListeners) listener(code, signal)
+    })
+  }
+
+  static async start(options: CodexProcessOptions): Promise<CodexAppServerProcess> {
+    assertCliRuntimeAvailable('codex')
+    const { spawn } = await loadDesktopNodeModule<
+      typeof import('node:child_process')
+    >('node:child_process')
+    const spec = resolveSpawnSpec(options.command?.trim() || 'codex')
+    const child = spawn(spec.command, spec.args, {
+      cwd: options.cwd,
+      env: await getProcessEnv(options.env),
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+      windowsVerbatimArguments: spec.windowsVerbatimArguments,
+    })
+    return new CodexAppServerProcess(child, spec, spawn)
+  }
+
+  write(line: string): void {
+    if (!this.child.stdin?.writable) throw new Error('Codex app-server stdin is closed.')
+    this.child.stdin.write(line)
+  }
+
+  onLine(listener: (line: string) => void): () => void {
+    this.lineListeners.add(listener)
+    return () => this.lineListeners.delete(listener)
+  }
+
+  onExit(listener: CodexProcessExitListener): () => void {
+    this.exitListeners.add(listener)
+    return () => this.exitListeners.delete(listener)
+  }
+
+  getStderrSnapshot(): string {
+    return this.stderr.trim()
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.child.exitCode !== null || this.child.killed) return
+    if (
+      process.platform === 'win32' &&
+      this.spawnSpec.killProcessTree &&
+      typeof this.child.pid === 'number'
+    ) {
+      this.spawn('taskkill.exe', ['/pid', String(this.child.pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      }).on('error', () => undefined)
+      return
+    }
+    this.child.kill('SIGTERM')
+  }
+
+  private flushLines(): void {
+    while (true) {
+      const newline = this.stdoutBuffer.indexOf('\n')
+      if (newline < 0) return
+      const line = this.stdoutBuffer.slice(0, newline).trim()
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1)
+      if (!line) continue
+      for (const listener of this.lineListeners) listener(line)
+    }
+  }
+}

--- a/src/core/cli-runtime/codex/protocol.ts
+++ b/src/core/cli-runtime/codex/protocol.ts
@@ -1,0 +1,82 @@
+export type JsonRpcId = string | number
+
+export type JsonRpcError = {
+  code: number
+  message: string
+  data?: unknown
+}
+
+export type CodexUserInput =
+  | { type: 'text'; text: string; text_elements: [] }
+  | { type: 'image'; url: string }
+
+export type CodexThreadItem =
+  | { type: 'userMessage'; id: string; content: CodexUserInput[] }
+  | { type: 'agentMessage'; id: string; text: string }
+  | { type: 'reasoning'; id: string; summary: string[]; content: string[] }
+  | {
+      type: 'commandExecution'
+      id: string
+      command: string
+      cwd: string
+      status: string
+      aggregatedOutput: string | null
+      exitCode: number | null
+      durationMs: number | null
+    }
+  | {
+      type: 'fileChange'
+      id: string
+      changes: unknown[]
+      status: string
+    }
+  | {
+      type: 'mcpToolCall'
+      id: string
+      server: string
+      tool: string
+      status: string
+      arguments: unknown
+      result: unknown
+      error: unknown
+    }
+
+export type CodexTurn = {
+  id: string
+  items: CodexThreadItem[]
+  status: string
+  error: { message?: string } | null
+}
+
+export type CodexThread = {
+  id: string
+  preview: string
+  path: string | null
+  cwd: string
+  createdAt: number
+  updatedAt: number
+  name: string | null
+  turns: CodexTurn[]
+  modelProvider?: string
+}
+
+export type ThreadListResponse = {
+  data: CodexThread[]
+  nextCursor: string | null
+}
+
+export type ThreadReadResponse = { thread: CodexThread }
+export type ThreadStartResponse = { thread: CodexThread; model?: string }
+export type ThreadResumeResponse = { thread: CodexThread; model?: string }
+export type TurnStartResponse = { turn: CodexTurn }
+
+export type CodexNotification = {
+  method: string
+  params: Record<string, unknown>
+}
+
+export type CodexServerRequest = {
+  id: JsonRpcId
+  method: string
+  params: Record<string, unknown>
+}

--- a/src/core/cli-runtime/codex/runtime.test.ts
+++ b/src/core/cli-runtime/codex/runtime.test.ts
@@ -1,0 +1,114 @@
+import type { CodexProcessExitListener, CodexProcessLike } from './process'
+import { CodexCliRuntime } from './runtime'
+
+class RpcFakeProcess implements CodexProcessLike {
+  responses: unknown[] = []
+  private lineListener: ((line: string) => void) | null = null
+  private thread = {
+    id: 'thread-1',
+    preview: 'First prompt',
+    path: '/sessions/thread-1.jsonl',
+    cwd: '/vault',
+    createdAt: 10,
+    updatedAt: 20,
+    name: null,
+    turns: [],
+  }
+
+  write(line: string): void {
+    const request = JSON.parse(line) as {
+      id?: string | number
+      method?: string
+      result?: unknown
+    }
+    if (request.result !== undefined) {
+      this.responses.push(request.result)
+      return
+    }
+    if (request.id === undefined || !request.method) return
+    const result =
+      request.method === 'thread/list'
+        ? { data: [this.thread], nextCursor: null }
+        : request.method === 'thread/read'
+          ? { thread: this.thread }
+          : request.method === 'thread/start' || request.method === 'thread/resume'
+            ? { thread: this.thread }
+            : request.method === 'turn/start'
+              ? { turn: { id: 'turn-1', items: [], status: 'inProgress', error: null } }
+              : {}
+    queueMicrotask(() =>
+      this.emit({ jsonrpc: '2.0', id: request.id, result }),
+    )
+  }
+  onLine(listener: (line: string) => void): () => void {
+    this.lineListener = listener
+    return () => {
+      this.lineListener = null
+    }
+  }
+  onExit(_listener: CodexProcessExitListener): () => void {
+    return () => undefined
+  }
+  getStderrSnapshot(): string {
+    return ''
+  }
+  async shutdown(): Promise<void> {}
+  emit(message: unknown): void {
+    this.lineListener?.(JSON.stringify(message))
+  }
+}
+
+describe('CodexCliRuntime', () => {
+  it('lists vault sessions and starts a thread with assistant instructions', async () => {
+    const process = new RpcFakeProcess()
+    const runtime = new CodexCliRuntime({
+      cwd: '/vault',
+      createProcess: async () => process,
+    })
+    await expect(runtime.listSessions()).resolves.toMatchObject([
+      {
+        title: 'First prompt',
+        ref: { runtimeId: 'codex', nativeSessionId: 'thread-1' },
+      },
+    ])
+
+    const events: string[] = []
+    runtime.subscribe((event) => events.push(event.type))
+    await runtime.ensureReady({
+      assistant: {
+        assistantId: 'assistant-1',
+        systemPrompt: 'Be precise.',
+        enabledSkillNames: [],
+      },
+    })
+    expect(events).toContain('session_bound')
+  })
+
+  it('surfaces server approvals and routes the UI decision back by tool id', async () => {
+    const process = new RpcFakeProcess()
+    const runtime = new CodexCliRuntime({
+      cwd: '/vault',
+      createProcess: async () => process,
+    })
+    const events: string[] = []
+    runtime.subscribe((event) => {
+      if (event.type === 'run_state') events.push(event.state)
+    })
+    await runtime.ensureReady({
+      assistant: { systemPrompt: '', enabledSkillNames: [] },
+    })
+    process.emit({
+      jsonrpc: '2.0',
+      id: 91,
+      method: 'item/commandExecution/requestApproval',
+      params: { itemId: 'command-1', command: 'pwd', cwd: '/vault' },
+    })
+    expect(events).toContain('waiting_for_approval')
+
+    await runtime.respondApproval({
+      requestId: 'command-1',
+      decision: 'approve_for_session',
+    })
+    expect(process.responses).toContainEqual({ decision: 'acceptForSession' })
+  })
+})

--- a/src/core/cli-runtime/codex/runtime.ts
+++ b/src/core/cli-runtime/codex/runtime.ts
@@ -1,0 +1,445 @@
+import type { ContentPart } from '../../../types/llm/request'
+import { ToolCallResponseStatus } from '../../../types/tool-call.types'
+import type {
+  CliApprovalResponse,
+  CliQuestionResponse,
+  CliRuntime,
+  CliRuntimeEvent,
+  CliRuntimeEventListener,
+  CliRuntimeReadyInput,
+  CliSessionHydration,
+  CliSessionMetadata,
+  CliSessionRef,
+  CliTurnInput,
+} from '../types'
+
+import { buildPendingToolMessages, mapCodexItem, mapCodexTurns } from './mapping'
+import type {
+  CodexServerRequest,
+  CodexThread,
+  CodexThreadItem,
+  CodexUserInput,
+  ThreadListResponse,
+  ThreadReadResponse,
+  ThreadResumeResponse,
+  ThreadStartResponse,
+  TurnStartResponse,
+} from './protocol'
+import {
+  CodexAppServerProcess,
+  type CodexProcessLike,
+  type CodexProcessOptions,
+} from './process'
+import { CodexRpcTransport, initializeCodexTransport } from './transport'
+
+type PendingServerRequest = {
+  request: CodexServerRequest
+  toolCallId: string
+}
+
+export type CodexCliRuntimeOptions = CodexProcessOptions & {
+  createProcess?: (options: CodexProcessOptions) => Promise<CodexProcessLike>
+}
+
+const toSessionRef = (thread: CodexThread): CliSessionRef => ({
+  runtimeId: 'codex',
+  nativeSessionId: thread.id,
+  ...(thread.path ? { sessionPathHint: thread.path } : {}),
+})
+
+const toSessionMetadata = (thread: CodexThread): CliSessionMetadata => ({
+  ref: toSessionRef(thread),
+  title: thread.name?.trim() || thread.preview.trim() || 'Codex session',
+  ...(thread.preview.trim() ? { preview: thread.preview.trim() } : {}),
+  createdAt: thread.createdAt * 1000,
+  updatedAt: thread.updatedAt * 1000,
+  cwd: thread.cwd,
+})
+
+const toCodexInput = (content: string | ContentPart[]): CodexUserInput[] => {
+  if (typeof content === 'string') {
+    return [{ type: 'text', text: content, text_elements: [] }]
+  }
+  return content.flatMap((part): CodexUserInput[] => {
+    if (part.type === 'text') {
+      return [{ type: 'text', text: part.text, text_elements: [] }]
+    }
+    if (part.type === 'image_url') {
+      return [{ type: 'image', url: part.image_url.url }]
+    }
+    throw new Error('Codex CLI runtime does not support PDF attachments.')
+  })
+}
+
+const approvalDecision = (
+  decision: CliApprovalResponse['decision'],
+): 'accept' | 'acceptForSession' | 'decline' => {
+  if (decision === 'approve_once') return 'accept'
+  if (decision === 'approve_for_session') return 'acceptForSession'
+  return 'decline'
+}
+
+const toCodexQuestionAnswers = (answer: unknown): Record<string, unknown> => {
+  if (!answer || typeof answer !== 'object' || Array.isArray(answer)) return {}
+  const rawAnswers = (answer as { answers?: unknown }).answers
+  if (!Array.isArray(rawAnswers)) return {}
+  return Object.fromEntries(
+    rawAnswers.flatMap((entry): Array<[string, { answers: string[] }]> => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return []
+      const value = entry as {
+        id?: unknown
+        value?: unknown
+        otherText?: unknown
+      }
+      if (typeof value.id !== 'string') return []
+      const answers = Array.isArray(value.value)
+        ? value.value.filter((item): item is string => typeof item === 'string')
+        : typeof value.value === 'string'
+          ? [value.value]
+          : []
+      if (typeof value.otherText === 'string' && value.otherText.trim()) {
+        answers.push(value.otherText.trim())
+      }
+      return [[value.id, { answers }]]
+    }),
+  )
+}
+
+export class CodexCliRuntime implements CliRuntime {
+  readonly runtimeId = 'codex' as const
+
+  private process: CodexProcessLike | null = null
+  private transport: CodexRpcTransport | null = null
+  private transportPromise: Promise<CodexRpcTransport> | null = null
+  private readonly listeners = new Set<CliRuntimeEventListener>()
+  private readonly pendingRequests = new Map<string, PendingServerRequest>()
+  private activeSessionRef: CliSessionRef | null = null
+  private activeTurnId: string | null = null
+  private assistantKey = ''
+
+  constructor(private readonly options: CodexCliRuntimeOptions) {}
+
+  async listSessions(): Promise<CliSessionMetadata[]> {
+    const transport = await this.getTransport()
+    const sessions: CliSessionMetadata[] = []
+    let cursor: string | null = null
+    do {
+      const response: ThreadListResponse = await transport.request<ThreadListResponse>('thread/list', {
+        cursor,
+        limit: 100,
+        sortKey: 'updated_at',
+        sortDirection: 'desc',
+        cwd: this.options.cwd,
+      })
+      sessions.push(...response.data.map(toSessionMetadata))
+      cursor = response.nextCursor
+    } while (cursor)
+    return sessions
+  }
+
+  async openSession(ref: CliSessionRef): Promise<CliSessionHydration> {
+    if (ref.runtimeId !== 'codex') throw new Error('Cannot open a non-Codex session.')
+    const transport = await this.getTransport()
+    const response = await transport.request<ThreadReadResponse>('thread/read', {
+      threadId: ref.nativeSessionId,
+      includeTurns: true,
+    })
+    return { ref: toSessionRef(response.thread), messages: mapCodexTurns(response.thread.turns) }
+  }
+
+  async ensureReady(input: CliRuntimeReadyInput): Promise<void> {
+    const transport = await this.getTransport()
+    const assistantKey = JSON.stringify(input.assistant)
+    if (
+      this.activeSessionRef &&
+      input.sessionRef?.nativeSessionId === this.activeSessionRef.nativeSessionId &&
+      assistantKey === this.assistantKey
+    ) {
+      return
+    }
+
+    const params = {
+      cwd: this.options.cwd,
+      approvalPolicy: 'on-request',
+      sandbox: 'workspace-write',
+      developerInstructions: input.assistant.systemPrompt || null,
+      experimentalRawEvents: true,
+    }
+    const response = input.sessionRef
+      ? await transport.request<ThreadResumeResponse>('thread/resume', {
+          threadId: input.sessionRef.nativeSessionId,
+          ...params,
+        })
+      : await transport.request<ThreadStartResponse>('thread/start', params)
+    this.activeSessionRef = toSessionRef(response.thread)
+    this.assistantKey = assistantKey
+    this.emit({ type: 'session_bound', ref: this.activeSessionRef })
+  }
+
+  async sendTurn(input: CliTurnInput): Promise<void> {
+    if (input.sessionRef) {
+      if (
+        !this.activeSessionRef ||
+        input.sessionRef.nativeSessionId !== this.activeSessionRef.nativeSessionId
+      ) {
+        throw new Error('Codex session must be resumed with ensureReady before sending.')
+      }
+    }
+    if (!this.activeSessionRef) throw new Error('Codex runtime is not ready.')
+    this.emit({ type: 'run_state', state: 'running' })
+    const response = await (await this.getTransport()).request<TurnStartResponse>(
+      'turn/start',
+      {
+        threadId: this.activeSessionRef.nativeSessionId,
+        input: toCodexInput(input.content),
+      },
+      0,
+    )
+    this.activeTurnId ??= response.turn.id
+  }
+
+  async cancel(): Promise<void> {
+    if (!this.activeSessionRef || !this.activeTurnId) return
+    await (await this.getTransport()).request('turn/interrupt', {
+      threadId: this.activeSessionRef.nativeSessionId,
+      turnId: this.activeTurnId,
+    })
+  }
+
+  async respondApproval(response: CliApprovalResponse): Promise<void> {
+    const pending = this.pendingRequests.get(response.requestId)
+    if (!pending) throw new Error('Codex approval request is no longer pending.')
+    this.pendingRequests.delete(response.requestId)
+    ;(await this.getTransport()).respond(pending.request.id, {
+      decision: approvalDecision(response.decision),
+    })
+  }
+
+  async respondQuestion(response: CliQuestionResponse): Promise<void> {
+    const pending = this.pendingRequests.get(response.requestId)
+    if (!pending) throw new Error('Codex question is no longer pending.')
+    this.pendingRequests.delete(response.requestId)
+    ;(await this.getTransport()).respond(pending.request.id, {
+      answers: toCodexQuestionAnswers(response.answer),
+    })
+  }
+
+  subscribe(listener: CliRuntimeEventListener): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  async dispose(): Promise<void> {
+    if (this.transportPromise) {
+      await this.transportPromise.catch(() => undefined)
+    }
+    this.transport?.dispose()
+    this.transport = null
+    if (this.process) await this.process.shutdown()
+    this.process = null
+    this.listeners.clear()
+    this.pendingRequests.clear()
+  }
+
+  private emit(event: CliRuntimeEvent): void {
+    for (const listener of this.listeners) listener(event)
+  }
+
+  private async getTransport(): Promise<CodexRpcTransport> {
+    if (this.transport) return this.transport
+    if (this.transportPromise) return this.transportPromise
+    const promise = this.createTransport()
+    this.transportPromise = promise
+    try {
+      return await promise
+    } finally {
+      if (this.transportPromise === promise) this.transportPromise = null
+    }
+  }
+
+  private async createTransport(): Promise<CodexRpcTransport> {
+    const createProcess = this.options.createProcess ?? CodexAppServerProcess.start
+    this.process = await createProcess(this.options)
+    const transport = new CodexRpcTransport(this.process)
+    transport.onNotification((notification) =>
+      this.handleNotification(notification.method, notification.params),
+    )
+    transport.onServerRequest((request) => this.handleServerRequest(request))
+    try {
+      await initializeCodexTransport(transport)
+      this.transport = transport
+      return transport
+    } catch (error) {
+      transport.dispose()
+      await this.process.shutdown()
+      this.process = null
+      throw error
+    }
+  }
+
+  private handleNotification(
+    method: string,
+    params: Record<string, unknown>,
+  ): void {
+    if (method === 'turn/started') {
+      const turn = params.turn as { id?: unknown } | undefined
+      this.activeTurnId = typeof turn?.id === 'string' ? turn.id : null
+      return
+    }
+    if (method === 'item/agentMessage/delta') {
+      const itemId = typeof params.itemId === 'string' ? params.itemId : 'stream'
+      const delta = typeof params.delta === 'string' ? params.delta : ''
+      const existing = this.streamingAssistantText.get(itemId) ?? ''
+      const content = `${existing}${delta}`
+      this.streamingAssistantText.set(itemId, content)
+      this.emit({
+        type: 'message_upsert',
+        message: {
+          role: 'assistant',
+          id: `codex-assistant-${itemId}`,
+          content,
+          metadata: { generationState: 'streaming' },
+        },
+      })
+      return
+    }
+    if (method === 'item/reasoning/summaryTextDelta') {
+      const itemId = typeof params.itemId === 'string' ? params.itemId : 'reasoning'
+      const delta = typeof params.delta === 'string' ? params.delta : ''
+      const reasoning = `${this.streamingReasoningText.get(itemId) ?? ''}${delta}`
+      this.streamingReasoningText.set(itemId, reasoning)
+      this.emit({
+        type: 'message_upsert',
+        message: {
+          role: 'assistant',
+          id: `codex-reasoning-${itemId}`,
+          content: '',
+          reasoning,
+          metadata: { generationState: 'streaming' },
+        },
+      })
+      return
+    }
+    if (method === 'item/started' || method === 'item/completed') {
+      const item = params.item as CodexThreadItem | undefined
+      if (!item) return
+      for (const message of mapCodexItem(item)) {
+        this.emit({ type: 'message_upsert', message })
+      }
+      return
+    }
+    if (method === 'serverRequest/resolved') {
+      const requestId = params.requestId
+      if (typeof requestId === 'string' || typeof requestId === 'number') {
+        for (const [key, pending] of this.pendingRequests) {
+          if (String(pending.request.id) === String(requestId)) {
+            this.pendingRequests.delete(key)
+          }
+        }
+      }
+      return
+    }
+    if (method === 'turn/completed') {
+      const turn = params.turn as { status?: unknown; error?: { message?: unknown } } | undefined
+      const status = typeof turn?.status === 'string' ? turn.status : 'completed'
+      const isError = status === 'failed'
+      this.emit({
+        type: 'run_state',
+        state: status === 'interrupted' ? 'aborted' : isError ? 'error' : 'completed',
+        ...(isError && typeof turn?.error?.message === 'string'
+          ? { error: turn.error.message }
+          : {}),
+      })
+      this.activeTurnId = null
+    }
+  }
+
+  private readonly streamingAssistantText = new Map<string, string>()
+  private readonly streamingReasoningText = new Map<string, string>()
+
+  private handleServerRequest(request: CodexServerRequest): void {
+    const key =
+      typeof request.params.approvalId === 'string'
+        ? request.params.approvalId
+        : typeof request.params.itemId === 'string'
+          ? request.params.itemId
+          : String(request.id)
+    const itemId =
+      typeof request.params.itemId === 'string' ? request.params.itemId : key
+    if (
+      request.method === 'item/commandExecution/requestApproval' ||
+      request.method === 'item/fileChange/requestApproval' ||
+      request.method === 'item/permissions/requestApproval'
+    ) {
+      this.pendingRequests.set(key, { request, toolCallId: itemId })
+      const [assistant, tool] = buildPendingToolMessages({
+        requestId: request.id,
+        toolCallId: itemId,
+        name:
+          request.method === 'item/commandExecution/requestApproval'
+            ? 'codex_command_execution'
+            : request.method === 'item/fileChange/requestApproval'
+              ? 'codex_file_change'
+              : 'codex_permissions',
+        argumentsValue: request.params,
+        responseStatus: ToolCallResponseStatus.PendingApproval,
+      })
+      this.emit({ type: 'message_upsert', message: assistant })
+      this.emit({ type: 'message_upsert', message: tool })
+      this.emit({ type: 'run_state', state: 'waiting_for_approval' })
+      return
+    }
+    if (request.method === 'item/tool/requestUserInput') {
+      this.pendingRequests.set(key, { request, toolCallId: itemId })
+      const rawQuestions = Array.isArray(request.params.questions)
+        ? request.params.questions
+        : []
+      const questions = rawQuestions.map((raw, index) => {
+        const question = raw as {
+          id?: unknown
+          question?: unknown
+          options?: unknown
+        }
+        const options = Array.isArray(question.options)
+          ? question.options.map((option, optionIndex) => {
+              const value = option as { label?: unknown; description?: unknown }
+              const label =
+                typeof value.label === 'string' ? value.label : `Option ${optionIndex + 1}`
+              return {
+                id: label,
+                label,
+                ...(typeof value.description === 'string'
+                  ? { description: value.description }
+                  : {}),
+              }
+            })
+          : undefined
+        const selectableOptions =
+          options && options.length >= 2 ? options : undefined
+        return {
+          id: typeof question.id === 'string' ? question.id : `question-${index + 1}`,
+          prompt:
+            typeof question.question === 'string'
+              ? question.question
+              : 'Codex requires input.',
+          inputType: selectableOptions ? 'single_select' : 'free_text',
+          ...(selectableOptions ? { options: selectableOptions } : {}),
+        }
+      })
+      const [assistant, tool] = buildPendingToolMessages({
+        requestId: request.id,
+        toolCallId: itemId,
+        name: 'ask_user_question',
+        argumentsValue: { questions },
+        responseStatus: ToolCallResponseStatus.AwaitingUserInput,
+      })
+      this.emit({ type: 'message_upsert', message: assistant })
+      this.emit({ type: 'message_upsert', message: tool })
+      this.emit({ type: 'run_state', state: 'waiting_for_user' })
+      return
+    }
+    void this.getTransport().then((transport) =>
+      transport.respondError(request.id, -32601, `Unsupported Codex request: ${request.method}`),
+    )
+  }
+}

--- a/src/core/cli-runtime/codex/transport.test.ts
+++ b/src/core/cli-runtime/codex/transport.test.ts
@@ -1,0 +1,72 @@
+import type { CodexProcessExitListener, CodexProcessLike } from './process'
+import { CodexRpcTransport } from './transport'
+
+class FakeProcess implements CodexProcessLike {
+  writes: string[] = []
+  private lineListener: ((line: string) => void) | null = null
+
+  write(line: string): void {
+    this.writes.push(line)
+  }
+  onLine(listener: (line: string) => void): () => void {
+    this.lineListener = listener
+    return () => {
+      this.lineListener = null
+    }
+  }
+  onExit(_listener: CodexProcessExitListener): () => void {
+    return () => undefined
+  }
+  getStderrSnapshot(): string {
+    return ''
+  }
+  async shutdown(): Promise<void> {}
+  emit(message: unknown): void {
+    this.lineListener?.(JSON.stringify(message))
+  }
+}
+
+describe('CodexRpcTransport', () => {
+  it('routes responses, notifications, and server requests independently', async () => {
+    const process = new FakeProcess()
+    const transport = new CodexRpcTransport(process)
+    const notifications: string[] = []
+    const requests: string[] = []
+    transport.onNotification((notification) =>
+      notifications.push(notification.method),
+    )
+    transport.onServerRequest((request) => requests.push(request.method))
+
+    const resultPromise = transport.request<{ ok: boolean }>('thread/list', {})
+    const sent = JSON.parse(process.writes[0]) as { id: number }
+    process.emit({ jsonrpc: '2.0', method: 'turn/started', params: {} })
+    process.emit({
+      jsonrpc: '2.0',
+      id: 'approval-1',
+      method: 'item/commandExecution/requestApproval',
+      params: {},
+    })
+    process.emit({ jsonrpc: '2.0', id: sent.id, result: { ok: true } })
+
+    await expect(resultPromise).resolves.toEqual({ ok: true })
+    expect(notifications).toEqual(['turn/started'])
+    expect(requests).toEqual(['item/commandExecution/requestApproval'])
+  })
+
+  it('buffers notifications that arrive before the matching response', async () => {
+    const process = new FakeProcess()
+    const transport = new CodexRpcTransport(process)
+    const order: string[] = []
+    transport.onNotification(() => order.push('notification'))
+
+    const resultPromise = transport.request('turn/start', {}).then(() =>
+      order.push('response'),
+    )
+    const sent = JSON.parse(process.writes[0]) as { id: number }
+    process.emit({ jsonrpc: '2.0', method: 'turn/started', params: {} })
+    process.emit({ jsonrpc: '2.0', id: sent.id, result: {} })
+    await resultPromise
+
+    expect(order).toEqual(['notification', 'response'])
+  })
+})

--- a/src/core/cli-runtime/codex/transport.ts
+++ b/src/core/cli-runtime/codex/transport.ts
@@ -1,0 +1,159 @@
+import type {
+  CodexNotification,
+  CodexServerRequest,
+  JsonRpcError,
+  JsonRpcId,
+} from './protocol'
+import type { CodexProcessLike } from './process'
+
+type PendingRequest = {
+  method: string
+  resolve: (result: unknown) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+export type CodexNotificationListener = (
+  notification: CodexNotification,
+) => void
+export type CodexServerRequestListener = (
+  request: CodexServerRequest,
+) => void
+
+export class CodexRpcTransport {
+  private nextId = 1
+  private readonly pending = new Map<number, PendingRequest>()
+  private readonly notificationListeners =
+    new Set<CodexNotificationListener>()
+  private readonly serverRequestListeners = new Set<CodexServerRequestListener>()
+  private readonly removeLineListener: () => void
+  private readonly removeExitListener: () => void
+  private disposed = false
+
+  constructor(private readonly process: CodexProcessLike) {
+    this.removeLineListener = process.onLine((line) => this.handleLine(line))
+    this.removeExitListener = process.onExit(() => {
+      const stderr = process.getStderrSnapshot()
+      this.rejectAll(
+        new Error(stderr ? `Codex app-server exited: ${stderr}` : 'Codex app-server exited.'),
+      )
+    })
+  }
+
+  request<T>(method: string, params: unknown, timeoutMs = 30_000): Promise<T> {
+    if (this.disposed) return Promise.reject(new Error('Codex transport disposed.'))
+    const id = this.nextId++
+    return new Promise<T>((resolve, reject) => {
+      const timer = timeoutMs
+        ? globalThis.setTimeout(() => {
+            this.pending.delete(id)
+            reject(new Error(`Codex request timed out: ${method}`))
+          }, timeoutMs)
+        : null
+      this.pending.set(id, {
+        method,
+        resolve: (result) => resolve(result as T),
+        reject,
+        timer,
+      })
+      this.send({ jsonrpc: '2.0', id, method, params })
+    })
+  }
+
+  notify(method: string, params?: unknown): void {
+    this.send({ jsonrpc: '2.0', method, ...(params === undefined ? {} : { params }) })
+  }
+
+  respond(id: JsonRpcId, result: unknown): void {
+    this.send({ jsonrpc: '2.0', id, result })
+  }
+
+  respondError(id: JsonRpcId, code: number, message: string): void {
+    this.send({ jsonrpc: '2.0', id, error: { code, message } })
+  }
+
+  onNotification(listener: CodexNotificationListener): () => void {
+    this.notificationListeners.add(listener)
+    return () => this.notificationListeners.delete(listener)
+  }
+
+  onServerRequest(listener: CodexServerRequestListener): () => void {
+    this.serverRequestListeners.add(listener)
+    return () => this.serverRequestListeners.delete(listener)
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.removeLineListener()
+    this.removeExitListener()
+    this.rejectAll(new Error('Codex transport disposed.'))
+  }
+
+  private send(message: unknown): void {
+    if (this.disposed) throw new Error('Codex transport disposed.')
+    this.process.write(`${JSON.stringify(message)}\n`)
+  }
+
+  private handleLine(line: string): void {
+    let value: unknown
+    try {
+      value = JSON.parse(line)
+    } catch {
+      return
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return
+    const message = value as Record<string, unknown>
+    const id = message.id
+    const method = message.method
+
+    if (typeof id === 'number' && typeof method !== 'string') {
+      const pending = this.pending.get(id)
+      if (!pending) return
+      this.pending.delete(id)
+      if (pending.timer !== null) globalThis.clearTimeout(pending.timer)
+      if (message.error) {
+        const error = message.error as JsonRpcError
+        pending.reject(new Error(`${pending.method}: ${error.message}`))
+      } else {
+        pending.resolve(message.result)
+      }
+      return
+    }
+
+    if (typeof method !== 'string') return
+    const params =
+      message.params && typeof message.params === 'object'
+        ? (message.params as Record<string, unknown>)
+        : {}
+    if (id === undefined) {
+      for (const listener of this.notificationListeners) {
+        listener({ method, params })
+      }
+      return
+    }
+    if (typeof id === 'string' || typeof id === 'number') {
+      for (const listener of this.serverRequestListeners) {
+        listener({ id, method, params })
+      }
+    }
+  }
+
+  private rejectAll(error: Error): void {
+    for (const pending of this.pending.values()) {
+      if (pending.timer !== null) globalThis.clearTimeout(pending.timer)
+      pending.reject(error)
+    }
+    this.pending.clear()
+  }
+}
+
+export const initializeCodexTransport = async (
+  transport: CodexRpcTransport,
+): Promise<void> => {
+  await transport.request('initialize', {
+    clientInfo: { name: 'obsidian-yolo', version: '1.0.0' },
+    capabilities: { experimentalApi: true },
+  })
+  transport.notify('initialized')
+}

--- a/src/core/cli-runtime/index.ts
+++ b/src/core/cli-runtime/index.ts
@@ -1,4 +1,5 @@
 export * from './actions'
+export * from './codex'
 export * from './desktop'
 export * from './session-index'
 export * from './types'


### PR DESCRIPTION
## Summary

- start the local Codex app-server behind the desktop-only process boundary
- implement initialize/initialized JSON-RPC transport and pending-turn-safe routing
- list/read/start/resume native threads without YOLO transcript persistence
- map live messages, tools, approvals, ask-user, cancellation, and hydration to the shared runtime contract

## Verification

- `npx jest src/core/cli-runtime/codex --runInBand`
- `npm run type:check`
- live read-only probe against codex-cli 0.139.0: initialize + thread/list