### PR TITLE
feat(cli-runtime): 增加 CLI 会话内存控制器

### DIFF
--- a/src/core/cli-runtime/conversation-controller.test.ts
+++ b/src/core/cli-runtime/conversation-controller.test.ts
@@ -153,6 +153,27 @@ describe('CliConversationController', () => {
     ).toEqual(['user-1', 'assistant-2'])
   })
 
+  it('deduplicates hydrated message ids in linear order with the last content', async () => {
+    const runtime = new FakeCliRuntime()
+    const ref = session('duplicate-transcript')
+    runtime.openSessionImpl = async () => ({
+      ref,
+      messages: [
+        assistantMessage('duplicate', 'first'),
+        userMessage('between'),
+        assistantMessage('duplicate', 'last'),
+      ],
+    })
+    const controller = new CliConversationController(runtime)
+
+    await controller.hydrateSession(ref)
+
+    expect(controller.getSnapshot().messages).toMatchObject([
+      { id: 'duplicate', content: 'last' },
+      { id: 'between' },
+    ])
+  })
+
   it('binds the hydrated session and reflects every runtime run state', async () => {
     const runtime = new FakeCliRuntime()
     const ref = session('resume-me')
@@ -217,6 +238,33 @@ describe('CliConversationController', () => {
         content: 'hello',
       },
     ])
+  })
+
+  it('does not dispatch a turn when an optimistic listener switches runtime', async () => {
+    const codex = new FakeCliRuntime('codex')
+    const claude = new FakeCliRuntime('claude-code')
+    const controller = new CliConversationController(codex)
+    await controller.ensureReady(assistant)
+    let switched = false
+    controller.subscribe(() => {
+      if (switched) return
+      switched = true
+      controller.setRuntime(claude)
+    })
+
+    await controller.sendTurn({
+      userMessage: userMessage('reentrant-user'),
+      content: 'must not dispatch',
+    })
+
+    expect(codex.turnInputs).toEqual([])
+    expect(claude.turnInputs).toEqual([])
+    expect(controller.getSnapshot()).toMatchObject({
+      runtimeId: 'claude-code',
+      sessionRef: null,
+      messages: [],
+      runState: 'idle',
+    })
   })
 
   it('ignores stale hydration and event callbacks after a session switch', async () => {

--- a/src/core/cli-runtime/conversation-controller.test.ts
+++ b/src/core/cli-runtime/conversation-controller.test.ts
@@ -1,0 +1,331 @@
+import type { ChatAssistantMessage, ChatUserMessage } from '../../types/chat'
+
+import { CliConversationController } from './conversation-controller'
+import type {
+  CliApprovalResponse,
+  CliQuestionResponse,
+  CliRuntime,
+  CliRuntimeEvent,
+  CliRuntimeEventListener,
+  CliRuntimeId,
+  CliRuntimeReadyInput,
+  CliSessionHydration,
+  CliSessionMetadata,
+  CliSessionRef,
+  CliTurnInput,
+} from './types'
+
+const assistant = {
+  assistantId: 'assistant-1',
+  systemPrompt: 'Be concise.',
+  enabledSkillNames: ['review'],
+}
+
+const session = (
+  nativeSessionId: string,
+  runtimeId: CliRuntimeId = 'codex',
+): CliSessionRef => ({ runtimeId, nativeSessionId })
+
+const userMessage = (id: string, text = id): ChatUserMessage => ({
+  role: 'user',
+  id,
+  content: null,
+  promptContent: text,
+  mentionables: [],
+})
+
+const assistantMessage = (id: string, content = id): ChatAssistantMessage => ({
+  role: 'assistant',
+  id,
+  content,
+})
+
+const deferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+class FakeCliRuntime implements CliRuntime {
+  readonly listeners = new Set<CliRuntimeEventListener>()
+  readonly subscribedListeners: CliRuntimeEventListener[] = []
+  readonly readyInputs: CliRuntimeReadyInput[] = []
+  readonly turnInputs: CliTurnInput[] = []
+  openSessionImpl: (ref: CliSessionRef) => Promise<CliSessionHydration> =
+    async (ref) => ({ ref, messages: [] })
+  ensureReadyImpl: (input: CliRuntimeReadyInput) => Promise<void> = async (
+    input,
+  ) => {
+    this.emit({
+      type: 'session_bound',
+      ref: input.sessionRef ?? session(`new-${this.runtimeId}`, this.runtimeId),
+    })
+  }
+  sendTurnImpl: (input: CliTurnInput) => Promise<void> = async () => undefined
+  cancelImpl: () => Promise<void> = async () => undefined
+
+  constructor(readonly runtimeId: CliRuntimeId = 'codex') {}
+
+  async listSessions(): Promise<CliSessionMetadata[]> {
+    return []
+  }
+
+  openSession(ref: CliSessionRef): Promise<CliSessionHydration> {
+    return this.openSessionImpl(ref)
+  }
+
+  async ensureReady(input: CliRuntimeReadyInput): Promise<void> {
+    this.readyInputs.push(input)
+    await this.ensureReadyImpl(input)
+  }
+
+  async sendTurn(input: CliTurnInput): Promise<void> {
+    this.turnInputs.push(input)
+    await this.sendTurnImpl(input)
+  }
+
+  cancel(): Promise<void> {
+    return this.cancelImpl()
+  }
+
+  async respondApproval(_response: CliApprovalResponse): Promise<void> {}
+
+  async respondQuestion(_response: CliQuestionResponse): Promise<void> {}
+
+  subscribe(listener: CliRuntimeEventListener): () => void {
+    this.listeners.add(listener)
+    this.subscribedListeners.push(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  async dispose(): Promise<void> {}
+
+  emit(event: CliRuntimeEvent): void {
+    for (const listener of [...this.listeners]) listener(event)
+  }
+}
+
+describe('CliConversationController', () => {
+  it('hydrates messages, upserts by stable id in place, and removes by id', async () => {
+    const runtime = new FakeCliRuntime()
+    const ref = session('existing')
+    runtime.openSessionImpl = async () => ({
+      ref: { ...ref, sessionPathHint: '/native/session.jsonl' },
+      messages: [userMessage('user-1'), assistantMessage('assistant-1', 'old')],
+    })
+    const controller = new CliConversationController(runtime)
+
+    await controller.hydrateSession(ref)
+    await controller.ensureReady(assistant)
+    expect(controller.getSnapshot()).toMatchObject({
+      sessionRef: {
+        runtimeId: 'codex',
+        nativeSessionId: 'existing',
+        sessionPathHint: '/native/session.jsonl',
+      },
+      runState: 'idle',
+    })
+    expect(
+      controller.getSnapshot().messages.map((message) => message.id),
+    ).toEqual(['user-1', 'assistant-1'])
+
+    runtime.emit({
+      type: 'message_upsert',
+      message: assistantMessage('assistant-2', 'streaming'),
+    })
+    runtime.emit({
+      type: 'message_upsert',
+      message: assistantMessage('assistant-1', 'updated'),
+    })
+    expect(controller.getSnapshot().messages).toMatchObject([
+      { id: 'user-1' },
+      { id: 'assistant-1', content: 'updated' },
+      { id: 'assistant-2', content: 'streaming' },
+    ])
+
+    runtime.emit({ type: 'message_remove', messageId: 'assistant-1' })
+    expect(
+      controller.getSnapshot().messages.map((message) => message.id),
+    ).toEqual(['user-1', 'assistant-2'])
+  })
+
+  it('binds the hydrated session and reflects every runtime run state', async () => {
+    const runtime = new FakeCliRuntime()
+    const ref = session('resume-me')
+    const controller = new CliConversationController(runtime)
+    await controller.hydrateSession(ref)
+
+    await controller.ensureReady(assistant)
+    expect(runtime.readyInputs).toEqual([{ sessionRef: ref, assistant }])
+    expect(controller.getSnapshot().sessionRef).toEqual(ref)
+
+    const states = [
+      'running',
+      'waiting_for_approval',
+      'waiting_for_user',
+      'completed',
+      'aborted',
+      'error',
+    ] as const
+    for (const state of states) {
+      runtime.emit({
+        type: 'run_state',
+        state,
+        ...(state === 'error' ? { error: 'native failure' } : {}),
+      })
+      expect(controller.getSnapshot().runState).toBe(state)
+    }
+    expect(controller.getSnapshot().error).toBe('native failure')
+  })
+
+  it('preserves events delivered before sendTurn resolves', async () => {
+    const runtime = new FakeCliRuntime()
+    const send = deferred<undefined>()
+    runtime.sendTurnImpl = () => {
+      runtime.emit({
+        type: 'message_upsert',
+        message: assistantMessage('assistant-stream', 'done early'),
+      })
+      runtime.emit({ type: 'run_state', state: 'completed' })
+      return send.promise
+    }
+    const controller = new CliConversationController(runtime)
+    await controller.ensureReady(assistant)
+
+    const message = userMessage('user-optimistic', 'hello')
+    const sending = controller.sendTurn({
+      userMessage: message,
+      content: 'hello',
+    })
+    expect(controller.getSnapshot().messages[0]).toBe(message)
+    expect(controller.getSnapshot()).toMatchObject({ runState: 'completed' })
+    expect(controller.getSnapshot().messages.at(-1)).toMatchObject({
+      id: 'assistant-stream',
+      content: 'done early',
+    })
+
+    send.resolve(undefined)
+    await sending
+    expect(controller.getSnapshot().runState).toBe('completed')
+    expect(runtime.turnInputs).toEqual([
+      {
+        sessionRef: session('new-codex'),
+        content: 'hello',
+      },
+    ])
+  })
+
+  it('ignores stale hydration and event callbacks after a session switch', async () => {
+    const runtime = new FakeCliRuntime()
+    const firstHydration = deferred<CliSessionHydration>()
+    runtime.openSessionImpl = (ref) =>
+      ref.nativeSessionId === 'first'
+        ? firstHydration.promise
+        : Promise.resolve({ ref, messages: [userMessage('second-user')] })
+    const controller = new CliConversationController(runtime)
+
+    const first = controller.hydrateSession(session('first'))
+    const staleListener = runtime.subscribedListeners.at(-1)!
+    await controller.hydrateSession(session('second'))
+    await controller.ensureReady(assistant)
+
+    staleListener({
+      type: 'message_upsert',
+      message: assistantMessage('stale-event'),
+    })
+    firstHydration.resolve({
+      ref: session('first'),
+      messages: [userMessage('stale-hydration')],
+    })
+    await first
+
+    expect(controller.getSnapshot().sessionRef).toEqual(session('second'))
+    expect(
+      controller.getSnapshot().messages.map((message) => message.id),
+    ).toEqual(['second-user'])
+  })
+
+  it('isolates old runtime callbacks after switching providers', async () => {
+    const codex = new FakeCliRuntime('codex')
+    const claude = new FakeCliRuntime('claude-code')
+    const controller = new CliConversationController(codex)
+    const staleListener = codex.subscribedListeners[0]
+
+    controller.setRuntime(claude)
+    await controller.ensureReady(assistant)
+    claude.emit({
+      type: 'message_upsert',
+      message: assistantMessage('claude-message'),
+    })
+    staleListener({
+      type: 'message_upsert',
+      message: assistantMessage('codex-stale'),
+    })
+
+    expect(controller.getSnapshot().runtimeId).toBe('claude-code')
+    expect(
+      controller.getSnapshot().messages.map((message) => message.id),
+    ).toEqual(['claude-message'])
+  })
+
+  it('unsubscribes and ignores outstanding callbacks when disposed', async () => {
+    const runtime = new FakeCliRuntime()
+    const controller = new CliConversationController(runtime)
+    await controller.ensureReady(assistant)
+    const staleListener = runtime.subscribedListeners[0]
+    const beforeDispose = controller.getSnapshot()
+
+    controller.dispose()
+    staleListener({
+      type: 'message_upsert',
+      message: assistantMessage('after-dispose'),
+    })
+
+    expect(runtime.listeners.size).toBe(0)
+    expect(controller.getSnapshot()).toBe(beforeDispose)
+    expect(() => controller.resetSession()).toThrow('disposed')
+  })
+
+  it('keeps the optimistic user message and exposes a send error', async () => {
+    const runtime = new FakeCliRuntime()
+    runtime.sendTurnImpl = async () => {
+      throw new Error('send failed')
+    }
+    const controller = new CliConversationController(runtime)
+    await controller.ensureReady(assistant)
+    const message = userMessage('failed-user')
+
+    await expect(
+      controller.sendTurn({ userMessage: message, content: 'failed' }),
+    ).rejects.toThrow('send failed')
+    expect(controller.getSnapshot().messages).toContain(message)
+    expect(controller.getSnapshot()).toMatchObject({
+      runState: 'error',
+      error: 'send failed',
+    })
+  })
+
+  it('exposes cancel errors without losing the current transcript', async () => {
+    const runtime = new FakeCliRuntime()
+    runtime.cancelImpl = async () => {
+      throw new Error('cancel failed')
+    }
+    const controller = new CliConversationController(runtime)
+    await controller.ensureReady(assistant)
+    runtime.emit({
+      type: 'message_upsert',
+      message: assistantMessage('keep-me'),
+    })
+
+    await expect(controller.cancel()).rejects.toThrow('cancel failed')
+    expect(controller.getSnapshot()).toMatchObject({
+      runState: 'error',
+      error: 'cancel failed',
+      messages: [{ id: 'keep-me' }],
+    })
+  })
+})

--- a/src/core/cli-runtime/conversation-controller.ts
+++ b/src/core/cli-runtime/conversation-controller.ts
@@ -46,8 +46,20 @@ const upsertMessage = (
 
 const normalizeMessages = (
   messages: readonly ChatMessage[],
-): readonly ChatMessage[] =>
-  messages.reduce<readonly ChatMessage[]>(upsertMessage, Object.freeze([]))
+): readonly ChatMessage[] => {
+  const normalized: ChatMessage[] = []
+  const indexById = new Map<string, number>()
+  for (const message of messages) {
+    const index = indexById.get(message.id)
+    if (index === undefined) {
+      indexById.set(message.id, normalized.length)
+      normalized.push(message)
+    } else {
+      normalized[index] = message
+    }
+  }
+  return Object.freeze(normalized)
+}
 
 /**
  * Owns the transient timeline for the currently selected CLI runtime/session.
@@ -147,6 +159,7 @@ export class CliConversationController {
     if (!this.acceptingEvents) {
       throw new Error('CLI runtime is not ready for the selected session.')
     }
+    const sessionRef = this.snapshot.sessionRef
 
     this.publish({
       ...this.snapshot,
@@ -154,12 +167,11 @@ export class CliConversationController {
       runState: 'running',
       error: null,
     })
+    if (!this.isCurrent(operation) || !this.acceptingEvents) return
 
     try {
       await operation.runtime.sendTurn({
-        ...(this.snapshot.sessionRef
-          ? { sessionRef: this.snapshot.sessionRef }
-          : {}),
+        ...(sessionRef ? { sessionRef } : {}),
         content,
       })
       // Runtime notifications may arrive before sendTurn resolves. Do not

--- a/src/core/cli-runtime/conversation-controller.ts
+++ b/src/core/cli-runtime/conversation-controller.ts
@@ -1,0 +1,388 @@
+import type { ChatMessage, ChatUserMessage } from '../../types/chat'
+
+import type {
+  CliAssistantBinding,
+  CliRuntime,
+  CliRuntimeEvent,
+  CliRuntimeRunState,
+  CliSessionRef,
+  CliTurnInput,
+} from './types'
+
+export type CliConversationSnapshot = Readonly<{
+  runtimeId: CliRuntime['runtimeId']
+  messages: readonly ChatMessage[]
+  sessionRef: CliSessionRef | null
+  runState: CliRuntimeRunState
+  error: string | null
+}>
+
+export type CliConversationTurn = Readonly<{
+  userMessage: ChatUserMessage
+  content: CliTurnInput['content']
+}>
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const isSameSession = (
+  left: CliSessionRef | null | undefined,
+  right: CliSessionRef | null | undefined,
+): boolean =>
+  left?.runtimeId === right?.runtimeId &&
+  left?.nativeSessionId === right?.nativeSessionId
+
+const upsertMessage = (
+  messages: readonly ChatMessage[],
+  message: ChatMessage,
+): readonly ChatMessage[] => {
+  const index = messages.findIndex((candidate) => candidate.id === message.id)
+  if (index < 0) return Object.freeze([...messages, message])
+  if (messages[index] === message) return messages
+  const next = [...messages]
+  next[index] = message
+  return Object.freeze(next)
+}
+
+const normalizeMessages = (
+  messages: readonly ChatMessage[],
+): readonly ChatMessage[] =>
+  messages.reduce<readonly ChatMessage[]>(upsertMessage, Object.freeze([]))
+
+/**
+ * Owns the transient timeline for the currently selected CLI runtime/session.
+ * The runtime remains owned by the caller; disposing this controller only
+ * detaches its listeners and invalidates outstanding operations.
+ */
+export class CliConversationController {
+  private runtime: CliRuntime
+  private snapshot: CliConversationSnapshot
+  private readonly listeners = new Set<() => void>()
+  private unsubscribeRuntime: (() => void) | null = null
+  private runtimeEpoch = 0
+  private conversationEpoch = 0
+  private acceptingEvents = false
+  private bindingTarget: CliSessionRef | null | undefined
+  private bindingEpoch: number | null = null
+  private readyTail: Promise<void> = Promise.resolve()
+  private disposed = false
+
+  constructor(runtime: CliRuntime) {
+    this.runtime = runtime
+    this.snapshot = this.createEmptySnapshot(runtime)
+    this.subscribeToRuntime()
+  }
+
+  getSnapshot = (): CliConversationSnapshot => this.snapshot
+
+  subscribe = (listener: () => void): (() => void) => {
+    if (this.disposed) return () => undefined
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  /** Switches the selected provider without taking ownership of either runtime. */
+  setRuntime(runtime: CliRuntime): void {
+    this.assertActive()
+    if (runtime === this.runtime) return
+    this.invalidateRuntimeSubscription()
+    this.runtime = runtime
+    this.runtimeEpoch += 1
+    this.conversationEpoch += 1
+    this.readyTail = Promise.resolve()
+    this.resetEventGate()
+    this.snapshot = this.createEmptySnapshot(runtime)
+    this.subscribeToRuntime()
+    this.notify()
+  }
+
+  /** Clears the current transcript before starting a provider-native session. */
+  resetSession(): void {
+    this.assertActive()
+    this.beginSessionTransition(null)
+  }
+
+  async hydrateSession(ref: CliSessionRef): Promise<void> {
+    this.assertActive()
+    this.assertRuntimeRef(ref)
+    this.beginSessionTransition(ref)
+    const operation = this.captureOperation()
+
+    try {
+      const hydration = await operation.runtime.openSession(ref)
+      if (!this.isCurrent(operation)) return
+      this.assertRuntimeRef(hydration.ref)
+      if (!isSameSession(ref, hydration.ref)) {
+        throw new Error('CLI runtime hydrated a different session.')
+      }
+      this.publish({
+        ...this.snapshot,
+        messages: normalizeMessages(hydration.messages),
+        sessionRef: hydration.ref,
+        runState: 'idle',
+        error: null,
+      })
+    } catch (error) {
+      if (this.isCurrent(operation)) this.publishError(error)
+      throw error
+    }
+  }
+
+  ensureReady(assistant: CliAssistantBinding): Promise<void> {
+    this.assertActive()
+    const operation = this.captureOperation()
+    const task = this.readyTail
+      .catch(() => undefined)
+      .then(async () => {
+        if (!this.isCurrent(operation)) return
+        await this.ensureReadyNow(operation, assistant)
+      })
+    this.readyTail = task.catch(() => undefined)
+    return task
+  }
+
+  async sendTurn({ userMessage, content }: CliConversationTurn): Promise<void> {
+    this.assertActive()
+    const operation = this.captureOperation()
+    if (!this.acceptingEvents) {
+      throw new Error('CLI runtime is not ready for the selected session.')
+    }
+
+    this.publish({
+      ...this.snapshot,
+      messages: upsertMessage(this.snapshot.messages, userMessage),
+      runState: 'running',
+      error: null,
+    })
+
+    try {
+      await operation.runtime.sendTurn({
+        ...(this.snapshot.sessionRef
+          ? { sessionRef: this.snapshot.sessionRef }
+          : {}),
+        content,
+      })
+      // Runtime notifications may arrive before sendTurn resolves. Do not
+      // overwrite messages or a newer run state after the await.
+    } catch (error) {
+      if (this.isCurrent(operation)) this.publishError(error)
+      throw error
+    }
+  }
+
+  async cancel(): Promise<void> {
+    this.assertActive()
+    const operation = this.captureOperation()
+    try {
+      await operation.runtime.cancel()
+      // Completion/abort may be notified before cancel resolves; the event is
+      // the authoritative run state, so success does not publish another one.
+    } catch (error) {
+      if (this.isCurrent(operation)) this.publishError(error)
+      throw error
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.runtimeEpoch += 1
+    this.conversationEpoch += 1
+    this.invalidateRuntimeSubscription()
+    this.resetEventGate()
+    this.listeners.clear()
+  }
+
+  private async ensureReadyNow(
+    operation: ReturnType<CliConversationController['captureOperation']>,
+    assistant: CliAssistantBinding,
+  ): Promise<void> {
+    const target = this.snapshot.sessionRef
+    this.acceptingEvents = false
+    this.bindingTarget = target
+    this.bindingEpoch = operation.conversationEpoch
+    this.publish({ ...this.snapshot, error: null })
+
+    try {
+      await operation.runtime.ensureReady({
+        ...(target ? { sessionRef: target } : {}),
+        assistant,
+      })
+      if (!this.isCurrent(operation)) return
+      if (!target && !this.snapshot.sessionRef) {
+        throw new Error('CLI runtime did not bind a session.')
+      }
+      this.acceptingEvents = true
+      this.bindingTarget = undefined
+      this.bindingEpoch = null
+    } catch (error) {
+      if (this.isCurrent(operation)) {
+        this.resetEventGate()
+        this.publishError(error)
+      }
+      throw error
+    }
+  }
+
+  private beginSessionTransition(ref: CliSessionRef | null): void {
+    this.conversationEpoch += 1
+    this.resetEventGate()
+    this.replaceRuntimeSubscription()
+    this.publish({
+      runtimeId: this.runtime.runtimeId,
+      messages: Object.freeze([]),
+      sessionRef: ref,
+      runState: 'idle',
+      error: null,
+    })
+  }
+
+  private handleRuntimeEvent(
+    event: CliRuntimeEvent,
+    runtimeEpoch: number,
+    conversationEpoch: number,
+  ): void {
+    if (
+      this.disposed ||
+      runtimeEpoch !== this.runtimeEpoch ||
+      conversationEpoch !== this.conversationEpoch
+    ) {
+      return
+    }
+
+    if (event.type === 'session_bound') {
+      if (event.ref.runtimeId !== this.runtime.runtimeId) return
+      if (this.bindingEpoch === conversationEpoch) {
+        if (
+          this.bindingTarget &&
+          !isSameSession(this.bindingTarget, event.ref)
+        ) {
+          return
+        }
+        this.acceptingEvents = true
+        this.publish({ ...this.snapshot, sessionRef: event.ref, error: null })
+        return
+      }
+      if (
+        this.acceptingEvents &&
+        isSameSession(this.snapshot.sessionRef, event.ref)
+      ) {
+        this.publish({ ...this.snapshot, sessionRef: event.ref })
+      }
+      return
+    }
+
+    if (!this.acceptingEvents) return
+    if (event.type === 'message_upsert') {
+      this.publish({
+        ...this.snapshot,
+        messages: upsertMessage(this.snapshot.messages, event.message),
+      })
+      return
+    }
+    if (event.type === 'message_remove') {
+      const messages = this.snapshot.messages.filter(
+        (message) => message.id !== event.messageId,
+      )
+      if (messages.length !== this.snapshot.messages.length) {
+        this.publish({ ...this.snapshot, messages: Object.freeze(messages) })
+      }
+      return
+    }
+    this.publish({
+      ...this.snapshot,
+      runState: event.state,
+      error: event.error ?? null,
+    })
+  }
+
+  private subscribeToRuntime(): void {
+    const runtimeEpoch = this.runtimeEpoch
+    const conversationEpoch = this.conversationEpoch
+    this.unsubscribeRuntime = this.runtime.subscribe((event) =>
+      this.handleRuntimeEvent(event, runtimeEpoch, conversationEpoch),
+    )
+  }
+
+  private replaceRuntimeSubscription(): void {
+    this.invalidateRuntimeSubscription()
+    this.subscribeToRuntime()
+  }
+
+  private invalidateRuntimeSubscription(): void {
+    this.unsubscribeRuntime?.()
+    this.unsubscribeRuntime = null
+  }
+
+  private resetEventGate(): void {
+    this.acceptingEvents = false
+    this.bindingTarget = undefined
+    this.bindingEpoch = null
+  }
+
+  private captureOperation(): {
+    runtime: CliRuntime
+    runtimeEpoch: number
+    conversationEpoch: number
+  } {
+    return {
+      runtime: this.runtime,
+      runtimeEpoch: this.runtimeEpoch,
+      conversationEpoch: this.conversationEpoch,
+    }
+  }
+
+  private isCurrent(operation: {
+    runtime: CliRuntime
+    runtimeEpoch: number
+    conversationEpoch: number
+  }): boolean {
+    return (
+      !this.disposed &&
+      operation.runtime === this.runtime &&
+      operation.runtimeEpoch === this.runtimeEpoch &&
+      operation.conversationEpoch === this.conversationEpoch
+    )
+  }
+
+  private assertRuntimeRef(ref: CliSessionRef): void {
+    if (ref.runtimeId !== this.runtime.runtimeId) {
+      throw new Error(
+        `Cannot use ${ref.runtimeId} session with ${this.runtime.runtimeId} runtime.`,
+      )
+    }
+  }
+
+  private assertActive(): void {
+    if (this.disposed)
+      throw new Error('CLI conversation controller is disposed.')
+  }
+
+  private publishError(error: unknown): void {
+    this.publish({
+      ...this.snapshot,
+      runState: 'error',
+      error: getErrorMessage(error),
+    })
+  }
+
+  private createEmptySnapshot(runtime: CliRuntime): CliConversationSnapshot {
+    return Object.freeze({
+      runtimeId: runtime.runtimeId,
+      messages: Object.freeze([]),
+      sessionRef: null,
+      runState: 'idle',
+      error: null,
+    })
+  }
+
+  private publish(snapshot: CliConversationSnapshot): void {
+    if (this.disposed) return
+    this.snapshot = Object.freeze(snapshot)
+    this.notify()
+  }
+
+  private notify(): void {
+    for (const listener of [...this.listeners]) listener()
+  }
+}

--- a/src/core/cli-runtime/index.ts
+++ b/src/core/cli-runtime/index.ts
@@ -1,5 +1,6 @@
 export * from './actions'
 export * from './codex'
+export * from './conversation-controller'
 export * from './desktop'
 export * from './session-index'
 export * from './session-service'


### PR DESCRIPTION
## Summary
- add a provider-neutral in-memory controller for CLI timeline, session, and run state
- isolate stale runtime/session events and concurrent hydration
- keep optimistic CLI messages outside YOLO persistence

## Verification
- `npx jest src/core/cli-runtime --runInBand` (10 suites / 37 tests)
- `npm run type:check`
- focused ESLint and Prettier checks