### PR TITLE
feat(chat): 添加桌面聊天运行时选择器

### DIFF
--- a/src/components/chat-view/RuntimeSelector.test.tsx
+++ b/src/components/chat-view/RuntimeSelector.test.tsx
@@ -1,0 +1,70 @@
+jest.mock('../../contexts/language-context', () => ({
+  useLanguage: () => ({
+    t: (key: string) =>
+      (
+        ({
+          'sidebar.runtimeSelector.accessibleLabel': 'Chat backend: {runtime}',
+          'sidebar.runtimeSelector.menuLabel': 'Chat backend',
+          'sidebar.runtimeSelector.chatBadge': 'Chat',
+          'sidebar.runtimeSelector.cliBadge': 'CLI',
+          'sidebar.runtimeSelector.yoloLabel': 'YOLO Chat',
+          'sidebar.runtimeSelector.yoloDescription':
+            'Built-in YOLO chat runtime',
+          'sidebar.runtimeSelector.claudeCodeLabel': 'Claude Code',
+          'sidebar.runtimeSelector.claudeCodeDescription':
+            'Claude Code on this device',
+          'sidebar.runtimeSelector.codexLabel': 'Codex',
+          'sidebar.runtimeSelector.codexDescription': 'Codex on this device',
+        }) as Record<string, string>
+      )[key] ?? key,
+  }),
+}))
+
+import { Platform } from 'obsidian'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import {
+  RuntimeSelector,
+  getRuntimeSelectorOptions,
+  resolveAvailableRuntimeId,
+} from './RuntimeSelector'
+
+describe('RuntimeSelector', () => {
+  const originalIsDesktop = Platform.isDesktop
+
+  afterEach(() => {
+    Platform.isDesktop = originalIsDesktop
+  })
+
+  it('exposes all runtime backends on desktop', () => {
+    expect(getRuntimeSelectorOptions(true).map((option) => option.id)).toEqual([
+      'yolo',
+      'claude-code',
+      'codex',
+    ])
+    expect(resolveAvailableRuntimeId('claude-code', true)).toBe('claude-code')
+    expect(resolveAvailableRuntimeId('codex', true)).toBe('codex')
+  })
+
+  it('exposes only YOLO and rejects CLI selections without desktop capability', () => {
+    expect(getRuntimeSelectorOptions(false).map((option) => option.id)).toEqual(
+      ['yolo'],
+    )
+    expect(resolveAvailableRuntimeId('yolo', false)).toBe('yolo')
+    expect(resolveAvailableRuntimeId('claude-code', false)).toBeUndefined()
+    expect(resolveAvailableRuntimeId('codex', false)).toBeUndefined()
+  })
+
+  it('renders and accessibly announces the current runtime', () => {
+    Platform.isDesktop = true
+
+    const html = renderToStaticMarkup(
+      <RuntimeSelector currentRuntimeId="codex" onRuntimeChange={() => {}} />,
+    )
+
+    expect(html).toContain('data-runtime-id="codex"')
+    expect(html).toContain('aria-label="Chat backend: Codex"')
+    expect(html).toContain('>Codex<')
+    expect(html).toContain('>CLI<')
+  })
+})

--- a/src/components/chat-view/RuntimeSelector.test.tsx
+++ b/src/components/chat-view/RuntimeSelector.test.tsx
@@ -67,4 +67,19 @@ describe('RuntimeSelector', () => {
     expect(html).toContain('>Codex<')
     expect(html).toContain('>CLI<')
   })
+
+  it('renders no runtime entry on mobile even with a stale CLI selection', () => {
+    Platform.isDesktop = false
+
+    const html = renderToStaticMarkup(
+      <RuntimeSelector
+        currentRuntimeId="claude-code"
+        onRuntimeChange={() => {}}
+      />,
+    )
+
+    expect(html).toBe('')
+    expect(html).not.toContain('yolo-runtime-selector')
+    expect(html).not.toContain('CLI')
+  })
 })

