### PR TITLE
feat(skills): 统一为标准目录包

### DIFF
--- a/src/components/settings/modals/AgentSkillsModal.tsx
+++ b/src/components/settings/modals/AgentSkillsModal.tsx
@@ -1,4 +1,4 @@
-import { App, Notice, TFile, TFolder, normalizePath } from 'obsidian'
+import { App, Notice } from 'obsidian'
 import { useCallback, useMemo, useState } from 'react'
 
 import { useLanguage } from '../../../contexts/language-context'
@@ -7,7 +7,10 @@ import {
   useSettings,
 } from '../../../contexts/settings-context'
 import { getYoloSkillsDir } from '../../../core/paths/yoloPaths'
-import { humanizeSkillName } from '../../../core/skills/liteSkills'
+import {
+  getSkillPackageDirPath,
+  humanizeSkillName,
+} from '../../../core/skills/liteSkills'
 import { useLiteSkillEntries } from '../../../hooks/useLiteSkillEntries'
 import YoloPlugin from '../../../main'
 import { ObsidianButton } from '../../common/ObsidianButton'
@@ -137,41 +140,28 @@ function AgentSkillsModalContent({
   }, [deletableSkills])
 
   const deleteSkillPath = async (path: string) => {
-    const normalizedPath = normalizePath(path)
-    const file = app.vault.getAbstractFileByPath(normalizedPath)
-    if (file) {
-      if (file instanceof TFile) {
-        const parent = file.parent
-        if (
-          parent &&
-          parent.path !== skillsDir &&
-          parent instanceof TFolder &&
-          file.name === 'SKILL.md'
-        ) {
-          await app.fileManager.trashFile(parent)
-        } else {
-          await app.fileManager.trashFile(file)
-        }
-      } else if (file instanceof TFolder) {
-        await app.fileManager.trashFile(file)
-      }
-      return
-    }
-
-    if (!(await app.vault.adapter.exists(normalizedPath))) {
-      throw new Error('Skill file not found')
-    }
-
-    if (normalizedPath.endsWith('/SKILL.md')) {
-      const parentPath = normalizedPath.slice(
-        0,
-        normalizedPath.lastIndexOf('/'),
+    const packageDir = getSkillPackageDirPath(path)
+    if (!packageDir) {
+      throw new Error(
+        t(
+          'settings.agent.deleteSkillInvalidPackage',
+          'Invalid skill package path',
+        ),
       )
-      await app.vault.adapter.rmdir(parentPath, true)
+    }
+
+    const folder = app.vault.getAbstractFileByPath(packageDir)
+    if (folder) {
+      await app.fileManager.trashFile(folder)
       return
     }
 
-    await app.vault.adapter.remove(normalizedPath)
+    if (!(await app.vault.adapter.exists(packageDir))) {
+      throw new Error(
+        t('settings.agent.deleteSkillNotFound', 'Skill package not found'),
+      )
+    }
+    await app.vault.adapter.rmdir(packageDir, true)
   }
 
   const handleDeleteSelected = () => {
@@ -184,7 +174,7 @@ function AgentSkillsModalContent({
       title: t('settings.agent.deleteSkillTitle', 'Delete skill'),
       message: t(
         'settings.agent.deleteSkillBatchMessage',
-        'Are you sure you want to delete {count} skill(s)? This cannot be undone.',
+        'Are you sure you want to delete {count} skill package(s), including all resources? This cannot be undone.',
       ).replace('{count}', String(names.length)),
       ctaText: t('settings.agent.deleteSkillConfirm', 'Delete'),
       onConfirm: async () => {
@@ -228,7 +218,7 @@ function AgentSkillsModalContent({
       <div className="yolo-settings-desc yolo-settings-callout">
         {t(
           'settings.agent.skillsGlobalDesc',
-          'Skills are discovered from built-in skills and {path}/**/*.md (excluding Skills.md where applicable). Disable a skill here to block it for all agents.',
+          'Skills are discovered from built-in skills and {path}/<name>/SKILL.md packages. Disable a skill here to block it for all agents.',
         ).replace('{path}', skillsDir)}
       </div>
 
@@ -355,7 +345,7 @@ function AgentSkillsModalContent({
           <div className="yolo-agent-tools-empty">
             {t(
               'settings.agent.skillsEmptyHint',
-              'No skills found. Create skill markdown files under {path}.',
+              'No skills found. Create a {path}/<name>/SKILL.md package.',
             ).replace('{path}', skillsDir)}
           </div>
         )}

--- a/src/components/settings/modals/ImportSkillModal.tsx
+++ b/src/components/settings/modals/ImportSkillModal.tsx
@@ -20,7 +20,7 @@ import {
   type ValidationError,
   parseFrontmatter,
   validateDirectoryPackage,
-  validateSingleFileSkill,
+  wrapMarkdownAsSkillPackage,
 } from '../../../core/skills/skillValidation'
 import YoloPlugin from '../../../main'
 import { ReactModal } from '../../common/ReactModal'
@@ -79,17 +79,15 @@ function ImportSkillModalWrapper({
 type SkillPackage = {
   /** 用作错误信息显示的源名称(原文件夹名 / 文件名) */
   sourceName: string
-  /** 目标名称:目录模式 = frontmatter.name;单文件模式 = 源文件名 */
+  /** 目标目录名，始终取自 frontmatter.name */
   targetName: string
   /** 用于列表显示 */
   displayName: string
   description: string
   files: FileEntry[]
-  isDirectory: boolean
 }
 
 const SKILL_MD = 'SKILL.md'
-const MAX_PATH_DEPTH = 16
 
 // ---------------------------------------------------------------------------
 // 校验错误转为通俗提示
@@ -191,10 +189,7 @@ type RawCandidate = {
 async function readDirectoryEntryRecursively(
   dirEntry: FileSystemDirectoryEntry,
   basePath: string,
-  depth: number,
 ): Promise<FileEntry[]> {
-  if (depth > MAX_PATH_DEPTH) return []
-
   const readBatch = (
     reader: FileSystemDirectoryReader,
   ): Promise<FileSystemEntry[]> =>
@@ -217,19 +212,18 @@ async function readDirectoryEntryRecursively(
       const file = await new Promise<File>((resolve, reject) => {
         fileEntry.file(resolve, reject)
       })
-      const content = await file.text()
       const relativePath = basePath
         ? `${basePath}/${fileEntry.name}`
         : fileEntry.name
-      results.push({ relativePath, content })
+      if (fileEntry.name === SKILL_MD) {
+        results.push({ relativePath, content: await file.text() })
+      } else {
+        results.push({ relativePath, data: await file.arrayBuffer() })
+      }
     } else if (entry.isDirectory) {
       const subDir = entry as FileSystemDirectoryEntry
       const subPath = basePath ? `${basePath}/${subDir.name}` : subDir.name
-      const subFiles = await readDirectoryEntryRecursively(
-        subDir,
-        subPath,
-        depth + 1,
-      )
+      const subFiles = await readDirectoryEntryRecursively(subDir, subPath)
       results.push(...subFiles)
     }
   }
@@ -255,7 +249,7 @@ async function readRawCandidatesFromDataTransfer(
   for (const entry of rootEntries) {
     if (entry.isDirectory) {
       const dirEntry = entry as FileSystemDirectoryEntry
-      const files = await readDirectoryEntryRecursively(dirEntry, '', 0)
+      const files = await readDirectoryEntryRecursively(dirEntry, '')
       candidates.push({
         rootName: dirEntry.name,
         files,
@@ -312,9 +306,12 @@ async function readRawCandidatesFromFileList(
     const rootDir = slashIdx > 0 ? relPath.slice(0, slashIdx) : relPath
     const innerPath = slashIdx > 0 ? relPath.slice(slashIdx + 1) : ''
     if (!innerPath) continue
-    const content = await file.text()
     const entries = groupedByRoot.get(rootDir) ?? []
-    entries.push({ relativePath: innerPath, content })
+    if (innerPath.split('/').pop() === SKILL_MD) {
+      entries.push({ relativePath: innerPath, content: await file.text() })
+    } else {
+      entries.push({ relativePath: innerPath, data: await file.arrayBuffer() })
+    }
     groupedByRoot.set(rootDir, entries)
   }
 
@@ -393,11 +390,11 @@ function extractSkillsFromDirectoryCandidate(
           : f.relativePath.startsWith(prefix),
       )
       .map((f) => ({
+        ...f,
         relativePath:
           rootRelDir === ''
             ? f.relativePath
             : f.relativePath.slice(prefix.length),
-        content: f.content,
       }))
     const sourceName =
       rootRelDir === ''
@@ -493,38 +490,19 @@ function ImportSkillModalContent({
 
         if (candidate.isSingleFile) {
           const content = candidate.files[0]?.content ?? ''
-          const validationErrors = validateSingleFileSkill(content)
-          if (validationErrors.length > 0) {
+          const wrapped = wrapMarkdownAsSkillPackage(content)
+          if (!wrapped.package) {
             errors.push(
-              formatValidationErrors(validationErrors, candidate.rootName, t),
-            )
-            continue
-          }
-          const fm = parseFrontmatter(content)
-          const fmName =
-            typeof fm?.name === 'string' && fm.name.trim()
-              ? fm.name.trim()
-              : null
-          const description =
-            (typeof fm?.description === 'string' && fm.description.trim()) || ''
-          if (!isSafeRelativePath(candidate.rootName)) {
-            errors.push(
-              t(
-                'settings.agent.importSkillUnsafePath',
-                'Refused unsafe path in "{name}": {path}',
-              )
-                .replace('{name}', candidate.rootName)
-                .replace('{path}', candidate.rootName),
+              formatValidationErrors(wrapped.errors, candidate.rootName, t),
             )
             continue
           }
           pushValid({
             sourceName: candidate.rootName,
-            targetName: candidate.rootName,
-            displayName: fmName ?? candidate.rootName,
-            description,
-            files: candidate.files,
-            isDirectory: false,
+            targetName: wrapped.package.name,
+            displayName: wrapped.package.name,
+            description: wrapped.package.description,
+            files: wrapped.package.files,
           })
           continue
         }
@@ -556,7 +534,6 @@ function ImportSkillModalContent({
             displayName: fmName,
             description,
             files: skill.files,
-            isDirectory: true,
           })
         }
       }
@@ -788,42 +765,34 @@ function ImportSkillModalContent({
 
       for (const pkg of skillPackages) {
         try {
-          if (pkg.isDirectory) {
-            const pkgDir = normalizePath(`${skillsDir}/${pkg.targetName}`)
-            // 覆盖时:无论已存在的是文件还是目录,先 trash 再写新,避免遗留旧资源 / 类型冲突
-            const existing = app.vault.getAbstractFileByPath(pkgDir)
-            if (existing) {
-              await app.fileManager.trashFile(existing)
-            }
-            await app.vault.createFolder(pkgDir)
+          const pkgDir = normalizePath(`${skillsDir}/${pkg.targetName}`)
+          // 覆盖时:无论已存在的是文件还是目录,先 trash 再写新,避免遗留旧资源 / 类型冲突
+          const existing = app.vault.getAbstractFileByPath(pkgDir)
+          if (existing) {
+            await app.fileManager.trashFile(existing)
+          }
+          await app.vault.createFolder(pkgDir)
 
-            for (const file of pkg.files) {
-              if (!isSafeRelativePath(file.relativePath)) {
-                throw new Error(`unsafe path: ${file.relativePath}`)
-              }
-              const targetPath = normalizePath(`${pkgDir}/${file.relativePath}`)
-              if (!targetPath.startsWith(`${pkgDir}/`)) {
-                throw new Error(`path escaped target: ${file.relativePath}`)
-              }
-              const parentDir = targetPath.substring(
-                0,
-                targetPath.lastIndexOf('/'),
-              )
-              if (parentDir) {
-                await ensureFolder(parentDir)
-              }
-              await app.vault.create(targetPath, file.content)
+          for (const file of pkg.files) {
+            if (!isSafeRelativePath(file.relativePath)) {
+              throw new Error(`unsafe path: ${file.relativePath}`)
             }
-          } else {
-            const targetPath = normalizePath(`${skillsDir}/${pkg.targetName}`)
-            if (!targetPath.startsWith(`${skillsDir}/`)) {
-              throw new Error(`path escaped target: ${pkg.targetName}`)
+            const targetPath = normalizePath(`${pkgDir}/${file.relativePath}`)
+            if (!targetPath.startsWith(`${pkgDir}/`)) {
+              throw new Error(`path escaped target: ${file.relativePath}`)
             }
-            const existing = app.vault.getAbstractFileByPath(targetPath)
-            if (existing) {
-              await app.fileManager.trashFile(existing)
+            const parentDir = targetPath.substring(
+              0,
+              targetPath.lastIndexOf('/'),
+            )
+            if (parentDir) {
+              await ensureFolder(parentDir)
             }
-            await app.vault.create(targetPath, pkg.files[0].content)
+            if (file.data) {
+              await app.vault.createBinary(targetPath, file.data)
+            } else {
+              await app.vault.create(targetPath, file.content ?? '')
+            }
           }
           successCount++
         } catch (err) {
@@ -887,7 +856,7 @@ function ImportSkillModalContent({
       <div className="yolo-settings-desc yolo-settings-callout">
         {t(
           'settings.agent.importSkillDesc',
-          'Import skill packages into {path}. Supports single .md files or Agent Skills standard folders (containing SKILL.md, scripts/, references/, etc.).',
+          'Import skill packages into {path}. Single Markdown files are wrapped as <name>/SKILL.md; folders keep SKILL.md and all package resources.',
         ).replace('{path}', skillsDir)}
       </div>
 

--- a/src/components/settings/modals/ImportSkillModal.tsx
+++ b/src/components/settings/modals/ImportSkillModal.tsx
@@ -16,6 +16,11 @@ import {
   parseGitHubUrl,
 } from '../../../core/skills/githubSkillImporter'
 import {
+  MAX_SKILL_PACKAGE_IMPORT_DEPTH,
+  SkillPackageImportDepthExceededError,
+  assertSkillPackageImportDepth,
+} from '../../../core/skills/skillImportLimits'
+import {
   type FileEntry,
   type ValidationError,
   parseFrontmatter,
@@ -189,7 +194,10 @@ type RawCandidate = {
 async function readDirectoryEntryRecursively(
   dirEntry: FileSystemDirectoryEntry,
   basePath: string,
+  depth: number,
 ): Promise<FileEntry[]> {
+  assertSkillPackageImportDepth(depth)
+
   const readBatch = (
     reader: FileSystemDirectoryReader,
   ): Promise<FileSystemEntry[]> =>
@@ -223,7 +231,11 @@ async function readDirectoryEntryRecursively(
     } else if (entry.isDirectory) {
       const subDir = entry as FileSystemDirectoryEntry
       const subPath = basePath ? `${basePath}/${subDir.name}` : subDir.name
-      const subFiles = await readDirectoryEntryRecursively(subDir, subPath)
+      const subFiles = await readDirectoryEntryRecursively(
+        subDir,
+        subPath,
+        depth + 1,
+      )
       results.push(...subFiles)
     }
   }
@@ -249,7 +261,7 @@ async function readRawCandidatesFromDataTransfer(
   for (const entry of rootEntries) {
     if (entry.isDirectory) {
       const dirEntry = entry as FileSystemDirectoryEntry
-      const files = await readDirectoryEntryRecursively(dirEntry, '')
+      const files = await readDirectoryEntryRecursively(dirEntry, '', 0)
       candidates.push({
         rootName: dirEntry.name,
         files,
@@ -306,6 +318,7 @@ async function readRawCandidatesFromFileList(
     const rootDir = slashIdx > 0 ? relPath.slice(0, slashIdx) : relPath
     const innerPath = slashIdx > 0 ? relPath.slice(slashIdx + 1) : ''
     if (!innerPath) continue
+    assertSkillPackageImportDepth(innerPath.split('/').length - 1)
     const entries = groupedByRoot.get(rootDir) ?? []
     if (innerPath.split('/').pop() === SKILL_MD) {
       entries.push({ relativePath: innerPath, content: await file.text() })
@@ -447,6 +460,24 @@ function ImportSkillModalContent({
       isMountedRef.current = false
     }
   }, [])
+
+  const showReadError = useCallback(
+    (error: unknown) => {
+      if (error instanceof SkillPackageImportDepthExceededError) {
+        new Notice(
+          t(
+            'settings.agent.importSkillErrTooDeep',
+            'Skill package exceeds the maximum import depth of {depth}. Nothing was imported.',
+          ).replace('{depth}', String(MAX_SKILL_PACKAGE_IMPORT_DEPTH)),
+        )
+        return
+      }
+      new Notice(
+        t('settings.agent.importSkillReadError', 'Failed to read files.'),
+      )
+    },
+    [t],
+  )
 
   const buildSkillPackagesFromCandidates = useCallback(
     (
@@ -632,14 +663,12 @@ function ImportSkillModalContent({
       try {
         const candidates = await readRawCandidatesFromFileList(files)
         addCandidates(candidates)
-      } catch {
-        new Notice(
-          t('settings.agent.importSkillReadError', 'Failed to read files.'),
-        )
+      } catch (error) {
+        showReadError(error)
       }
       e.target.value = ''
     },
-    [addCandidates, t],
+    [addCandidates, showReadError],
   )
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -665,14 +694,12 @@ function ImportSkillModalContent({
         try {
           const candidates = await readRawCandidatesFromDataTransfer(items)
           addCandidates(candidates)
-        } catch {
-          new Notice(
-            t('settings.agent.importSkillReadError', 'Failed to read files.'),
-          )
+        } catch (error) {
+          showReadError(error)
         }
       }
     },
-    [addCandidates, t],
+    [addCandidates, showReadError],
   )
 
   const runUrlFetch = useCallback(async () => {

--- a/src/components/settings/sections/AgentsSectionContent.tsx
+++ b/src/components/settings/sections/AgentsSectionContent.tsx
@@ -2077,7 +2077,7 @@ export function AgentsSectionContent({
                   <div className="yolo-agent-tools-empty">
                     {t(
                       'settings.agent.skillsEmptyHint',
-                      'No skills found. Create skill markdown files under {path}.',
+                      'No skills found. Create a {path}/<name>/SKILL.md package.',
                     ).replace('{path}', skillsDir)}
                   </div>
                 )}

--- a/src/core/skills/builtinSkills.test.ts
+++ b/src/core/skills/builtinSkills.test.ts
@@ -12,6 +12,9 @@ describe('builtin skills', () => {
 
     expect(builtin).not.toBeNull()
     expect(builtin?.content).toContain('99-Assets/YOLO/skills')
+    expect(builtin?.content).toContain(
+      '99-Assets/YOLO/skills/<skill-name>/SKILL.md',
+    )
     expect(builtin?.content).not.toContain(
       'fs_write { path: "YOLO/skills/<skill-name>.md"',
     )

--- a/src/core/skills/githubSkillImporter.test.ts
+++ b/src/core/skills/githubSkillImporter.test.ts
@@ -1,4 +1,24 @@
-import { parseGitHubUrl } from './githubSkillImporter'
+import { type RequestUrlResponse, requestUrl } from 'obsidian'
+
+import { fetchGitHubSkill, parseGitHubUrl } from './githubSkillImporter'
+
+const mockedRequestUrl = requestUrl as jest.MockedFunction<typeof requestUrl>
+
+const makeResponse = ({
+  arrayBuffer = new ArrayBuffer(0),
+  json = null,
+  text = '',
+}: {
+  arrayBuffer?: ArrayBuffer
+  json?: unknown
+  text?: string
+}): RequestUrlResponse => ({
+  status: 200,
+  headers: {},
+  arrayBuffer,
+  json,
+  text,
+})
 
 describe('parseGitHubUrl', () => {
   it('parses a single-file blob URL', () => {
@@ -175,5 +195,64 @@ describe('parseGitHubUrl', () => {
     expect(
       parseGitHubUrl('https://github.com/user/repo/tree/../path'),
     ).toBeNull()
+  })
+})
+
+describe('fetchGitHubSkill package resources', () => {
+  beforeEach(() => {
+    mockedRequestUrl.mockReset()
+  })
+
+  it('keeps non-entry package resources as exact bytes', async () => {
+    const skillContent = [
+      '---',
+      'name: binary-assets',
+      'description: Keeps binary assets unchanged.',
+      '---',
+    ].join('\n')
+    const skillBytes = new TextEncoder().encode(skillContent).buffer
+    const assetBytes = new Uint8Array([0, 255, 1, 2]).buffer
+    mockedRequestUrl
+      .mockResolvedValueOnce(
+        makeResponse({
+          json: {
+            sha: 'tree',
+            truncated: false,
+            tree: [
+              {
+                path: 'SKILL.md',
+                mode: '100644',
+                type: 'blob',
+                sha: 'skill',
+                size: skillBytes.byteLength,
+              },
+              {
+                path: 'assets/icon.bin',
+                mode: '100644',
+                type: 'blob',
+                sha: 'asset',
+                size: assetBytes.byteLength,
+              },
+            ],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(makeResponse({ arrayBuffer: skillBytes }))
+      .mockResolvedValueOnce(makeResponse({ arrayBuffer: assetBytes }))
+
+    const [result] = await fetchGitHubSkill(
+      'https://github.com/user/binary-assets',
+    )
+
+    expect(result.targetName).toBe('binary-assets')
+    expect(
+      result.files.find((file) => file.relativePath === 'SKILL.md'),
+    ).toEqual({ relativePath: 'SKILL.md', content: skillContent })
+    const asset = result.files.find(
+      (file) => file.relativePath === 'assets/icon.bin',
+    )
+    expect(new Uint8Array(asset?.data ?? new ArrayBuffer(0))).toEqual(
+      new Uint8Array([0, 255, 1, 2]),
+    )
   })
 })

--- a/src/core/skills/githubSkillImporter.ts
+++ b/src/core/skills/githubSkillImporter.ts
@@ -224,6 +224,37 @@ async function fetchRawText(rawUrl: string): Promise<string> {
   return text
 }
 
+/** Fetch package resources as exact bytes so binary assets are never decoded. */
+async function fetchRawBytes(rawUrl: string): Promise<ArrayBuffer> {
+  const response = await requestUrl({ url: rawUrl, throw: false })
+
+  if (isRateLimitResponse(response.status, response.headers)) {
+    throw new GitHubRateLimitError()
+  }
+  if (response.status === 404) {
+    throw new GitHubNotFoundError(`404: ${rawUrl}`)
+  }
+  if (response.status >= 400) {
+    throw new Error(`HTTP ${response.status}: ${rawUrl}`)
+  }
+
+  const contentLengthRaw =
+    response.headers?.['content-length'] ?? response.headers?.['Content-Length']
+  const contentLength = contentLengthRaw ? Number(contentLengthRaw) : NaN
+  if (Number.isFinite(contentLength) && contentLength > MAX_FILE_BYTES) {
+    throw new GitHubLimitExceededError(
+      `file exceeds ${MAX_FILE_BYTES} bytes: ${rawUrl}`,
+    )
+  }
+
+  if (response.arrayBuffer.byteLength > MAX_FILE_BYTES) {
+    throw new GitHubLimitExceededError(
+      `file exceeds ${MAX_FILE_BYTES} bytes: ${rawUrl}`,
+    )
+  }
+  return response.arrayBuffer.slice(0)
+}
+
 // ---------------------------------------------------------------------------
 // Git Trees API:一次请求拿整棵树,后续 raw 下载不消耗 API 配额
 // ---------------------------------------------------------------------------
@@ -304,7 +335,7 @@ export type GitHubFetchResult = {
   files: FileEntry[]
   /** 显示用源名 */
   sourceName: string
-  /** 目录模式 = frontmatter.name;单文件模式 = 源文件名 */
+  /** 标准包目录名：优先 frontmatter.name，仅在无法解析时使用源名供校验报错 */
   targetName: string
   isDirectory: boolean
 }
@@ -352,18 +383,22 @@ async function buildSkillPackage(
     RAW_DOWNLOAD_CONCURRENCY,
     async (blob) => ({
       blob,
-      content: await fetchRawText(buildRawUrl(effectiveInfo, blob.path)),
+      data: await fetchRawBytes(buildRawUrl(effectiveInfo, blob.path)),
     }),
   )
 
   const files: FileEntry[] = []
   let skillMdContent = ''
-  for (const { blob, content } of downloaded) {
+  for (const { blob, data } of downloaded) {
     const relativePath = skillDir
       ? blob.path.slice(subtreePrefix.length)
       : blob.path
-    files.push({ relativePath, content })
-    if (blob.path === skillMdPath) skillMdContent = content
+    if (blob.path === skillMdPath) {
+      skillMdContent = new TextDecoder().decode(data)
+      files.push({ relativePath, content: skillMdContent })
+    } else {
+      files.push({ relativePath, data })
+    }
   }
 
   const fm = parseFrontmatter(skillMdContent)
@@ -403,11 +438,16 @@ export async function fetchGitHubSkill(
     const filePath = info.path!
     const content = await fetchRawText(buildRawUrl(info, filePath))
     const fileName = filePath.split('/').pop() ?? filePath
+    const frontmatter = parseFrontmatter(content)
+    const targetName =
+      typeof frontmatter?.name === 'string' && frontmatter.name.trim()
+        ? frontmatter.name.trim()
+        : fileName
     return [
       {
         files: [{ relativePath: fileName, content }],
         sourceName: fileName,
-        targetName: fileName,
+        targetName,
         isDirectory: false,
       },
     ]

--- a/src/core/skills/liteSkills.test.ts
+++ b/src/core/skills/liteSkills.test.ts
@@ -3,12 +3,15 @@ import { App, normalizePath } from 'obsidian'
 import {
   getLiteSkillDocument,
   getLiteSkillDocumentByPath,
+  getLiteSkillPackageSource,
   getSkillScanDirs,
   humanizeSkillName,
   listLiteSkillEntries,
+  migrateLegacySkillFilesToPackages,
   migrateVaultSkillFrontmatter,
   rewriteSkillFrontmatterIdToName,
 } from './liteSkills'
+import { resolveAssistantSkillPolicy } from './skillPolicy'
 
 const OBSIDIAN_CONFIG_DIR = ['.', 'obsidian'].join('')
 
@@ -336,12 +339,31 @@ const makeAdapterApp = ({
 }): App => {
   const reads = { ...fileContents }
   const writes: Array<{ path: string; content: string }> = []
+  const directoryListings = Object.fromEntries(
+    Object.entries(listings).map(([path, listing]) => [
+      normalizePath(path),
+      {
+        files: listing.files.map((file) => normalizePath(file)),
+        folders: listing.folders.map((folder) => normalizePath(folder)),
+      },
+    ]),
+  ) as Record<string, AdapterDirListing>
+
+  const parentPath = (path: string) => {
+    const slashIndex = path.lastIndexOf('/')
+    return slashIndex === -1 ? '' : path.slice(0, slashIndex)
+  }
 
   const adapter = {
-    exists: (path: string) =>
-      Promise.resolve(Boolean(listings[normalizePath(path)])),
+    exists: (path: string) => {
+      const normalized = normalizePath(path)
+      return Promise.resolve(
+        Boolean(directoryListings[normalized]) ||
+          Object.prototype.hasOwnProperty.call(reads, normalized),
+      )
+    },
     list: (path: string) => {
-      const listing = listings[normalizePath(path)]
+      const listing = directoryListings[normalizePath(path)]
       if (!listing) {
         return Promise.resolve({ files: [], folders: [] })
       }
@@ -355,6 +377,59 @@ const makeAdapterApp = ({
       const normalized = normalizePath(path)
       reads[normalized] = content
       writes.push({ path: normalized, content })
+      return Promise.resolve()
+    },
+    mkdir: (path: string) => {
+      const normalized = normalizePath(path)
+      if (
+        directoryListings[normalized] ||
+        Object.prototype.hasOwnProperty.call(reads, normalized)
+      ) {
+        return Promise.reject(new Error(`already exists: ${normalized}`))
+      }
+      directoryListings[normalized] = { files: [], folders: [] }
+      const parent = parentPath(normalized)
+      const parentListing = directoryListings[parent]
+      if (parentListing && !parentListing.folders.includes(normalized)) {
+        parentListing.folders.push(normalized)
+      }
+      return Promise.resolve()
+    },
+    rename: (source: string, target: string) => {
+      const normalizedSource = normalizePath(source)
+      const normalizedTarget = normalizePath(target)
+      if (!Object.prototype.hasOwnProperty.call(reads, normalizedSource)) {
+        return Promise.reject(new Error(`missing source: ${normalizedSource}`))
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(reads, normalizedTarget) ||
+        directoryListings[normalizedTarget]
+      ) {
+        return Promise.reject(new Error(`target exists: ${normalizedTarget}`))
+      }
+      reads[normalizedTarget] = reads[normalizedSource]
+      delete reads[normalizedSource]
+      const sourceParent = directoryListings[parentPath(normalizedSource)]
+      if (sourceParent) {
+        sourceParent.files = sourceParent.files.filter(
+          (path) => path !== normalizedSource,
+        )
+      }
+      const targetParent = directoryListings[parentPath(normalizedTarget)]
+      targetParent?.files.push(normalizedTarget)
+      return Promise.resolve()
+    },
+    rmdir: (path: string) => {
+      const normalized = normalizePath(path)
+      const listing = directoryListings[normalized]
+      if (!listing || listing.files.length > 0 || listing.folders.length > 0) {
+        return Promise.reject(new Error(`directory not empty: ${normalized}`))
+      }
+      delete directoryListings[normalized]
+      const parent = directoryListings[parentPath(normalized)]
+      if (parent) {
+        parent.folders = parent.folders.filter((item) => item !== normalized)
+      }
       return Promise.resolve()
     },
   }
@@ -403,32 +478,52 @@ describe('getSkillScanDirs', () => {
 describe('listLiteSkillEntries and getLiteSkillDocument', () => {
   const settings = { yolo: { baseDir: 'YOLO' } }
 
-  it('lists default-dir and hidden-dir skills via adapter scan', async () => {
+  it('lists only standard directory packages in default and hidden roots', async () => {
     const app = makeAdapterApp({
       listings: {
         'YOLO/skills': {
-          files: ['YOLO/skills/default-skill.md'],
+          files: ['YOLO/skills/legacy-root.md'],
+          folders: ['YOLO/skills/default-skill'],
+        },
+        'YOLO/skills/default-skill': {
+          files: ['YOLO/skills/default-skill/SKILL.md'],
           folders: [],
         },
         [`${OBSIDIAN_CONFIG_DIR}/skills`]: {
-          files: [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-skill.md`],
+          files: [`${OBSIDIAN_CONFIG_DIR}/skills/legacy-hidden.md`],
+          folders: [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-skill`],
+        },
+        [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-skill`]: {
+          files: [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-skill/SKILL.md`],
           folders: [],
         },
       },
       fileContents: {
-        'YOLO/skills/default-skill.md': [
+        'YOLO/skills/default-skill/SKILL.md': [
           '---',
           'name: default-skill',
           'description: from default dir',
           '---',
           '',
         ].join('\n'),
-        [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-skill.md`]: [
+        [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-skill/SKILL.md`]: [
           '---',
           'name: hidden-skill',
           'description: from hidden dir',
           '---',
           '',
+        ].join('\n'),
+        'YOLO/skills/legacy-root.md': [
+          '---',
+          'name: legacy-root',
+          'description: must not be scanned',
+          '---',
+        ].join('\n'),
+        [`${OBSIDIAN_CONFIG_DIR}/skills/legacy-hidden.md`]: [
+          '---',
+          'name: legacy-hidden',
+          'description: must not be scanned',
+          '---',
         ].join('\n'),
       },
     })
@@ -438,6 +533,8 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
 
     expect(names).toContain('default-skill')
     expect(names).toContain('hidden-skill')
+    expect(names).not.toContain('legacy-root')
+    expect(names).not.toContain('legacy-hidden')
   })
 
   it('discovers Claude-style SKILL.md under hidden directories', async () => {
@@ -472,23 +569,31 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
     const app = makeAdapterApp({
       listings: {
         'YOLO/skills': {
-          files: ['YOLO/skills/shared-skill.md'],
+          files: [],
+          folders: ['YOLO/skills/shared-skill'],
+        },
+        'YOLO/skills/shared-skill': {
+          files: ['YOLO/skills/shared-skill/SKILL.md'],
           folders: [],
         },
         [`${OBSIDIAN_CONFIG_DIR}/skills`]: {
-          files: [`${OBSIDIAN_CONFIG_DIR}/skills/shared-skill.md`],
+          files: [],
+          folders: [`${OBSIDIAN_CONFIG_DIR}/skills/shared-skill`],
+        },
+        [`${OBSIDIAN_CONFIG_DIR}/skills/shared-skill`]: {
+          files: [`${OBSIDIAN_CONFIG_DIR}/skills/shared-skill/SKILL.md`],
           folders: [],
         },
       },
       fileContents: {
-        'YOLO/skills/shared-skill.md': [
+        'YOLO/skills/shared-skill/SKILL.md': [
           '---',
           'name: shared-skill',
           'description: default wins',
           '---',
           '',
         ].join('\n'),
-        [`${OBSIDIAN_CONFIG_DIR}/skills/shared-skill.md`]: [
+        [`${OBSIDIAN_CONFIG_DIR}/skills/shared-skill/SKILL.md`]: [
           '---',
           'name: shared-skill',
           'description: hidden loses',
@@ -501,42 +606,8 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
     const entries = await listLiteSkillEntries(app, { settings })
     const shared = entries.find((entry) => entry.name === 'shared-skill')
 
-    expect(shared?.path).toBe('YOLO/skills/shared-skill.md')
+    expect(shared?.path).toBe('YOLO/skills/shared-skill/SKILL.md')
     expect(shared?.description).toBe('default wins')
-  })
-
-  it('uses path order within the same directory for duplicate names', async () => {
-    const app = makeAdapterApp({
-      listings: {
-        'YOLO/skills': {
-          files: ['YOLO/skills/b-skill.md', 'YOLO/skills/a-skill.md'],
-          folders: [],
-        },
-        [`${OBSIDIAN_CONFIG_DIR}/skills`]: { files: [], folders: [] },
-      },
-      fileContents: {
-        'YOLO/skills/a-skill.md': [
-          '---',
-          'name: same-name',
-          'description: first by path',
-          '---',
-          '',
-        ].join('\n'),
-        'YOLO/skills/b-skill.md': [
-          '---',
-          'name: same-name',
-          'description: second by path',
-          '---',
-          '',
-        ].join('\n'),
-      },
-    })
-
-    const entries = await listLiteSkillEntries(app, { settings })
-    const winner = entries.find((entry) => entry.name === 'same-name')
-
-    expect(winner?.path).toBe('YOLO/skills/a-skill.md')
-    expect(winner?.description).toBe('first by path')
   })
 
   it('opens a hidden-directory skill through the shared registry', async () => {
@@ -551,12 +622,16 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
       listings: {
         'YOLO/skills': { files: [], folders: [] },
         [`${OBSIDIAN_CONFIG_DIR}/skills`]: {
-          files: [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-open.md`],
+          files: [],
+          folders: [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-open`],
+        },
+        [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-open`]: {
+          files: [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-open/SKILL.md`],
           folders: [],
         },
       },
       fileContents: {
-        [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-open.md`]: content,
+        [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-open/SKILL.md`]: content,
       },
     })
 
@@ -567,9 +642,116 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
     })
 
     expect(document?.entry.path).toBe(
-      `${OBSIDIAN_CONFIG_DIR}/skills/hidden-open.md`,
+      `${OBSIDIAN_CONFIG_DIR}/skills/hidden-open/SKILL.md`,
     )
     expect(document?.content).toBe(content)
+  })
+
+  it('ignores nested and folder-name-mismatched packages', async () => {
+    const app = makeAdapterApp({
+      listings: {
+        'YOLO/skills': {
+          files: [],
+          folders: ['YOLO/skills/group', 'YOLO/skills/wrong-folder'],
+        },
+        'YOLO/skills/group': {
+          files: [],
+          folders: ['YOLO/skills/group/nested-skill'],
+        },
+        'YOLO/skills/group/nested-skill': {
+          files: ['YOLO/skills/group/nested-skill/SKILL.md'],
+          folders: [],
+        },
+        'YOLO/skills/wrong-folder': {
+          files: ['YOLO/skills/wrong-folder/SKILL.md'],
+          folders: [],
+        },
+      },
+      fileContents: {
+        'YOLO/skills/group/nested-skill/SKILL.md': [
+          '---',
+          'name: nested-skill',
+          'description: nested too deeply',
+          '---',
+        ].join('\n'),
+        'YOLO/skills/wrong-folder/SKILL.md': [
+          '---',
+          'name: other-name',
+          'description: folder mismatch',
+          '---',
+        ].join('\n'),
+      },
+    })
+
+    const names = (await listLiteSkillEntries(app, { settings })).map(
+      (entry) => entry.name,
+    )
+    expect(names).not.toContain('nested-skill')
+    expect(names).not.toContain('other-name')
+  })
+
+  it('exposes every package resource without flattening its paths', async () => {
+    const app = makeAdapterApp({
+      listings: {
+        'YOLO/skills': {
+          files: [],
+          folders: ['YOLO/skills/resourceful'],
+        },
+        'YOLO/skills/resourceful': {
+          files: ['YOLO/skills/resourceful/SKILL.md'],
+          folders: [
+            'YOLO/skills/resourceful/assets',
+            'YOLO/skills/resourceful/references',
+          ],
+        },
+        'YOLO/skills/resourceful/assets': {
+          files: ['YOLO/skills/resourceful/assets/icon.png'],
+          folders: [],
+        },
+        'YOLO/skills/resourceful/references': {
+          files: ['YOLO/skills/resourceful/references/guide.md'],
+          folders: [],
+        },
+      },
+      fileContents: {
+        'YOLO/skills/resourceful/SKILL.md': [
+          '---',
+          'name: resourceful',
+          'description: Uses package resources.',
+          '---',
+        ].join('\n'),
+        'YOLO/skills/resourceful/assets/icon.png': 'binary-path-placeholder',
+        'YOLO/skills/resourceful/references/guide.md': '# Guide',
+      },
+    })
+
+    const source = await getLiteSkillPackageSource({
+      app,
+      name: 'resourceful',
+      settings,
+    })
+
+    expect(source?.entry.name).toBe('resourceful')
+    expect(source?.resources).toHaveLength(3)
+    expect(source?.resources).toEqual(
+      expect.arrayContaining([
+        {
+          kind: 'vault',
+          path: 'YOLO/skills/resourceful/SKILL.md',
+          relativePath: 'SKILL.md',
+        },
+        {
+          kind: 'vault',
+          path: 'YOLO/skills/resourceful/assets/icon.png',
+          relativePath: 'assets/icon.png',
+        },
+        {
+          kind: 'vault',
+          path: 'YOLO/skills/resourceful/references/guide.md',
+          relativePath: 'references/guide.md',
+        },
+      ]),
+    )
   })
 
   it('resolves builtin skill documents by canonical path', async () => {
@@ -627,6 +809,182 @@ describe('migrateVaultSkillFrontmatter hidden dirs', () => {
 
     expect(migrated).toContain('name: legacy-hidden')
     expect(migrated).not.toMatch(/^id:/m)
+  })
+})
+
+describe('migrateLegacySkillFilesToPackages', () => {
+  const settings = { yolo: { baseDir: 'YOLO' } }
+
+  it('moves a valid root Markdown skill without changing content and is idempotent', async () => {
+    const sourcePath = 'YOLO/skills/old-filename.md'
+    const targetPath = 'YOLO/skills/stable-name/SKILL.md'
+    const content = [
+      '---',
+      'name: stable-name',
+      'description: Keeps assistant preference identity.',
+      '---',
+      '# Body',
+    ].join('\n')
+    const app = makeAdapterApp({
+      listings: {
+        'YOLO/skills': { files: [sourcePath], folders: [] },
+      },
+      fileContents: { [sourcePath]: content },
+    })
+
+    const first = await migrateLegacySkillFilesToPackages(app, settings)
+
+    expect(first).toEqual({
+      migrated: [{ name: 'stable-name', sourcePath, targetPath }],
+      issues: [],
+    })
+    await expect(app.vault.adapter.exists(sourcePath)).resolves.toBe(false)
+    await expect(app.vault.adapter.read(targetPath)).resolves.toBe(content)
+    expect(
+      (await listLiteSkillEntries(app, { settings })).find(
+        (entry) => entry.name === 'stable-name',
+      )?.path,
+    ).toBe(targetPath)
+    expect(
+      resolveAssistantSkillPolicy({
+        assistant: {
+          id: 'assistant-1',
+          name: 'Assistant',
+          systemPrompt: '',
+          skillPreferences: {
+            'stable-name': { enabled: false, loadMode: 'always' },
+          },
+        },
+        skillName: 'stable-name',
+      }),
+    ).toEqual({ enabled: false, loadMode: 'always' })
+
+    await expect(
+      migrateLegacySkillFilesToPackages(app, settings),
+    ).resolves.toEqual({ migrated: [], issues: [] })
+  })
+
+  it('keeps invalid sources and reports why each was skipped', async () => {
+    const noFrontmatter = 'YOLO/skills/no-frontmatter.md'
+    const invalidName = 'YOLO/skills/invalid-name.md'
+    const app = makeAdapterApp({
+      listings: {
+        'YOLO/skills': {
+          files: [noFrontmatter, invalidName],
+          folders: [],
+        },
+      },
+      fileContents: {
+        [noFrontmatter]: '# Body only',
+        [invalidName]: [
+          '---',
+          'name: Invalid Name',
+          'description: Invalid standard name.',
+          '---',
+        ].join('\n'),
+      },
+    })
+
+    const report = await migrateLegacySkillFilesToPackages(app, settings)
+
+    expect(report.migrated).toEqual([])
+    expect(report.issues).toEqual([
+      { sourcePath: invalidName, reason: 'invalid_name' },
+      { sourcePath: noFrontmatter, reason: 'invalid_frontmatter' },
+    ])
+    await expect(app.vault.adapter.exists(noFrontmatter)).resolves.toBe(true)
+    await expect(app.vault.adapter.exists(invalidName)).resolves.toBe(true)
+  })
+
+  it('never overwrites an existing package or removes the conflicting source', async () => {
+    const sourcePath = 'YOLO/skills/conflicting-source.md'
+    const existingPath = 'YOLO/skills/conflict/SKILL.md'
+    const existingResource = 'YOLO/skills/conflict/assets/keep.txt'
+    const app = makeAdapterApp({
+      listings: {
+        'YOLO/skills': {
+          files: [sourcePath],
+          folders: ['YOLO/skills/conflict'],
+        },
+        'YOLO/skills/conflict': {
+          files: [existingPath],
+          folders: ['YOLO/skills/conflict/assets'],
+        },
+        'YOLO/skills/conflict/assets': {
+          files: [existingResource],
+          folders: [],
+        },
+      },
+      fileContents: {
+        [sourcePath]: [
+          '---',
+          'name: conflict',
+          'description: Must remain at source.',
+          '---',
+        ].join('\n'),
+        [existingPath]: 'existing skill',
+        [existingResource]: 'existing resource',
+      },
+    })
+
+    const report = await migrateLegacySkillFilesToPackages(app, settings)
+
+    expect(report).toEqual({
+      migrated: [],
+      issues: [
+        {
+          sourcePath,
+          targetPath: existingPath,
+          reason: 'target_exists',
+        },
+      ],
+    })
+    await expect(app.vault.adapter.read(sourcePath)).resolves.toContain(
+      'Must remain at source.',
+    )
+    await expect(app.vault.adapter.read(existingPath)).resolves.toBe(
+      'existing skill',
+    )
+    await expect(app.vault.adapter.read(existingResource)).resolves.toBe(
+      'existing resource',
+    )
+  })
+
+  it('keeps the source and removes its empty target if moving fails', async () => {
+    const sourcePath = 'YOLO/skills/cannot-move.md'
+    const app = makeAdapterApp({
+      listings: {
+        'YOLO/skills': { files: [sourcePath], folders: [] },
+      },
+      fileContents: {
+        [sourcePath]: [
+          '---',
+          'name: cannot-move',
+          'description: Simulate an adapter failure.',
+          '---',
+        ].join('\n'),
+      },
+    })
+    ;(
+      app.vault.adapter as unknown as {
+        rename: (source: string, target: string) => Promise<void>
+      }
+    ).rename = () => Promise.reject(new Error('move failed'))
+
+    const report = await migrateLegacySkillFilesToPackages(app, settings)
+
+    expect(report.issues).toEqual([
+      {
+        sourcePath,
+        targetPath: 'YOLO/skills/cannot-move/SKILL.md',
+        reason: 'migration_failed',
+        error: 'move failed',
+      },
+    ])
+    await expect(app.vault.adapter.exists(sourcePath)).resolves.toBe(true)
+    await expect(
+      app.vault.adapter.exists('YOLO/skills/cannot-move'),
+    ).resolves.toBe(false)
   })
 })
 

--- a/src/core/skills/liteSkills.ts
+++ b/src/core/skills/liteSkills.ts
@@ -10,6 +10,7 @@ import {
   getBuiltinLiteSkillByName,
   listBuiltinLiteSkills,
 } from './builtinSkills'
+import { parseFrontmatter, validateSkillName } from './skillValidation'
 
 export type LiteSkillMode = 'lazy' | 'always'
 
@@ -30,7 +31,24 @@ export type LiteSkillDocument = {
   content: string
 }
 
-const CLAUDE_SKILL_FILE_NAME = 'SKILL.md'
+export type LiteSkillPackageResource =
+  | {
+      kind: 'vault'
+      relativePath: string
+      path: string
+    }
+  | {
+      kind: 'builtin'
+      relativePath: typeof SKILL_PACKAGE_ENTRY_FILE_NAME
+      content: string
+    }
+
+export type LiteSkillPackageSource = {
+  entry: LiteSkillEntry
+  resources: LiteSkillPackageResource[]
+}
+
+export const SKILL_PACKAGE_ENTRY_FILE_NAME = 'SKILL.md'
 
 type SkillSettings = {
   yolo?: {
@@ -87,45 +105,9 @@ const asTrimmedString = (value: unknown): string | null => {
   return trimmed.length > 0 ? trimmed : null
 }
 
-const stripWrappingQuotes = (value: string): string => {
-  const trimmed = value.trim()
-  if (
-    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-    (trimmed.startsWith("'") && trimmed.endsWith("'"))
-  ) {
-    return trimmed.slice(1, -1)
-  }
-  return trimmed
-}
-
 const parseFrontmatterFromContent = (
   content: string,
-): Record<string, string> | null => {
-  if (!content.startsWith('---\n')) {
-    return null
-  }
-
-  const closingIndex = content.indexOf('\n---\n', 4)
-  if (closingIndex === -1) {
-    return null
-  }
-
-  const frontmatterText = content.slice(4, closingIndex)
-  const lines = frontmatterText.split('\n')
-  const frontmatter: Record<string, string> = {}
-
-  for (const line of lines) {
-    const matched = line.match(/^([A-Za-z0-9_-]+)\s*:\s*(.+)$/)
-    if (!matched) {
-      continue
-    }
-    const key = matched[1]
-    const value = stripWrappingQuotes(matched[2])
-    frontmatter[key] = value
-  }
-
-  return frontmatter
-}
+): Record<string, unknown> | null => parseFrontmatter(content)
 
 const toLiteSkillEntry = ({
   path,
@@ -151,32 +133,6 @@ const toLiteSkillEntry = ({
   }
 }
 
-const isLiteSkillPath = ({
-  path,
-  skillsDir,
-}: {
-  path: string
-  skillsDir: string
-}): boolean => {
-  const normalizedDir = normalizePath(skillsDir)
-  const prefix = `${normalizedDir}/`
-  if (!path.startsWith(prefix) || !path.endsWith('.md')) {
-    return false
-  }
-
-  const fileName = path.slice(path.lastIndexOf('/') + 1)
-  if (fileName === YOLO_SKILLS_INDEX_FILE_NAME) {
-    return false
-  }
-
-  const relativePath = path.slice(prefix.length)
-  if (!relativePath.includes('/')) {
-    return true
-  }
-
-  return fileName === CLAUDE_SKILL_FILE_NAME
-}
-
 const listSkillPathsInDir = async (
   adapter: App['vault']['adapter'],
   skillsDir: string,
@@ -186,22 +142,61 @@ const listSkillPathsInDir = async (
     return []
   }
 
+  const listing = await adapter.list(normalizedDir)
   const paths: string[] = []
-  const collect = async (currentDir: string): Promise<void> => {
-    const listing = await adapter.list(currentDir)
-    for (const filePath of listing.files) {
-      const normalizedPath = normalizePath(filePath)
-      if (isLiteSkillPath({ path: normalizedPath, skillsDir: normalizedDir })) {
-        paths.push(normalizedPath)
-      }
+  for (const rawFolderPath of listing.folders) {
+    const folderPath = normalizePath(rawFolderPath)
+    const relativePath = folderPath.slice(normalizedDir.length + 1)
+    if (!relativePath || relativePath.includes('/')) {
+      continue
     }
-    for (const folderPath of listing.folders) {
-      await collect(normalizePath(folderPath))
+    const skillPath = normalizePath(
+      `${folderPath}/${SKILL_PACKAGE_ENTRY_FILE_NAME}`,
+    )
+    if (await adapter.exists(skillPath)) {
+      paths.push(skillPath)
     }
   }
-
-  await collect(normalizedDir)
   return paths.sort((a, b) => a.localeCompare(b))
+}
+
+const listLegacyRootSkillPaths = async (
+  adapter: App['vault']['adapter'],
+  skillsDir: string,
+): Promise<string[]> => {
+  const normalizedDir = normalizePath(skillsDir)
+  if (!(await adapter.exists(normalizedDir))) {
+    return []
+  }
+
+  const listing = await adapter.list(normalizedDir)
+  return listing.files
+    .map((path) => normalizePath(path))
+    .filter((path) => {
+      const fileName = path.slice(path.lastIndexOf('/') + 1)
+      return (
+        fileName !== YOLO_SKILLS_INDEX_FILE_NAME && fileName.endsWith('.md')
+      )
+    })
+    .sort((a, b) => a.localeCompare(b))
+}
+
+const getSkillPackageDirName = (skillPath: string): string | null => {
+  const suffix = `/${SKILL_PACKAGE_ENTRY_FILE_NAME}`
+  if (!skillPath.endsWith(suffix)) {
+    return null
+  }
+  const packageDir = skillPath.slice(0, -suffix.length)
+  const slashIndex = packageDir.lastIndexOf('/')
+  return packageDir.slice(slashIndex + 1) || null
+}
+
+export const getSkillPackageDirPath = (skillPath: string): string | null => {
+  const normalizedPath = normalizePath(skillPath)
+  const suffix = `/${SKILL_PACKAGE_ENTRY_FILE_NAME}`
+  return normalizedPath.endsWith(suffix)
+    ? normalizedPath.slice(0, -suffix.length)
+    : null
 }
 
 const readSkillFileContent = async (
@@ -223,10 +218,6 @@ const resolveSkillFrontmatter = async (
   const metadataFrontmatter = file
     ? app.metadataCache.getFileCache(file)?.frontmatter
     : undefined
-  if (asTrimmedString(metadataFrontmatter?.name)) {
-    return metadataFrontmatter ?? null
-  }
-
   const content = await readSkillFileContent(app, path, file)
   const parsedFrontmatter = parseFrontmatterFromContent(content)
   return {
@@ -299,7 +290,11 @@ const buildSkillRegistry = async ({
       const file = app.vault.getFileByPath(path)
       const frontmatter = await resolveSkillFrontmatter(app, path, file)
       const entry = toLiteSkillEntry({ path, frontmatter })
-      if (!entry) {
+      if (
+        !entry ||
+        validateSkillName(entry.name).length > 0 ||
+        getSkillPackageDirName(path) !== entry.name
+      ) {
         continue
       }
       if (vaultClaimed.has(entry.name)) {
@@ -425,6 +420,72 @@ export async function getLiteSkillDocumentByPath({
   return null
 }
 
+const listPackageResourcePaths = async (
+  adapter: App['vault']['adapter'],
+  packageDir: string,
+): Promise<string[]> => {
+  const paths: string[] = []
+  const collect = async (dir: string): Promise<void> => {
+    const listing = await adapter.list(dir)
+    paths.push(...listing.files.map((path) => normalizePath(path)))
+    for (const folder of listing.folders) {
+      await collect(normalizePath(folder))
+    }
+  }
+  await collect(packageDir)
+  return paths.sort((a, b) => a.localeCompare(b))
+}
+
+/**
+ * Resolve the complete package behind a canonical frontmatter name. Vault
+ * resources are returned as paths so downstream materializers can preserve
+ * text and binary files with the adapter operation appropriate to each file.
+ */
+export async function getLiteSkillPackageSource({
+  app,
+  name,
+  settings,
+}: {
+  app: App
+  name?: string
+  settings?: SkillSettings
+}): Promise<LiteSkillPackageSource | null> {
+  const document = await getLiteSkillDocument({ app, name, settings })
+  if (!document) {
+    return null
+  }
+
+  if (document.entry.path.startsWith('builtin://')) {
+    return {
+      entry: document.entry,
+      resources: [
+        {
+          kind: 'builtin',
+          relativePath: SKILL_PACKAGE_ENTRY_FILE_NAME,
+          content: document.content,
+        },
+      ],
+    }
+  }
+
+  const packageDir = getSkillPackageDirPath(document.entry.path)
+  if (!packageDir) {
+    return null
+  }
+  const prefix = `${packageDir}/`
+  const resources = (
+    await listPackageResourcePaths(app.vault.adapter, packageDir)
+  ).map(
+    (path): LiteSkillPackageResource => ({
+      kind: 'vault',
+      path,
+      relativePath: path.slice(prefix.length),
+    }),
+  )
+
+  return { entry: document.entry, resources }
+}
+
 /**
  * Convert a canonical skill `name` (typically kebab-case, e.g.
  * `english-polisher`) into a human-friendly Title Case label
@@ -544,11 +605,11 @@ export function rewriteSkillFrontmatterIdToName(
 
 /**
  * One-time, idempotent migration of vault skill files from the legacy
- * `id + name` frontmatter to the converged `name`-only form. Scans every skill
- * file under any configured skill scan directory and, when a file carries a valid `id`,
- * promotes `id` -> `name` and removes the `id` line. Files without a valid `id`
- * are skipped. Per-file failures are logged and skipped without aborting the
- * batch.
+ * `id + name` frontmatter to the converged `name`-only form. Scans standard
+ * directory packages plus root-level legacy Markdown sources and, when a file
+ * carries a valid `id`, promotes `id` -> `name` and removes the `id` line.
+ * Files without a valid `id` are skipped. Per-file failures are logged and
+ * skipped without aborting the batch.
  *
  * Must run before any skill list/get so callers never observe a mixed state.
  */
@@ -564,7 +625,12 @@ export async function migrateVaultSkillFrontmatter(
     settings,
     configDir: app.vault.configDir,
   })) {
-    const paths = await listSkillPathsInDir(app.vault.adapter, skillsDir)
+    const paths = [
+      ...new Set([
+        ...(await listLegacyRootSkillPaths(app.vault.adapter, skillsDir)),
+        ...(await listSkillPathsInDir(app.vault.adapter, skillsDir)),
+      ]),
+    ].sort((a, b) => a.localeCompare(b))
     for (const path of paths) {
       try {
         const file = app.vault.getFileByPath(path)
@@ -604,4 +670,149 @@ export async function migrateVaultSkillFrontmatter(
       }
     }
   }
+}
+
+export type LegacySkillPackageMigrationIssueReason =
+  | 'invalid_frontmatter'
+  | 'invalid_name'
+  | 'target_exists'
+  | 'migration_failed'
+
+export type LegacySkillPackageMigrationIssue = {
+  sourcePath: string
+  targetPath?: string
+  reason: LegacySkillPackageMigrationIssueReason
+  error?: string
+}
+
+export type LegacySkillPackageMigrationReport = {
+  migrated: Array<{
+    name: string
+    sourcePath: string
+    targetPath: string
+  }>
+  issues: LegacySkillPackageMigrationIssue[]
+}
+
+const removeEmptyDirIfPresent = async (
+  adapter: App['vault']['adapter'],
+  path: string,
+): Promise<void> => {
+  if (!(await adapter.exists(path))) {
+    return
+  }
+  const listing = await adapter.list(path)
+  if (listing.files.length === 0 && listing.folders.length === 0) {
+    await adapter.rmdir(path, false)
+  }
+}
+
+/**
+ * Move root-level legacy Markdown skills into standard directory packages.
+ *
+ * The migration is intentionally conservative and idempotent: identity comes
+ * only from a standards-valid frontmatter `name`; an existing target path is
+ * always treated as a conflict; and failed/invalid sources are never removed.
+ */
+export async function migrateLegacySkillFilesToPackages(
+  app: App,
+  settings?: SkillSettings,
+): Promise<LegacySkillPackageMigrationReport> {
+  const report: LegacySkillPackageMigrationReport = {
+    migrated: [],
+    issues: [],
+  }
+
+  for (const skillsDir of getSkillScanDirs({
+    settings,
+    configDir: app.vault.configDir,
+  })) {
+    const sourcePaths = await listLegacyRootSkillPaths(
+      app.vault.adapter,
+      skillsDir,
+    )
+    for (const sourcePath of sourcePaths) {
+      let targetDir: string | null = null
+      let createdTargetDir = false
+      try {
+        const content = await app.vault.adapter.read(sourcePath)
+        const frontmatter = parseFrontmatterFromContent(content)
+        if (!frontmatter) {
+          report.issues.push({
+            sourcePath,
+            reason: 'invalid_frontmatter',
+          })
+          continue
+        }
+
+        const nameErrors = validateSkillName(frontmatter.name)
+        if (nameErrors.length > 0 || typeof frontmatter.name !== 'string') {
+          report.issues.push({ sourcePath, reason: 'invalid_name' })
+          continue
+        }
+
+        const name = frontmatter.name.trim()
+        targetDir = normalizePath(`${skillsDir}/${name}`)
+        const targetPath = normalizePath(
+          `${targetDir}/${SKILL_PACKAGE_ENTRY_FILE_NAME}`,
+        )
+        if (await app.vault.adapter.exists(targetDir)) {
+          report.issues.push({
+            sourcePath,
+            targetPath,
+            reason: 'target_exists',
+          })
+          continue
+        }
+
+        await app.vault.adapter.mkdir(targetDir)
+        createdTargetDir = true
+        if (await app.vault.adapter.exists(targetPath)) {
+          await removeEmptyDirIfPresent(app.vault.adapter, targetDir)
+          report.issues.push({
+            sourcePath,
+            targetPath,
+            reason: 'target_exists',
+          })
+          continue
+        }
+        await app.vault.adapter.rename(sourcePath, targetPath)
+        report.migrated.push({ name, sourcePath, targetPath })
+      } catch (error) {
+        if (targetDir && createdTargetDir) {
+          try {
+            await removeEmptyDirIfPresent(app.vault.adapter, targetDir)
+          } catch (cleanupError) {
+            console.warn(
+              `[YOLO] Failed to clean up skill migration target ${targetDir}.`,
+              cleanupError,
+            )
+          }
+        }
+        report.issues.push({
+          sourcePath,
+          ...(targetDir
+            ? {
+                targetPath: normalizePath(
+                  `${targetDir}/${SKILL_PACKAGE_ENTRY_FILE_NAME}`,
+                ),
+              }
+            : {}),
+          reason: 'migration_failed',
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+  }
+
+  return report
+}
+
+/** Run all vault-skill upgrades in dependency order at startup. */
+export async function migrateVaultSkillsToDirectoryPackages(
+  app: App,
+  settings?: SkillSettings,
+): Promise<LegacySkillPackageMigrationReport> {
+  await migrateVaultSkillFrontmatter(app, settings)
+  return migrateLegacySkillFilesToPackages(app, settings)
 }

--- a/src/core/skills/skillImportLimits.test.ts
+++ b/src/core/skills/skillImportLimits.test.ts
@@ -1,0 +1,19 @@
+import {
+  MAX_SKILL_PACKAGE_IMPORT_DEPTH,
+  SkillPackageImportDepthExceededError,
+  assertSkillPackageImportDepth,
+} from './skillImportLimits'
+
+describe('skill package import depth', () => {
+  it('allows the configured boundary', () => {
+    expect(() =>
+      assertSkillPackageImportDepth(MAX_SKILL_PACKAGE_IMPORT_DEPTH),
+    ).not.toThrow()
+  })
+
+  it('rejects the whole package beyond the configured boundary', () => {
+    expect(() =>
+      assertSkillPackageImportDepth(MAX_SKILL_PACKAGE_IMPORT_DEPTH + 1),
+    ).toThrow(SkillPackageImportDepthExceededError)
+  })
+})

--- a/src/core/skills/skillImportLimits.ts
+++ b/src/core/skills/skillImportLimits.ts
@@ -1,0 +1,21 @@
+export const MAX_SKILL_PACKAGE_IMPORT_DEPTH = 16
+
+export class SkillPackageImportDepthExceededError extends Error {
+  readonly maxDepth: number
+
+  constructor(maxDepth: number = MAX_SKILL_PACKAGE_IMPORT_DEPTH) {
+    super(`Skill package exceeds the maximum import depth of ${maxDepth}.`)
+    this.name = 'SkillPackageImportDepthExceededError'
+    this.maxDepth = maxDepth
+  }
+}
+
+/** Reject the complete package before silently dropping deep resources. */
+export const assertSkillPackageImportDepth = (
+  depth: number,
+  maxDepth: number = MAX_SKILL_PACKAGE_IMPORT_DEPTH,
+): void => {
+  if (depth > maxDepth) {
+    throw new SkillPackageImportDepthExceededError(maxDepth)
+  }
+}

--- a/src/core/skills/skillValidation.test.ts
+++ b/src/core/skills/skillValidation.test.ts
@@ -5,6 +5,7 @@ import {
   validateDirectoryPackage,
   validateSingleFileSkill,
   validateSkillName,
+  wrapMarkdownAsSkillPackage,
 } from './skillValidation'
 
 // ---------------------------------------------------------------------------
@@ -422,7 +423,7 @@ describe('validateSingleFileSkill', () => {
   it('passes for valid single file skill', () => {
     const content = [
       '---',
-      'name: My Custom Skill',
+      'name: my-custom-skill',
       'description: Does something useful.',
       '---',
       '',
@@ -449,17 +450,21 @@ describe('validateSingleFileSkill', () => {
     })
   })
 
-  it('passes with name only (legacy format allows free-form names)', () => {
+  it('requires a standards-valid name and description before wrapping', () => {
     const content = ['---', 'name: Any Name With Spaces', '---'].join('\n')
-    // Legacy 格式不强制 name 命名规范
-    expect(validateSingleFileSkill(content)).toEqual([])
+    expect(validateSingleFileSkill(content)).toEqual(
+      expect.arrayContaining([
+        { field: 'name', message: 'uppercase not allowed' },
+        { field: 'description', message: 'missing' },
+      ]),
+    )
   })
 
   it('passes with all frontmatter fields', () => {
     const content = [
       '---',
       'id: custom-id',
-      'name: My Skill',
+      'name: my-skill',
       'description: Detailed description here.',
       'mode: always',
       '---',
@@ -467,5 +472,32 @@ describe('validateSingleFileSkill', () => {
       'Body content.',
     ].join('\n')
     expect(validateSingleFileSkill(content)).toEqual([])
+  })
+
+  it('wraps a single Markdown input as <frontmatter.name>/SKILL.md', () => {
+    const content = [
+      '---',
+      'name: imported-skill',
+      'description: Imported from one Markdown file.',
+      '---',
+      '# Instructions',
+    ].join('\n')
+
+    expect(wrapMarkdownAsSkillPackage(content)).toEqual({
+      package: {
+        name: 'imported-skill',
+        description: 'Imported from one Markdown file.',
+        files: [{ relativePath: 'SKILL.md', content }],
+      },
+      errors: [],
+    })
+  })
+
+  it('does not derive package identity from an invalid input filename', () => {
+    const content = ['---', 'description: Missing name.', '---'].join('\n')
+    const result = wrapMarkdownAsSkillPackage(content)
+
+    expect(result.package).toBeNull()
+    expect(result.errors).toContainEqual({ field: 'name', message: 'missing' })
   })
 })

--- a/src/core/skills/skillValidation.ts
+++ b/src/core/skills/skillValidation.ts
@@ -135,7 +135,10 @@ export function parseFrontmatter(
 
 export type FileEntry = {
   relativePath: string
-  content: string
+  /** Text content for SKILL.md and text-only remote inputs. */
+  content?: string
+  /** Exact bytes for package resources that must not be text-decoded. */
+  data?: ArrayBuffer
 }
 
 /**
@@ -152,6 +155,10 @@ export function validateDirectoryPackage(
   const skillMdEntry = files.find((f) => f.relativePath === 'SKILL.md')
   if (!skillMdEntry) {
     errors.push({ field: 'SKILL.md', message: 'missing' })
+    return errors
+  }
+  if (typeof skillMdEntry.content !== 'string') {
+    errors.push({ field: 'SKILL.md', message: 'must be text' })
     return errors
   }
 
@@ -185,24 +192,58 @@ export function validateDirectoryPackage(
 }
 
 /**
- * 对单文件格式的 skill 进行校验(Legacy 格式)。
- * 要求有 frontmatter 且包含 name 字段。
+ * 校验将被包装为 `<name>/SKILL.md` 的单个 Markdown 输入。
+ * 单文件只是导入边界，落盘后仍必须是完整的标准目录包。
  */
 export function validateSingleFileSkill(content: string): ValidationError[] {
-  const errors: ValidationError[] = []
-
   const frontmatter = parseFrontmatter(content)
   if (!frontmatter) {
-    errors.push({ field: 'frontmatter', message: 'missing or invalid' })
-    return errors
+    return [{ field: 'frontmatter', message: 'missing or invalid' }]
   }
 
+  return [
+    ...validateSkillName(frontmatter.name),
+    ...validateDescription(frontmatter.description),
+    ...validateCompatibility(frontmatter.compatibility),
+  ]
+}
+
+export type WrappedMarkdownSkillPackage = {
+  name: string
+  description: string
+  files: FileEntry[]
+}
+
+/**
+ * 把通过标准校验的单 Markdown 输入包装成目录包。
+ * 返回校验错误而不猜测文件名，确保身份始终来自 frontmatter.name。
+ */
+export function wrapMarkdownAsSkillPackage(content: string): {
+  package: WrappedMarkdownSkillPackage | null
+  errors: ValidationError[]
+} {
+  const errors = validateSingleFileSkill(content)
+  if (errors.length > 0) {
+    return { package: null, errors }
+  }
+
+  const frontmatter = parseFrontmatter(content)
   if (
-    typeof frontmatter.name !== 'string' ||
-    frontmatter.name.trim().length === 0
+    typeof frontmatter?.name !== 'string' ||
+    typeof frontmatter.description !== 'string'
   ) {
-    errors.push({ field: 'name', message: 'missing' })
+    return {
+      package: null,
+      errors: [{ field: 'frontmatter', message: 'missing or invalid' }],
+    }
   }
 
-  return errors
+  return {
+    package: {
+      name: frontmatter.name.trim(),
+      description: frontmatter.description.trim(),
+      files: [{ relativePath: 'SKILL.md', content }],
+    },
+    errors: [],
+  }
 }

--- a/src/core/skills/templates.ts
+++ b/src/core/skills/templates.ts
@@ -11,12 +11,12 @@ export const getSkillsPathAwareTemplate = (
 
 export const YOLO_SKILLS_INDEX_TEMPLATE = `# YOLO Skills
 
-Store your skill files here.
+Store standard Agent Skills directory packages here.
 
-- Supported formats:
-  - Legacy: \`YOLO/skills/*.md\` (exclude \`Skills.md\`)
-  - Claude-style: \`YOLO/skills/**/SKILL.md\`
-- Required frontmatter: \`name\` (required, kebab-case unique identifier), \`description\` (optional); \`mode\` (\`lazy\` | \`always\`, optional)
+- Required layout: \`YOLO/skills/<name>/SKILL.md\`
+- The directory name must exactly match frontmatter \`name\`.
+- Required frontmatter: \`name\` (kebab-case unique identifier) and \`description\`; \`mode\` (\`lazy\` | \`always\`) is optional.
+- Keep supporting \`scripts/\`, \`references/\`, \`assets/\`, and other resources inside the same \`<name>/\` package.
 `
 
 export const YOLO_OBSIDIAN_OUTPUT_FORMAT_TEMPLATE = `---
@@ -110,17 +110,20 @@ Obsidian vaults contain the user's real data. Prefer minimal edits, explicit ver
 
 ## Anatomy of a Skill
 
-Every YOLO skill is a single \`.md\` file stored in the vault's \`YOLO/skills/\` folder:
+Every YOLO skill is a self-contained directory package stored in the vault's \`YOLO/skills/\` folder:
 
 ~~~
 YOLO/skills/
-├── skill-creator.md
-├── meeting-notes.md
-├── pdf-editor.md
+├── meeting-notes/
+│   ├── SKILL.md
+│   └── references/
+├── pdf-editor/
+│   ├── SKILL.md
+│   └── scripts/
 └── ...
 ~~~
 
-Each skill \`.md\` file consists of two parts:
+Each package has a required \`SKILL.md\` entry file with two parts, plus optional resources used by its workflow:
 
 ### Frontmatter (YAML, required)
 
@@ -179,12 +182,12 @@ Key principle: When a skill supports multiple variations or domains, split into 
 ~~~
 # Instead of one monolithic "data-analysis" skill:
 YOLO/skills/
-├── bigquery-finance.md
-├── bigquery-sales.md
-└── bigquery-product.md
+├── bigquery-finance/SKILL.md
+├── bigquery-sales/SKILL.md
+└── bigquery-product/SKILL.md
 ~~~
 
-This way, when the user asks about sales metrics, only \`bigquery-sales.md\` activates and loads.
+This way, when the user asks about sales metrics, only \`bigquery-sales/SKILL.md\` activates and loads.
 
 ## Available Tools
 
@@ -240,7 +243,7 @@ Before creating something new, check what already exists:
 ~~~
 fs_list YOLO/skills/          -> see current inventory
 fs_search <topic keywords>    -> find related skills
-fs_read <similar-skill.md>    -> study patterns that work (prefer line ranges when a section is known)
+fs_read <similar-skill>/SKILL.md -> study patterns that work (prefer line ranges when a section is known)
 ~~~
 
 This avoids duplication and helps maintain consistency across the vault's skill collection.
@@ -258,7 +261,7 @@ Analyze each concrete example by considering:
 Write the frontmatter first, then the body.
 
 Frontmatter checklist:
-- \`name\` is kebab-case, unique, and matches the filename
+- \`name\` is kebab-case, unique, and exactly matches the package directory name
 - \`description\` clearly states what the skill does and when to trigger it
 
 Body guidelines:
@@ -270,10 +273,11 @@ Body guidelines:
 ### Step 5: Write to Vault
 
 ~~~
-fs_write { path: "YOLO/skills/<skill-name>.md", content: "..." }
+fs_create_dir { path: "YOLO/skills/<skill-name>" }
+fs_write { path: "YOLO/skills/<skill-name>/SKILL.md", content: "..." }
 ~~~
 
-For updates to existing skills, prefer \`fs_edit\` to make minimal, targeted changes rather than rewriting the entire file.
+Put scripts, references, assets, and other supporting files under the same package directory. For updates to existing skills, prefer \`fs_edit\` to make minimal, targeted changes rather than rewriting the entire entry file.
 
 ### Step 6: Verify and Iterate
 
@@ -297,7 +301,8 @@ Before finalizing any skill, verify:
 
 - [ ] Frontmatter includes \`name\` and \`description\`
 - [ ] Description states clear trigger conditions (not buried in body)
-- [ ] \`name\` is kebab-case and matches the filename
+- [ ] \`name\` is kebab-case and matches the package directory name
+- [ ] The entry file is exactly \`<name>/SKILL.md\`, with all supporting resources kept inside \`<name>/\`
 - [ ] Workflow is executable with available tools (\`fs_list\`, \`fs_search\`, \`fs_read\`, \`fs_edit\`, \`fs_write\`, \`fs_delete\`, \`fs_create_dir\`, \`fs_move\`)
 - [ ] Instructions are concise and avoid redundant background
 - [ ] Output pattern is defined where consistency matters

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -467,7 +467,7 @@ export const en: TranslationKeys = {
       skillsCount: '{count} skills',
       skillsCountWithEnabled: '{count} skills (enabled {enabled})',
       skillsGlobalDesc:
-        'Skills are discovered from built-in skills and {path}/**/*.md (excluding Skills.md where applicable). Disable a skill here to block it for all agents.',
+        'Skills are discovered from built-in skills and {path}/<name>/SKILL.md packages. Disable a skill here to block it for all agents.',
       yoloBaseDir: 'YOLO base folder',
       yoloBaseDirDesc:
         'Enter a vault-relative path (without a leading /). Example: use YOLO at vault root, or setting/YOLO under the setting folder.',
@@ -487,16 +487,15 @@ export const en: TranslationKeys = {
       yoloBaseDirConflictTitle: 'YOLO root was not moved',
       yoloBaseDirConflictMessage:
         '{target} already exists and contains files. Nothing was moved to avoid overwriting or merging data. Choose an empty or nonexistent folder.',
-      skillsSourcePath:
-        'Source: built-in skills + {path}/*.md + {path}/**/SKILL.md',
+      skillsSourcePath: 'Source: built-in skills + {path}/<name>/SKILL.md',
       refreshSkills: 'Refresh',
       skillsEmptyHint:
-        'No skills found. Create skill markdown files under {path}.',
+        'No skills found. Create a {path}/<name>/SKILL.md package.',
       createSkillTemplates: 'Initialize Skills system',
       skillsTemplateCreated: 'Skills system initialized in {path}.',
       importSkill: 'Import Skill',
       importSkillDesc:
-        'Import skill packages into {path}. Supports single .md files or Agent Skills standard folders.',
+        'Import skill packages into {path}. Single Markdown files are wrapped as <name>/SKILL.md; folders keep SKILL.md and all package resources.',
       importSkillDropzoneText: 'Drag & drop skill files or folders here',
       importSkillBrowseFiles: 'Browse Files',
       importSkillBrowseFolder: 'Browse Folder',
@@ -550,16 +549,31 @@ export const en: TranslationKeys = {
       importSkillFromUrlFetchError: 'Failed to fetch from GitHub: {error}',
       deleteSkillTitle: 'Delete skill',
       deleteSkillMessage:
-        'Are you sure you want to delete "{name}"? This cannot be undone.',
+        'Are you sure you want to delete the "{name}" skill package, including all resources? This cannot be undone.',
       deleteSkillConfirm: 'Delete',
       deleteSkillSuccess: '"{name}" has been deleted.',
       deleteSkillError: 'Failed to delete "{name}": {error}',
+      deleteSkillInvalidPackage: 'Invalid skill package path',
+      deleteSkillNotFound: 'Skill package not found',
       deleteSkillBatchMessage:
-        'Are you sure you want to delete {count} skill(s)? This cannot be undone.',
+        'Are you sure you want to delete {count} skill package(s), including all resources? This cannot be undone.',
       deleteSkillBatchSuccess: 'Deleted {count} skill(s).',
       deleteSkillBatchBtn: 'Delete',
       deleteSkillSelectAll: 'Select all',
       deleteSkillCancel: 'Cancel',
+      skillPackageMigrationIssues:
+        '{count} legacy skill file(s) need attention. YOLO did not overwrite or delete them:',
+      skillPackageMigrationInvalidFrontmatter:
+        '{path}: missing or invalid YAML frontmatter; file was kept.',
+      skillPackageMigrationInvalidName:
+        '{path}: frontmatter name must be 1–64 lowercase letters, numbers, or hyphens; file was kept.',
+      skillPackageMigrationConflict:
+        '{path}: target {target} already exists; file was kept.',
+      skillPackageMigrationFileFailed:
+        '{path}: migration failed ({error}); file was kept.',
+      skillPackageMigrationUnknownError: 'Unknown error',
+      skillPackageMigrationFailed:
+        'YOLO could not finish upgrading legacy skill files. The source files were kept; review the console and move them manually.',
       selectSkills: 'Select',
       agents: 'Agents',
       agentsDesc: 'Click Configure to edit each agent profile and prompt.',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -506,6 +506,8 @@ export const en: TranslationKeys = {
       importSkillSuccess: 'Successfully imported {count} skill(s).',
       importSkillInvalidFile: 'No valid skill files or packages found.',
       importSkillReadError: 'Failed to read files.',
+      importSkillErrTooDeep:
+        'Skill package exceeds the maximum import depth of {depth}. Nothing was imported.',
       importSkillWriteError: 'Failed to import {name}: {error}',
       importSkillErrHeader: '"{name}" cannot be imported:',
       importSkillErrNoSkillMd: 'missing SKILL.md file in folder',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -533,6 +533,8 @@ export const it: DeepPartial<TranslationKeys> = {
       importSkillSuccess: 'Importate con successo {count} skill.',
       importSkillInvalidFile: 'Nessun file o pacchetto skill valido trovato.',
       importSkillReadError: 'Impossibile leggere i file.',
+      importSkillErrTooDeep:
+        'Il pacchetto skill supera la profondità massima di importazione di {depth}. Non è stato importato nulla.',
       importSkillWriteError: 'Impossibile importare {name}: {error}',
       importSkillErrHeader: '"{name}" non può essere importato:',
       importSkillErrNoSkillMd: 'file SKILL.md mancante nella cartella',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -494,7 +494,7 @@ export const it: DeepPartial<TranslationKeys> = {
       skillsCount: '{count} competenze',
       skillsCountWithEnabled: '{count} competenze (abilitate {enabled})',
       skillsGlobalDesc:
-        'Le skill vengono rilevate dalle skill integrate e da {path}/**/*.md (escludendo Skills.md quando applicabile). Disabilitale qui per bloccarle su tutti gli agent.',
+        'Le skill vengono rilevate dalle skill integrate e dai pacchetti {path}/<name>/SKILL.md. Disabilitale qui per bloccarle su tutti gli agent.',
       yoloBaseDir: 'Cartella base YOLO',
       yoloBaseDirDesc:
         'Inserisci un percorso relativo al vault (senza / iniziale). Esempio: YOLO nella radice del vault, oppure setting/YOLO nella cartella setting.',
@@ -514,16 +514,15 @@ export const it: DeepPartial<TranslationKeys> = {
       yoloBaseDirConflictTitle: 'La cartella base YOLO non è stata spostata',
       yoloBaseDirConflictMessage:
         '{target} esiste già e contiene file. Nessun contenuto è stato spostato per evitare sovrascritture o fusioni. Scegli una cartella vuota o inesistente.',
-      skillsSourcePath:
-        'Origine: skill integrate + {path}/*.md + {path}/**/SKILL.md',
+      skillsSourcePath: 'Origine: skill integrate + {path}/<name>/SKILL.md',
       refreshSkills: 'Aggiorna',
       skillsEmptyHint:
-        'Nessuna skill trovata. Crea file markdown skill sotto {path}.',
+        'Nessuna skill trovata. Crea un pacchetto {path}/<name>/SKILL.md.',
       createSkillTemplates: 'Inizializza sistema Skills',
       skillsTemplateCreated: 'Sistema Skills inizializzato in {path}.',
       importSkill: 'Importa Skill',
       importSkillDesc:
-        'Importa pacchetti skill in {path}. Supporta file .md singoli o cartelle standard Agent Skills.',
+        'Importa pacchetti skill in {path}. I singoli file Markdown vengono inseriti in <name>/SKILL.md; le cartelle conservano SKILL.md e tutte le risorse.',
       importSkillDropzoneText: 'Trascina file o cartelle skill qui',
       importSkillBrowseFiles: 'Sfoglia File',
       importSkillBrowseFolder: 'Sfoglia Cartella',
@@ -568,16 +567,31 @@ export const it: DeepPartial<TranslationKeys> = {
         'Nome skill duplicato in questo batch: "{name}" (da "{source}"). Viene mantenuta solo la prima occorrenza.',
       deleteSkillTitle: 'Elimina skill',
       deleteSkillMessage:
-        'Sei sicuro di voler eliminare "{name}"? Questa azione non può essere annullata.',
+        'Sei sicuro di voler eliminare il pacchetto skill "{name}", incluse tutte le risorse? Questa azione non può essere annullata.',
       deleteSkillConfirm: 'Elimina',
       deleteSkillSuccess: '"{name}" è stata eliminata.',
       deleteSkillError: 'Impossibile eliminare "{name}": {error}',
+      deleteSkillInvalidPackage: 'Percorso del pacchetto skill non valido',
+      deleteSkillNotFound: 'Pacchetto skill non trovato',
       deleteSkillBatchMessage:
-        'Sei sicuro di voler eliminare {count} skill? Questa azione non può essere annullata.',
+        'Sei sicuro di voler eliminare {count} pacchetti skill, incluse tutte le risorse? Questa azione non può essere annullata.',
       deleteSkillBatchSuccess: 'Eliminate {count} skill.',
       deleteSkillBatchBtn: 'Elimina',
       deleteSkillSelectAll: 'Seleziona tutto',
       deleteSkillCancel: 'Annulla',
+      skillPackageMigrationIssues:
+        '{count} file skill legacy richiedono attenzione. YOLO non li ha sovrascritti o eliminati:',
+      skillPackageMigrationInvalidFrontmatter:
+        '{path}: frontmatter YAML mancante o non valido; il file è stato conservato.',
+      skillPackageMigrationInvalidName:
+        '{path}: il nome nel frontmatter deve contenere 1–64 lettere minuscole, numeri o trattini; il file è stato conservato.',
+      skillPackageMigrationConflict:
+        '{path}: la destinazione {target} esiste già; il file è stato conservato.',
+      skillPackageMigrationFileFailed:
+        '{path}: migrazione non riuscita ({error}); il file è stato conservato.',
+      skillPackageMigrationUnknownError: 'Errore sconosciuto',
+      skillPackageMigrationFailed:
+        "YOLO non ha potuto completare l'aggiornamento dei file skill legacy. I file sorgente sono stati conservati; controlla la console e spostali manualmente.",
       selectSkills: 'Seleziona',
       agents: 'Agent',
       agentsDesc:

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -459,6 +459,8 @@ export const zh: TranslationKeys = {
       importSkillSuccess: '已成功导入 {count} 个技能。',
       importSkillInvalidFile: '未找到有效的技能文件或技能包。',
       importSkillReadError: '读取文件失败。',
+      importSkillErrTooDeep:
+        '技能包超过 {depth} 层导入深度上限，未导入任何内容。',
       importSkillWriteError: '导入 {name} 失败：{error}',
       importSkillErrHeader: '"{name}" 无法导入：',
       importSkillErrNoSkillMd: '文件夹中缺少 SKILL.md 文件',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -422,7 +422,7 @@ export const zh: TranslationKeys = {
       skillsCount: '{count} 个技能',
       skillsCountWithEnabled: '{count} 个技能（已启用 {enabled} 个）',
       skillsGlobalDesc:
-        '技能会从内置技能与 {path}/**/*.md 自动发现（适用时排除 Skills.md）。在这里禁用后，所有 Agent 都无法使用。',
+        '技能会从内置技能与 {path}/<name>/SKILL.md 目录包中自动发现。在这里禁用后，所有 Agent 都无法使用。',
       yoloBaseDir: 'YOLO 根目录',
       yoloBaseDirDesc:
         '填写库内相对路径（不要以 / 开头）。例如：放在库根目录填 YOLO；放在 setting 文件夹下填 setting/YOLO。',
@@ -441,14 +441,14 @@ export const zh: TranslationKeys = {
       yoloBaseDirConflictTitle: 'YOLO 根目录未移动',
       yoloBaseDirConflictMessage:
         '{target} 已存在且包含文件。为避免覆盖或合并数据，本次未移动任何内容。请选择空目录或尚不存在的路径。',
-      skillsSourcePath: '来源：内置技能 + {path}/*.md + {path}/**/SKILL.md',
+      skillsSourcePath: '来源：内置技能 + {path}/<name>/SKILL.md',
       refreshSkills: '刷新',
-      skillsEmptyHint: '未发现技能。请在 {path} 下创建 .md 技能文件。',
+      skillsEmptyHint: '未发现技能。请创建 {path}/<name>/SKILL.md 目录包。',
       createSkillTemplates: '初始化 Skills 系统',
       skillsTemplateCreated: '已在 {path} 完成 Skills 系统初始化。',
       importSkill: '导入技能',
       importSkillDesc:
-        '将技能包导入到 {path}。支持单个 .md 文件或 Agent Skills 标准文件夹。',
+        '将技能包导入到 {path}。单个 Markdown 会包装为 <name>/SKILL.md；文件夹会保留 SKILL.md 与全部包资源。',
       importSkillDropzoneText: '拖拽技能文件或文件夹到此处',
       importSkillBrowseFiles: '选择文件',
       importSkillBrowseFolder: '选择文件夹',
@@ -494,15 +494,32 @@ export const zh: TranslationKeys = {
       importSkillFromUrlTooLarge: '技能包超过大小限制：{error}',
       importSkillFromUrlFetchError: '从 GitHub 获取失败：{error}',
       deleteSkillTitle: '删除技能',
-      deleteSkillMessage: '确定要删除「{name}」吗？此操作无法撤销。',
+      deleteSkillMessage:
+        '确定要删除「{name}」技能包及其全部资源吗？此操作无法撤销。',
       deleteSkillConfirm: '删除',
       deleteSkillSuccess: '已删除「{name}」。',
       deleteSkillError: '删除「{name}」失败：{error}',
-      deleteSkillBatchMessage: '确定要删除 {count} 个技能吗？此操作无法撤销。',
+      deleteSkillInvalidPackage: '技能包路径无效',
+      deleteSkillNotFound: '未找到技能包',
+      deleteSkillBatchMessage:
+        '确定要删除 {count} 个技能包及其全部资源吗？此操作无法撤销。',
       deleteSkillBatchSuccess: '已删除 {count} 个技能。',
       deleteSkillBatchBtn: '删除',
       deleteSkillSelectAll: '全选',
       deleteSkillCancel: '取消',
+      skillPackageMigrationIssues:
+        '有 {count} 个旧技能文件需要处理。YOLO 未覆盖或删除它们：',
+      skillPackageMigrationInvalidFrontmatter:
+        '{path}：缺少或包含无效的 YAML frontmatter；已保留原文件。',
+      skillPackageMigrationInvalidName:
+        '{path}：frontmatter name 必须为 1–64 位小写字母、数字或连字符；已保留原文件。',
+      skillPackageMigrationConflict:
+        '{path}：目标 {target} 已存在；已保留原文件。',
+      skillPackageMigrationFileFailed:
+        '{path}：迁移失败（{error}）；已保留原文件。',
+      skillPackageMigrationUnknownError: '未知错误',
+      skillPackageMigrationFailed:
+        'YOLO 未能完成旧技能文件升级。原文件已保留，请查看控制台后手动移动。',
       selectSkills: '选择',
       agents: 'Agents',
       agentsDesc: '点击配置以编辑每个 Agent 的资料与提示词。',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -400,11 +400,20 @@ export type TranslationKeys = {
       deleteSkillConfirm?: string
       deleteSkillSuccess?: string
       deleteSkillError?: string
+      deleteSkillInvalidPackage?: string
+      deleteSkillNotFound?: string
       deleteSkillBatchMessage?: string
       deleteSkillBatchSuccess?: string
       deleteSkillBatchBtn?: string
       deleteSkillSelectAll?: string
       deleteSkillCancel?: string
+      skillPackageMigrationIssues?: string
+      skillPackageMigrationInvalidFrontmatter?: string
+      skillPackageMigrationInvalidName?: string
+      skillPackageMigrationConflict?: string
+      skillPackageMigrationFileFailed?: string
+      skillPackageMigrationUnknownError?: string
+      skillPackageMigrationFailed?: string
       selectSkills?: string
       agents?: string
       agentsDesc?: string

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -365,6 +365,7 @@ export type TranslationKeys = {
       importSkillSuccess?: string
       importSkillInvalidFile?: string
       importSkillReadError?: string
+      importSkillErrTooDeep?: string
       importSkillWriteError?: string
       importSkillErrHeader?: string
       importSkillErrNoSkillMd?: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,7 +135,10 @@ import {
   resolveRuntimeComponentArtifactSources,
   setRuntimeComponentService,
 } from './core/runtime-components'
-import { migrateVaultSkillFrontmatter } from './core/skills/liteSkills'
+import {
+  type LegacySkillPackageMigrationReport,
+  migrateVaultSkillsToDirectoryPackages,
+} from './core/skills/liteSkills'
 import {
   type InstallationIncompleteDetail,
   type ReleaseFileName,
@@ -2036,16 +2039,21 @@ export default class YoloPlugin extends Plugin {
     void pruneImageCache(this.app, 30, this.settings)
     void prunePdfTextCache(this.app, 30, this.settings)
     await this.getRagIndexService().initialize()
-    // One-time, idempotent migration of vault skill files from legacy
-    // `id + name` frontmatter to the converged `name`-only form. Kicked off as
-    // soon as the vault index is ready. Note: Obsidian's metadataCache updates
-    // asynchronously after each modify, so on the very first post-upgrade
-    // startup a skill list/open may briefly observe pre-migration frontmatter
-    // until the cache re-parses — self-healing and one-time. A full
-    // cache-event barrier is intentionally avoided as over-engineering for this
-    // sub-second transient; the migration is idempotent so it always converges.
+    // One-time, idempotent vault-skill upgrade: converge legacy frontmatter,
+    // then move root-level Markdown files into <name>/SKILL.md packages.
     this.app.workspace.onLayoutReady(() => {
-      void migrateVaultSkillFrontmatter(this.app, this.settings)
+      void migrateVaultSkillsToDirectoryPackages(this.app, this.settings)
+        .then((report) => this.showSkillPackageMigrationIssues(report))
+        .catch((error) => {
+          console.error('[YOLO] Vault skill package migration failed', error)
+          new Notice(
+            this.t(
+              'settings.agent.skillPackageMigrationFailed',
+              'YOLO could not finish upgrading legacy skill files. The source files were kept; review the console and move them manually.',
+            ),
+            0,
+          )
+        })
     })
     this.app.workspace.onLayoutReady(() => {
       void this.runtimeComponentService?.start().catch((error) => {
@@ -2604,6 +2612,56 @@ export default class YoloPlugin extends Plugin {
     setLLMDebugCaptureEnabled(
       this.settings.debug?.captureRawRequestDebug ?? false,
     )
+  }
+
+  private showSkillPackageMigrationIssues(
+    report: LegacySkillPackageMigrationReport,
+  ): void {
+    if (report.issues.length === 0) {
+      return
+    }
+
+    const details = report.issues.map((issue) => {
+      switch (issue.reason) {
+        case 'invalid_frontmatter':
+          return this.t(
+            'settings.agent.skillPackageMigrationInvalidFrontmatter',
+            '{path}: missing or invalid YAML frontmatter; file was kept.',
+          ).replace('{path}', issue.sourcePath)
+        case 'invalid_name':
+          return this.t(
+            'settings.agent.skillPackageMigrationInvalidName',
+            '{path}: frontmatter name must be 1–64 lowercase letters, numbers, or hyphens; file was kept.',
+          ).replace('{path}', issue.sourcePath)
+        case 'target_exists':
+          return this.t(
+            'settings.agent.skillPackageMigrationConflict',
+            '{path}: target {target} already exists; file was kept.',
+          )
+            .replace('{path}', issue.sourcePath)
+            .replace('{target}', issue.targetPath ?? '')
+        case 'migration_failed':
+          return this.t(
+            'settings.agent.skillPackageMigrationFileFailed',
+            '{path}: migration failed ({error}); file was kept.',
+          )
+            .replace('{path}', issue.sourcePath)
+            .replace(
+              '{error}',
+              issue.error ??
+                this.t(
+                  'settings.agent.skillPackageMigrationUnknownError',
+                  'Unknown error',
+                ),
+            )
+      }
+    })
+
+    const summary = this.t(
+      'settings.agent.skillPackageMigrationIssues',
+      '{count} legacy skill file(s) need attention. YOLO did not overwrite or delete them:',
+    ).replace('{count}', String(report.issues.length))
+    new Notice(`${summary}\n${details.join('\n')}`, 0)
   }
 
   /** Migrate old hidden roots before any service can open files beneath them. */


### PR DESCRIPTION
## Summary

- accept only `<skill-root>/<name>/SKILL.md` packages at rest
- migrate valid legacy root Markdown files without overwriting conflicts
- wrap single-file imports into standard packages and preserve binary resources
- delete whole packages and preserve Assistant preferences by canonical name
- retain and test the bounded local directory-import depth

## Verification

- 5 focused Jest suites, 100 tests
- `npm run type:check`