--- a/src/components/chat-view/RuntimeSelector.tsx
+++ b/src/components/chat-view/RuntimeSelector.tsx
@@ -93,6 +93,11 @@ export function RuntimeSelector({
   const { t } = useLanguage()
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const cliRuntimeAvailable = isCliRuntimeAvailable()
+
+  if (!cliRuntimeAvailable) {
+    return null
+  }
+
   const availableOptions = getRuntimeSelectorOptions(cliRuntimeAvailable)
   const currentOption = RUNTIME_OPTIONS[currentRuntimeId]
   const currentLabel = t(currentOption.labelKey)

--- a/src/components/chat-view/RuntimeSelector.tsx
+++ b/src/components/chat-view/RuntimeSelector.tsx
@@ -1,0 +1,201 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import {
+  Asterisk,
+  Check,
+  ChevronDown,
+  MessageCircle,
+  SquareTerminal,
+} from 'lucide-react'
+import { useRef } from 'react'
+
+import { useLanguage } from '../../contexts/language-context'
+import {
+  type ChatRuntimeId,
+  isCliRuntimeAvailable,
+} from '../../core/cli-runtime'
+import { YoloDropdownContent } from '../common/popover'
+
+type RuntimeKind = 'chat' | 'cli'
+
+export type RuntimeSelectorOption = {
+  id: ChatRuntimeId
+  kind: RuntimeKind
+  labelKey: string
+  descriptionKey: string
+}
+
+const RUNTIME_OPTIONS: Record<ChatRuntimeId, RuntimeSelectorOption> = {
+  yolo: {
+    id: 'yolo',
+    kind: 'chat',
+    labelKey: 'sidebar.runtimeSelector.yoloLabel',
+    descriptionKey: 'sidebar.runtimeSelector.yoloDescription',
+  },
+  'claude-code': {
+    id: 'claude-code',
+    kind: 'cli',
+    labelKey: 'sidebar.runtimeSelector.claudeCodeLabel',
+    descriptionKey: 'sidebar.runtimeSelector.claudeCodeDescription',
+  },
+  codex: {
+    id: 'codex',
+    kind: 'cli',
+    labelKey: 'sidebar.runtimeSelector.codexLabel',
+    descriptionKey: 'sidebar.runtimeSelector.codexDescription',
+  },
+}
+
+const DESKTOP_RUNTIME_IDS: readonly ChatRuntimeId[] = [
+  'yolo',
+  'claude-code',
+  'codex',
+]
+const MOBILE_RUNTIME_IDS: readonly ChatRuntimeId[] = ['yolo']
+
+export const getRuntimeSelectorOptions = (
+  cliRuntimeAvailable: boolean,
+): readonly RuntimeSelectorOption[] =>
+  (cliRuntimeAvailable ? DESKTOP_RUNTIME_IDS : MOBILE_RUNTIME_IDS).map(
+    (runtimeId) => RUNTIME_OPTIONS[runtimeId],
+  )
+
+export const resolveAvailableRuntimeId = (
+  value: string,
+  cliRuntimeAvailable: boolean,
+): ChatRuntimeId | undefined =>
+  getRuntimeSelectorOptions(cliRuntimeAvailable).find(
+    (option) => option.id === value,
+  )?.id
+
+export type RuntimeSelectorProps = {
+  currentRuntimeId: ChatRuntimeId
+  onRuntimeChange: (runtimeId: ChatRuntimeId) => void
+  disabled?: boolean
+  className?: string
+}
+
+const RuntimeIcon = ({ runtimeId }: { runtimeId: ChatRuntimeId }) => {
+  if (runtimeId === 'yolo') {
+    return <MessageCircle size={15} strokeWidth={2} />
+  }
+  if (runtimeId === 'claude-code') {
+    return <Asterisk size={15} strokeWidth={2} />
+  }
+  return <SquareTerminal size={15} strokeWidth={2} />
+}
+
+export function RuntimeSelector({
+  currentRuntimeId,
+  onRuntimeChange,
+  disabled = false,
+  className,
+}: RuntimeSelectorProps) {
+  const { t } = useLanguage()
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const cliRuntimeAvailable = isCliRuntimeAvailable()
+  const availableOptions = getRuntimeSelectorOptions(cliRuntimeAvailable)
+  const currentOption = RUNTIME_OPTIONS[currentRuntimeId]
+  const currentLabel = t(currentOption.labelKey)
+  const currentBadge = t(
+    currentOption.kind === 'chat'
+      ? 'sidebar.runtimeSelector.chatBadge'
+      : 'sidebar.runtimeSelector.cliBadge',
+  )
+  const accessibleLabel = t('sidebar.runtimeSelector.accessibleLabel').replace(
+    '{runtime}',
+    currentLabel,
+  )
+
+  return (
+    <DropdownMenu.Root modal={false}>
+      <DropdownMenu.Trigger
+        ref={triggerRef}
+        type="button"
+        className={`yolo-runtime-selector${className ? ` ${className}` : ''}`}
+        disabled={disabled}
+        aria-label={accessibleLabel}
+        data-runtime-id={currentRuntimeId}
+      >
+        <span className="yolo-runtime-selector__icon" aria-hidden="true">
+          <RuntimeIcon runtimeId={currentOption.id} />
+        </span>
+        <span className="yolo-runtime-selector__label">{currentLabel}</span>
+        <span className="yolo-runtime-selector__badge">{currentBadge}</span>
+        <ChevronDown
+          className="yolo-runtime-selector__chevron"
+          size={13}
+          strokeWidth={2.2}
+          aria-hidden="true"
+        />
+      </DropdownMenu.Trigger>
+
+      <YoloDropdownContent
+        anchorRef={triggerRef}
+        variant="default"
+        minWidth={224}
+        maxWidth={280}
+        maxHeight={320}
+        className="yolo-runtime-selector__content"
+        side="bottom"
+        sideOffset={6}
+        align="start"
+        collisionPadding={8}
+        loop
+      >
+        <DropdownMenu.RadioGroup
+          className="yolo-model-select-list yolo-runtime-selector__list"
+          value={currentRuntimeId}
+          aria-label={t('sidebar.runtimeSelector.menuLabel')}
+          onValueChange={(value) => {
+            const runtimeId = resolveAvailableRuntimeId(
+              value,
+              cliRuntimeAvailable,
+            )
+            if (runtimeId && runtimeId !== currentRuntimeId) {
+              onRuntimeChange(runtimeId)
+            }
+          }}
+        >
+          {availableOptions.map((option) => {
+            const badge = t(
+              option.kind === 'chat'
+                ? 'sidebar.runtimeSelector.chatBadge'
+                : 'sidebar.runtimeSelector.cliBadge',
+            )
+            return (
+              <DropdownMenu.RadioItem
+                key={option.id}
+                value={option.id}
+                className="yolo-popover-item yolo-runtime-selector__option"
+                data-runtime-id={option.id}
+              >
+                <span
+                  className="yolo-runtime-selector__option-icon"
+                  aria-hidden="true"
+                >
+                  <RuntimeIcon runtimeId={option.id} />
+                </span>
+                <span className="yolo-runtime-selector__option-copy">
+                  <span className="yolo-runtime-selector__option-heading">
+                    <span className="yolo-runtime-selector__option-label">
+                      {t(option.labelKey)}
+                    </span>
+                    <span className="yolo-runtime-selector__badge">
+                      {badge}
+                    </span>
+                  </span>
+                  <span className="yolo-runtime-selector__option-description">
+                    {t(option.descriptionKey)}
+                  </span>
+                </span>
+                <DropdownMenu.ItemIndicator className="yolo-popover-item__indicator">
+                  <Check size={12} aria-hidden="true" />
+                </DropdownMenu.ItemIndicator>
+              </DropdownMenu.RadioItem>
+            )
+          })}
+        </DropdownMenu.RadioGroup>
+      </YoloDropdownContent>
+    </DropdownMenu.Root>
+  )
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -66,6 +66,18 @@ export const en: TranslationKeys = {
       agent: 'Agent',
       composer: 'Sparkle',
     },
+    runtimeSelector: {
+      accessibleLabel: 'Chat backend: {runtime}',
+      menuLabel: 'Chat backend',
+      chatBadge: 'Chat',
+      cliBadge: 'CLI',
+      yoloLabel: 'YOLO Chat',
+      yoloDescription: 'Built-in YOLO chat runtime',
+      claudeCodeLabel: 'Claude Code',
+      claudeCodeDescription: 'Claude Code on this device',
+      codexLabel: 'Codex',
+      codexDescription: 'Codex on this device',
+    },
     chatList: {
       searchPlaceholder: 'Search conversations',
       empty: 'No conversations',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -82,6 +82,18 @@ export const it: DeepPartial<TranslationKeys> = {
       agent: 'Agent',
       composer: 'Sparkle',
     },
+    runtimeSelector: {
+      accessibleLabel: 'Backend della chat: {runtime}',
+      menuLabel: 'Backend della chat',
+      chatBadge: 'Chat',
+      cliBadge: 'CLI',
+      yoloLabel: 'YOLO Chat',
+      yoloDescription: 'Runtime di chat integrato in YOLO',
+      claudeCodeLabel: 'Claude Code',
+      claudeCodeDescription: 'Claude Code su questo dispositivo',
+      codexLabel: 'Codex',
+      codexDescription: 'Codex su questo dispositivo',
+    },
     chatList: {
       searchPlaceholder: 'Cerca conversazioni',
       empty: 'Nessuna conversazione',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -66,6 +66,18 @@ export const zh: TranslationKeys = {
       agent: 'Agent',
       composer: 'Sparkle',
     },
+    runtimeSelector: {
+      accessibleLabel: '聊天后端：{runtime}',
+      menuLabel: '聊天后端',
+      chatBadge: 'Chat',
+      cliBadge: 'CLI',
+      yoloLabel: 'YOLO Chat',
+      yoloDescription: 'YOLO 内置聊天运行时',
+      claudeCodeLabel: 'Claude Code',
+      claudeCodeDescription: '本机 Claude Code 运行时',
+      codexLabel: 'Codex',
+      codexDescription: '本机 Codex 运行时',
+    },
     chatList: {
       searchPlaceholder: '搜索聊天记录',
       empty: '暂无聊天记录',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -75,6 +75,18 @@ export type TranslationKeys = {
       agent?: string
       composer: string
     }
+    runtimeSelector: {
+      accessibleLabel: string
+      menuLabel: string
+      chatBadge: string
+      cliBadge: string
+      yoloLabel: string
+      yoloDescription: string
+      claudeCodeLabel: string
+      claudeCodeDescription: string
+      codexLabel: string
+      codexDescription: string
+    }
     chatList?: {
       searchPlaceholder?: string
       empty?: string

--- a/src/styles/chat/input.css
+++ b/src/styles/chat/input.css
@@ -44,6 +44,149 @@
   gap: var(--size-4-2);
 }
 
+button.yolo-runtime-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  height: 30px;
+  margin: 0;
+  padding: 4px 7px;
+  border: 1px solid
+    color-mix(in srgb, var(--background-modifier-border) 80%, transparent);
+  border-radius: var(--radius-s);
+  background: transparent;
+  background-color: transparent;
+  box-shadow: none;
+  color: var(--text-normal);
+  font: inherit;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+button.yolo-runtime-selector:hover,
+button.yolo-runtime-selector:focus,
+button.yolo-runtime-selector:active,
+button.yolo-runtime-selector[data-state='open'] {
+  background: var(--background-modifier-hover);
+  background-color: var(--background-modifier-hover);
+  box-shadow: none;
+}
+
+button.yolo-runtime-selector:focus-visible {
+  outline: 2px solid
+    color-mix(in srgb, var(--interactive-accent) 65%, transparent);
+  outline-offset: 2px;
+}
+
+button.yolo-runtime-selector:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.yolo-runtime-selector__icon,
+.yolo-runtime-selector__option-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.yolo-runtime-selector__label {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-normal);
+  font-size: var(--font-ui-smaller);
+  font-weight: var(--font-medium);
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.yolo-runtime-selector__badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 15px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: color-mix(
+    in srgb,
+    var(--background-modifier-border) 52%,
+    transparent
+  );
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.04em;
+  line-height: 15px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.yolo-runtime-selector__chevron {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition: transform 0.15s ease;
+}
+
+button.yolo-runtime-selector[data-state='open']
+  .yolo-runtime-selector__chevron {
+  transform: rotate(180deg);
+}
+
+.yolo-runtime-selector__content {
+  display: flex;
+  flex-direction: column;
+}
+
+.yolo-runtime-selector__list {
+  min-height: 0;
+}
+
+.yolo-popover-surface--default
+  .yolo-runtime-selector__list
+  > .yolo-runtime-selector__option {
+  align-items: center;
+  gap: 9px;
+  padding-block: 7px;
+}
+
+.yolo-runtime-selector__option-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.yolo-runtime-selector__option-heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.yolo-runtime-selector__option-label,
+.yolo-runtime-selector__option-description {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.yolo-runtime-selector__option-label {
+  color: var(--text-normal);
+  font-size: var(--font-ui-smaller);
+  font-weight: var(--font-medium);
+}
+
+.yolo-runtime-selector__option-description {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smallest);
+  font-weight: var(--font-normal);
+}
+
 .yolo-context-usage-ring {
   --yolo-context-usage-ring-color: var(--interactive-accent);
   position: relative;

--- a/styles.css
+++ b/styles.css
@@ -9634,6 +9634,149 @@ svg.svg-icon.yolo-orbit {
   gap: var(--size-4-2);
 }
 
+button.yolo-runtime-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  height: 30px;
+  margin: 0;
+  padding: 4px 7px;
+  border: 1px solid
+    color-mix(in srgb, var(--background-modifier-border) 80%, transparent);
+  border-radius: var(--radius-s);
+  background: transparent;
+  background-color: transparent;
+  box-shadow: none;
+  color: var(--text-normal);
+  font: inherit;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+button.yolo-runtime-selector:hover,
+button.yolo-runtime-selector:focus,
+button.yolo-runtime-selector:active,
+button.yolo-runtime-selector[data-state='open'] {
+  background: var(--background-modifier-hover);
+  background-color: var(--background-modifier-hover);
+  box-shadow: none;
+}
+
+button.yolo-runtime-selector:focus-visible {
+  outline: 2px solid
+    color-mix(in srgb, var(--interactive-accent) 65%, transparent);
+  outline-offset: 2px;
+}
+
+button.yolo-runtime-selector:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.yolo-runtime-selector__icon,
+.yolo-runtime-selector__option-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.yolo-runtime-selector__label {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-normal);
+  font-size: var(--font-ui-smaller);
+  font-weight: var(--font-medium);
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.yolo-runtime-selector__badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 15px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: color-mix(
+    in srgb,
+    var(--background-modifier-border) 52%,
+    transparent
+  );
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.04em;
+  line-height: 15px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.yolo-runtime-selector__chevron {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition: transform 0.15s ease;
+}
+
+button.yolo-runtime-selector[data-state='open']
+  .yolo-runtime-selector__chevron {
+  transform: rotate(180deg);
+}
+
+.yolo-runtime-selector__content {
+  display: flex;
+  flex-direction: column;
+}
+
+.yolo-runtime-selector__list {
+  min-height: 0;
+}
+
+.yolo-popover-surface--default
+  .yolo-runtime-selector__list
+  > .yolo-runtime-selector__option {
+  align-items: center;
+  gap: 9px;
+  padding-block: 7px;
+}
+
+.yolo-runtime-selector__option-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.yolo-runtime-selector__option-heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.yolo-runtime-selector__option-label,
+.yolo-runtime-selector__option-description {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.yolo-runtime-selector__option-label {
+  color: var(--text-normal);
+  font-size: var(--font-ui-smaller);
+  font-weight: var(--font-medium);
+}
+
+.yolo-runtime-selector__option-description {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smallest);
+  font-weight: var(--font-normal);
+}
+
 .yolo-context-usage-ring {
   --yolo-context-usage-ring-color: var(--interactive-accent);
   position: relative;


### PR DESCRIPTION
## Summary
- add a controlled runtime selector for YOLO Chat, Claude Code, and Codex
- reuse the existing dropdown surface and add accessible runtime labels
- hide the selector entirely outside the desktop capability boundary

## Verification
- `npx jest src/components/chat-view/RuntimeSelector.test.tsx --runInBand`
- `npm run type:check`
- `npm run styles:build`