### PR TITLE
feat(cli-runtime): 实现 Claude Code 运行时适配器

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.6.1.3",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@anthropic-ai/sdk": "^0.39.0",
         "@aws-sdk/client-bedrock": "^3.1020.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1019.0",
@@ -32,6 +31,7 @@
         "@radix-ui/react-popover": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.3",
         "@tanstack/react-query": "^5.56.2",
+        "@yolo/claude-agent-sdk-runtime": "file:src/core/cli-runtime/claude/sdk-runtime",
         "ajv": "^8.17.1",
         "clsx": "^2.1.1",
         "cross-spawn": "^7.0.6",
@@ -132,30 +132,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
-      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
-      "license": "SEE LICENSE IN README.md",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
-      },
-      "peerDependencies": {
-        "@anthropic-ai/sdk": ">=0.93.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
@@ -6132,6 +6108,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.56.2",
       "license": "MIT",
@@ -6722,6 +6704,10 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "license": "ISC"
+    },
+    "node_modules/@yolo/claude-agent-sdk-runtime": {
+      "resolved": "src/core/cli-runtime/claude/sdk-runtime",
+      "link": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -10436,6 +10422,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -12858,6 +12850,19 @@
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -16661,6 +16666,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -17129,6 +17144,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
@@ -18620,6 +18641,70 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "src/core/cli-runtime/claude/sdk-runtime": {
+      "name": "@yolo/claude-agent-sdk-runtime",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+        "@anthropic-ai/sdk": "^0.115.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "src/core/cli-runtime/claude/sdk-runtime/node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "src/core/cli-runtime/claude/sdk-runtime/node_modules/@anthropic-ai/sdk": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+      "integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "src/core/cli-runtime/claude/sdk-runtime/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.6.1.3",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@anthropic-ai/sdk": "^0.39.0",
         "@aws-sdk/client-bedrock": "^3.1020.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1019.0",
@@ -132,6 +133,146 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.39.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "wrangler": "4.26.1"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@anthropic-ai/sdk": "^0.39.0",
     "@aws-sdk/client-bedrock": "^3.1020.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1019.0",
@@ -106,6 +105,7 @@
     "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@tanstack/react-query": "^5.56.2",
+    "@yolo/claude-agent-sdk-runtime": "file:src/core/cli-runtime/claude/sdk-runtime",
     "ajv": "^8.17.1",
     "clsx": "^2.1.1",
     "cross-spawn": "^7.0.6",
@@ -150,11 +150,5 @@
     "uuid": "^10.0.0",
     "vscode-diff": "^2.1.1",
     "zod": "^3.25.76"
-  },
-  "overrides": {
-    "@anthropic-ai/claude-agent-sdk": {
-      "@anthropic-ai/sdk": "$@anthropic-ai/sdk",
-      "zod": "$zod"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "wrangler": "4.26.1"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@anthropic-ai/sdk": "^0.39.0",
     "@aws-sdk/client-bedrock": "^3.1020.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1019.0",
@@ -149,5 +150,11 @@
     "uuid": "^10.0.0",
     "vscode-diff": "^2.1.1",
     "zod": "^3.25.76"
+  },
+  "overrides": {
+    "@anthropic-ai/claude-agent-sdk": {
+      "@anthropic-ai/sdk": "$@anthropic-ai/sdk",
+      "zod": "$zod"
+    }
   }
 }

--- a/src/core/cli-runtime/claude/ClaudeCliRuntime.test.ts
+++ b/src/core/cli-runtime/claude/ClaudeCliRuntime.test.ts
@@ -1,0 +1,628 @@
+import type {
+  CanUseTool,
+  Options,
+  SDKMessage,
+  SDKSessionInfo,
+  SDKUserMessage,
+  SessionMessage,
+} from '@anthropic-ai/claude-agent-sdk'
+import { Platform } from 'obsidian'
+
+import { ToolCallResponseStatus } from '../../../types/tool-call.types'
+import type { CliRuntimeEvent } from '../types'
+
+import { ClaudeCliRuntime } from './ClaudeCliRuntime'
+import type {
+  ClaudeProcessSupport,
+  ClaudeSdkModule,
+  ClaudeSdkQuery,
+} from './types'
+
+type QueryInput = {
+  prompt: AsyncIterable<SDKUserMessage> | string
+  options?: Options
+}
+
+class FakeQuery implements ClaudeSdkQuery {
+  readonly interrupt = jest.fn(async () => undefined)
+  readonly initializationResult = jest.fn(async () => ({}))
+  readonly close = jest.fn()
+
+  private messages: SDKMessage[] = []
+  private waiting:
+    | ((result: IteratorResult<SDKMessage, void>) => void)
+    | undefined
+  private closed = false
+
+  push(message: SDKMessage): void {
+    if (this.waiting) {
+      const resolve = this.waiting
+      this.waiting = undefined
+      resolve({ done: false, value: message })
+      return
+    }
+    this.messages.push(message)
+  }
+
+  next(): Promise<IteratorResult<SDKMessage, void>> {
+    const message = this.messages.shift()
+    if (message) {
+      return Promise.resolve({ done: false, value: message })
+    }
+    if (this.closed) {
+      return Promise.resolve({ done: true, value: undefined })
+    }
+    return new Promise((resolve) => {
+      this.waiting = resolve
+    })
+  }
+
+  return(): Promise<IteratorResult<SDKMessage, void>> {
+    this.closed = true
+    this.waiting?.({ done: true, value: undefined })
+    this.waiting = undefined
+    return Promise.resolve({ done: true, value: undefined })
+  }
+
+  throw(error?: unknown): Promise<IteratorResult<SDKMessage, void>> {
+    return Promise.reject(
+      error instanceof Error ? error : new Error(String(error)),
+    )
+  }
+
+  [Symbol.asyncIterator](): ClaudeSdkQuery {
+    return this
+  }
+}
+
+const createSdk = () => {
+  const queryInstance = new FakeQuery()
+  const queryInputs: QueryInput[] = []
+  const listSessions = jest.fn<
+    Promise<SDKSessionInfo[]>,
+    [options?: { dir?: string }]
+  >(async () => [])
+  const getSessionMessages = jest.fn<
+    Promise<SessionMessage[]>,
+    [sessionId: string, options?: { dir?: string }]
+  >(async () => [])
+  const query = jest.fn<ClaudeSdkQuery, [input: QueryInput]>((input) => {
+    queryInputs.push(input)
+    return queryInstance
+  })
+  const sdk: ClaudeSdkModule = {
+    query,
+    listSessions,
+    getSessionMessages,
+  }
+  return {
+    sdk,
+    query,
+    queryInputs,
+    queryInstance,
+    listSessions,
+    getSessionMessages,
+  }
+}
+
+const processSupport: ClaudeProcessSupport = {
+  cliPath: '/opt/homebrew/bin/claude',
+  env: { PATH: '/opt/homebrew/bin:/usr/bin' },
+  spawnClaudeCodeProcess: jest.fn(),
+}
+
+const flushPromises = async (): Promise<void> => {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+const assistantMessage = (
+  content: Array<Record<string, unknown>>,
+): SDKMessage =>
+  ({
+    type: 'assistant',
+    message: {
+      id: 'msg_test',
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content,
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+    parent_tool_use_id: null,
+    uuid: 'assistant-uuid',
+    session_id: 'session-1',
+  }) as unknown as SDKMessage
+
+describe('ClaudeCliRuntime', () => {
+  const originalIsDesktop = Platform.isDesktop
+
+  afterEach(() => {
+    Platform.isDesktop = originalIsDesktop
+  })
+
+  it('gates SDK and Node support loading on desktop availability', async () => {
+    Platform.isDesktop = false
+    const { sdk } = createSdk()
+    const loadSdk = jest.fn(async () => sdk)
+    const resolveProcessSupport = jest.fn(async () => processSupport)
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk,
+      resolveProcessSupport,
+    })
+
+    await expect(runtime.listSessions()).rejects.toThrow(
+      /only available on desktop/,
+    )
+    await expect(
+      runtime.ensureReady({
+        assistant: {
+          systemPrompt: '',
+          enabledSkillNames: [],
+        },
+      }),
+    ).rejects.toThrow(/only available on desktop/)
+    expect(loadSdk).not.toHaveBeenCalled()
+    expect(resolveProcessSupport).not.toHaveBeenCalled()
+  })
+
+  it('discovers and hydrates native sessions for the current vault', async () => {
+    const { sdk, listSessions, getSessionMessages } = createSdk()
+    listSessions.mockResolvedValue([
+      {
+        sessionId: 'session-1',
+        summary: 'Native title',
+        firstPrompt: 'First prompt',
+        lastModified: 200,
+        createdAt: 100,
+        cwd: '/vault',
+      },
+    ])
+    getSessionMessages.mockResolvedValue([
+      {
+        type: 'user',
+        uuid: 'user-1',
+        session_id: 'session-1',
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+        message: { role: 'user', content: 'Run the tests' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-1',
+        session_id: 'session-1',
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+        message: {
+          id: 'msg_history',
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Running them.' },
+            {
+              type: 'tool_use',
+              id: 'tool-1',
+              name: 'Bash',
+              input: { command: 'npm test' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        uuid: 'result-1',
+        session_id: 'session-1',
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool-1',
+              content: 'All tests passed',
+            },
+          ],
+        },
+      },
+    ] as SessionMessage[])
+
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk: async () => sdk,
+      resolveProcessSupport: async () => processSupport,
+    })
+
+    await expect(runtime.listSessions()).resolves.toEqual([
+      {
+        ref: { runtimeId: 'claude-code', nativeSessionId: 'session-1' },
+        title: 'Native title',
+        preview: 'First prompt',
+        createdAt: 100,
+        updatedAt: 200,
+        cwd: '/vault',
+      },
+    ])
+    const hydration = await runtime.openSession({
+      runtimeId: 'claude-code',
+      nativeSessionId: 'session-1',
+    })
+
+    expect(listSessions).toHaveBeenCalledWith({ dir: '/vault' })
+    expect(getSessionMessages).toHaveBeenCalledWith('session-1', {
+      dir: '/vault',
+    })
+    expect(hydration.messages).toHaveLength(3)
+    expect(hydration.messages[0]).toMatchObject({
+      role: 'user',
+      id: 'user-1',
+      promptContent: 'Run the tests',
+    })
+    expect(hydration.messages[1]).toMatchObject({
+      role: 'assistant',
+      id: 'assistant-1',
+      content: 'Running them.',
+      toolCallRequests: [
+        {
+          id: 'tool-1',
+          name: 'Bash',
+          arguments: { kind: 'complete', value: { command: 'npm test' } },
+        },
+      ],
+    })
+    expect(hydration.messages[2]).toMatchObject({
+      role: 'tool',
+      toolCalls: [
+        {
+          request: { id: 'tool-1', name: 'Bash' },
+          response: {
+            status: ToolCallResponseStatus.Success,
+            data: { type: 'text', text: 'All tests passed' },
+          },
+        },
+      ],
+    })
+  })
+
+  it('keeps one streaming query across turns and resumes the native session', async () => {
+    const { sdk, query, queryInputs } = createSdk()
+    const resolvePluginPaths = jest.fn(async () => [
+      '/vault/.yolo-cache/claude-plugin',
+    ])
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk: async () => sdk,
+      resolveProcessSupport: async () => processSupport,
+      resolvePluginPaths,
+    })
+    const readyInput = {
+      sessionRef: {
+        runtimeId: 'claude-code' as const,
+        nativeSessionId: 'session-1',
+      },
+      assistant: {
+        assistantId: 'assistant-1',
+        systemPrompt: 'Be precise.',
+        enabledSkillNames: ['review'],
+      },
+    }
+
+    await runtime.ensureReady(readyInput)
+    await runtime.ensureReady(readyInput)
+    await runtime.sendTurn({
+      sessionRef: readyInput.sessionRef,
+      content: 'First turn',
+    })
+    await runtime.sendTurn({
+      sessionRef: readyInput.sessionRef,
+      content: 'Second turn',
+    })
+
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(resolvePluginPaths).toHaveBeenCalledWith({
+      assistantId: 'assistant-1',
+      enabledSkillNames: ['review'],
+    })
+    expect(queryInputs[0].options).toMatchObject({
+      cwd: '/vault',
+      pathToClaudeCodeExecutable: '/opt/homebrew/bin/claude',
+      resume: 'session-1',
+      includePartialMessages: true,
+      systemPrompt: {
+        type: 'preset',
+        preset: 'claude_code',
+        append: 'Be precise.',
+      },
+      plugins: [{ type: 'local', path: '/vault/.yolo-cache/claude-plugin' }],
+    })
+    const prompt = queryInputs[0].prompt
+    expect(typeof prompt).not.toBe('string')
+    if (typeof prompt === 'string') return
+    const iterator = prompt[Symbol.asyncIterator]()
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: 'user', message: { content: 'First turn' } },
+    })
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: 'user', message: { content: 'Second turn' } },
+    })
+  })
+
+  it('leaves enabled skill names unapplied when no plugin provider exists', async () => {
+    const { sdk, queryInputs } = createSdk()
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk: async () => sdk,
+      resolveProcessSupport: async () => processSupport,
+    })
+
+    await runtime.ensureReady({
+      assistant: {
+        systemPrompt: '',
+        enabledSkillNames: ['not-yet-materialized'],
+      },
+    })
+
+    expect(queryInputs[0].options?.plugins).toBeUndefined()
+  })
+
+  it('surfaces SDK initialization failures and closes the failed query', async () => {
+    const { sdk, queryInstance } = createSdk()
+    queryInstance.initializationResult.mockRejectedValueOnce(
+      new Error('Claude authentication failed'),
+    )
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk: async () => sdk,
+      resolveProcessSupport: async () => processSupport,
+    })
+
+    await expect(
+      runtime.ensureReady({
+        assistant: { systemPrompt: '', enabledSkillNames: [] },
+      }),
+    ).rejects.toThrow('Claude authentication failed')
+    expect(queryInstance.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('deduplicates the final assistant text after partial streaming', async () => {
+    const { sdk, queryInstance } = createSdk()
+    const events: CliRuntimeEvent[] = []
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk: async () => sdk,
+      resolveProcessSupport: async () => processSupport,
+    })
+    runtime.subscribe((event) => events.push(event))
+    await runtime.ensureReady({
+      assistant: { systemPrompt: '', enabledSkillNames: [] },
+    })
+
+    queryInstance.push({
+      type: 'stream_event',
+      event: {
+        type: 'message_start',
+        message: {
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          model: 'claude-sonnet-4-5',
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: 1,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+      },
+      parent_tool_use_id: null,
+      uuid: 'stream-1',
+      session_id: 'session-1',
+    } as unknown as SDKMessage)
+    queryInstance.push({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'Hello' },
+      },
+      parent_tool_use_id: null,
+      uuid: 'stream-2',
+      session_id: 'session-1',
+    } as unknown as SDKMessage)
+    queryInstance.push(assistantMessage([{ type: 'text', text: 'Hello' }]))
+    queryInstance.push({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: 'Hello',
+      duration_ms: 1,
+      duration_api_ms: 1,
+      num_turns: 1,
+      stop_reason: 'end_turn',
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        server_tool_use: null,
+        service_tier: 'standard',
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: 'result-1',
+      session_id: 'session-1',
+    } as unknown as SDKMessage)
+    await flushPromises()
+
+    const assistantUpserts = events.filter(
+      (event) =>
+        event.type === 'message_upsert' && event.message.role === 'assistant',
+    )
+    expect(assistantUpserts).not.toHaveLength(0)
+    expect(assistantUpserts.at(-1)).toMatchObject({
+      type: 'message_upsert',
+      message: {
+        role: 'assistant',
+        content: 'Hello',
+        metadata: { generationState: 'completed' },
+      },
+    })
+    expect(
+      assistantUpserts.some(
+        (event) =>
+          event.type === 'message_upsert' &&
+          event.message.role === 'assistant' &&
+          event.message.content === 'HelloHello',
+      ),
+    ).toBe(false)
+  })
+
+  it('bridges approvals and AskUserQuestion responses back to the SDK', async () => {
+    const { sdk, queryInputs } = createSdk()
+    const events: CliRuntimeEvent[] = []
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk: async () => sdk,
+      resolveProcessSupport: async () => processSupport,
+    })
+    runtime.subscribe((event) => events.push(event))
+    await runtime.ensureReady({
+      assistant: { systemPrompt: '', enabledSkillNames: [] },
+    })
+    const canUseTool = queryInputs[0].options?.canUseTool as CanUseTool
+
+    const approval = canUseTool(
+      'Bash',
+      { command: 'npm test' },
+      {
+        signal: new AbortController().signal,
+        toolUseID: 'tool-1',
+        requestId: 'request-1',
+        suggestions: [
+          {
+            type: 'addRules',
+            rules: [{ toolName: 'Bash', ruleContent: 'npm test' }],
+            behavior: 'allow',
+            destination: 'projectSettings',
+          },
+        ],
+      },
+    )
+    await flushPromises()
+    await runtime.respondApproval({
+      requestId: 'tool-1',
+      decision: 'approve_for_session',
+    })
+    await expect(approval).resolves.toMatchObject({
+      behavior: 'allow',
+      updatedInput: { command: 'npm test' },
+      updatedPermissions: [{ destination: 'session' }],
+    })
+
+    const question = canUseTool(
+      'AskUserQuestion',
+      { questions: [{ question: 'Continue?' }] },
+      {
+        signal: new AbortController().signal,
+        toolUseID: 'tool-2',
+        requestId: 'request-2',
+      },
+    )
+    await flushPromises()
+    await runtime.respondQuestion({
+      requestId: 'request-2',
+      answer: { Continue: 'Yes' },
+    })
+    await expect(question).resolves.toMatchObject({
+      behavior: 'allow',
+      updatedInput: {
+        questions: [{ question: 'Continue?', isOther: true }],
+        answers: { Continue: 'Yes' },
+      },
+    })
+
+    const approvalWithoutSuggestion = canUseTool(
+      'Write',
+      { file_path: '/vault/note.md' },
+      {
+        signal: new AbortController().signal,
+        toolUseID: 'tool-3',
+        requestId: 'request-3',
+      },
+    )
+    await flushPromises()
+    await runtime.respondApproval({
+      requestId: 'request-3',
+      decision: 'approve_for_session',
+    })
+    await expect(approvalWithoutSuggestion).resolves.toMatchObject({
+      behavior: 'allow',
+      updatedPermissions: [
+        {
+          type: 'addRules',
+          rules: [{ toolName: 'Write' }],
+          behavior: 'allow',
+          destination: 'session',
+        },
+      ],
+    })
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'run_state',
+          state: 'waiting_for_approval',
+        }),
+        expect.objectContaining({
+          type: 'run_state',
+          state: 'waiting_for_user',
+        }),
+        expect.objectContaining({
+          type: 'message_upsert',
+          message: expect.objectContaining({
+            role: 'tool',
+            toolCalls: [
+              expect.objectContaining({
+                response: {
+                  status: ToolCallResponseStatus.AwaitingUserInput,
+                },
+              }),
+            ],
+          }),
+        }),
+      ]),
+    )
+  })
+
+  it('interrupts without discarding the persistent query', async () => {
+    const { sdk, query, queryInstance } = createSdk()
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk: async () => sdk,
+      resolveProcessSupport: async () => processSupport,
+    })
+    const readyInput = {
+      assistant: { systemPrompt: '', enabledSkillNames: [] },
+    }
+    await runtime.ensureReady(readyInput)
+    await runtime.sendTurn({ content: 'Start' })
+    await runtime.cancel()
+    await runtime.ensureReady(readyInput)
+    await runtime.sendTurn({ content: 'Continue' })
+
+    expect(queryInstance.interrupt).toHaveBeenCalledTimes(1)
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/core/cli-runtime/claude/ClaudeCliRuntime.test.ts
+++ b/src/core/cli-runtime/claude/ClaudeCliRuntime.test.ts
@@ -5,7 +5,7 @@ import type {
   SDKSessionInfo,
   SDKUserMessage,
   SessionMessage,
-} from '@anthropic-ai/claude-agent-sdk'
+} from '@yolo/claude-agent-sdk-runtime'
 import { Platform } from 'obsidian'
 
 import { ToolCallResponseStatus } from '../../../types/tool-call.types'
@@ -233,6 +233,54 @@ describe('ClaudeCliRuntime', () => {
           ],
         },
       },
+      {
+        type: 'assistant',
+        uuid: 'assistant-question',
+        session_id: 'session-1',
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+        message: {
+          id: 'msg_question',
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'question-tool',
+              name: 'AskUserQuestion',
+              input: {
+                questions: [
+                  {
+                    id: 'choice',
+                    question: 'Choose one?',
+                    options: [
+                      { label: 'A', description: 'Option A' },
+                      { label: 'B', description: 'Option B' },
+                    ],
+                    multiSelect: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        uuid: 'question-result',
+        session_id: 'session-1',
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'question-tool',
+              content: 'Answered',
+            },
+          ],
+        },
+      },
     ] as SessionMessage[])
 
     const runtime = new ClaudeCliRuntime({
@@ -260,7 +308,7 @@ describe('ClaudeCliRuntime', () => {
     expect(getSessionMessages).toHaveBeenCalledWith('session-1', {
       dir: '/vault',
     })
-    expect(hydration.messages).toHaveLength(3)
+    expect(hydration.messages).toHaveLength(5)
     expect(hydration.messages[0]).toMatchObject({
       role: 'user',
       id: 'user-1',
@@ -286,6 +334,42 @@ describe('ClaudeCliRuntime', () => {
           response: {
             status: ToolCallResponseStatus.Success,
             data: { type: 'text', text: 'All tests passed' },
+          },
+        },
+      ],
+    })
+    expect(hydration.messages[3]).toMatchObject({
+      role: 'assistant',
+      toolCallRequests: [
+        {
+          id: 'question-tool',
+          name: 'yolo_local__ask_user_question',
+          arguments: {
+            kind: 'complete',
+            value: {
+              questions: [
+                {
+                  id: 'choice',
+                  prompt: 'Choose one?',
+                  inputType: 'single_select',
+                  options: [
+                    { id: 'A', label: 'A' },
+                    { id: 'B', label: 'B' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      ],
+    })
+    expect(hydration.messages[4]).toMatchObject({
+      role: 'tool',
+      toolCalls: [
+        {
+          request: {
+            id: 'question-tool',
+            name: 'yolo_local__ask_user_question',
           },
         },
       ],
@@ -533,7 +617,38 @@ describe('ClaudeCliRuntime', () => {
 
     const question = canUseTool(
       'AskUserQuestion',
-      { questions: [{ question: 'Continue?' }] },
+      {
+        questions: [
+          {
+            id: 'context',
+            question: 'Anything else?',
+            header: 'Context',
+            options: [],
+            multiSelect: false,
+            isOther: true,
+          },
+          {
+            id: 'approach',
+            question: 'Which approach?',
+            header: 'Approach',
+            options: [
+              { label: 'Simple', description: 'Use the direct path.' },
+              { label: 'Layered', description: 'Add an abstraction.' },
+            ],
+            multiSelect: false,
+          },
+          {
+            id: 'features',
+            question: 'Which features?',
+            header: 'Features',
+            options: [
+              { label: 'Fast', description: 'Optimize latency.' },
+              { label: 'Safe', description: 'Add more checks.' },
+            ],
+            multiSelect: true,
+          },
+        ],
+      },
       {
         signal: new AbortController().signal,
         toolUseID: 'tool-2',
@@ -543,13 +658,93 @@ describe('ClaudeCliRuntime', () => {
     await flushPromises()
     await runtime.respondQuestion({
       requestId: 'request-2',
-      answer: { Continue: 'Yes' },
+      answer: {
+        type: 'user_answers',
+        answers: [
+          {
+            id: 'context',
+            question: 'Anything else?',
+            inputType: 'free_text',
+            value: 'Keep the API narrow.',
+          },
+          {
+            id: 'approach',
+            question: 'Which approach?',
+            inputType: 'single_select',
+            value: '__other__',
+            otherText: 'Hybrid',
+          },
+          {
+            id: 'features',
+            question: 'Which features?',
+            inputType: 'multi_select',
+            value: ['Fast', '__other__'],
+            otherText: 'Observable',
+          },
+        ],
+      },
     })
     await expect(question).resolves.toMatchObject({
       behavior: 'allow',
       updatedInput: {
-        questions: [{ question: 'Continue?', isOther: true }],
-        answers: { Continue: 'Yes' },
+        answers: {
+          context: 'Keep the API narrow.',
+          approach: 'Hybrid',
+          features: ['Fast', 'Observable'],
+        },
+      },
+    })
+
+    const pendingQuestionEvent = [...events]
+      .reverse()
+      .find(
+        (event) =>
+          event.type === 'message_upsert' &&
+          event.message.role === 'tool' &&
+          event.message.toolCalls[0]?.request.id === 'tool-2' &&
+          event.message.toolCalls[0].response.status ===
+            ToolCallResponseStatus.AwaitingUserInput,
+      )
+    expect(pendingQuestionEvent).toMatchObject({
+      type: 'message_upsert',
+      message: {
+        toolCalls: [
+          {
+            request: {
+              name: 'yolo_local__ask_user_question',
+              arguments: {
+                kind: 'complete',
+                value: {
+                  questions: [
+                    {
+                      id: 'context',
+                      prompt: 'Anything else?',
+                      inputType: 'free_text',
+                    },
+                    {
+                      id: 'approach',
+                      prompt: 'Which approach?',
+                      inputType: 'single_select',
+                      options: [
+                        { id: 'Simple', label: 'Simple' },
+                        { id: 'Layered', label: 'Layered' },
+                      ],
+                    },
+                    {
+                      id: 'features',
+                      prompt: 'Which features?',
+                      inputType: 'multi_select',
+                      options: [
+                        { id: 'Fast', label: 'Fast' },
+                        { id: 'Safe', label: 'Safe' },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
       },
     })
 
@@ -598,6 +793,69 @@ describe('ClaudeCliRuntime', () => {
                 response: {
                   status: ToolCallResponseStatus.AwaitingUserInput,
                 },
+              }),
+            ],
+          }),
+        }),
+      ]),
+    )
+  })
+
+  it('denies malformed nested AskUserQuestion answer payloads', async () => {
+    const { sdk, queryInputs } = createSdk()
+    const events: CliRuntimeEvent[] = []
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk: async () => sdk,
+      resolveProcessSupport: async () => processSupport,
+    })
+    runtime.subscribe((event) => events.push(event))
+    await runtime.ensureReady({
+      assistant: { systemPrompt: '', enabledSkillNames: [] },
+    })
+    const canUseTool = queryInputs[0].options?.canUseTool as CanUseTool
+    const question = canUseTool(
+      'AskUserQuestion',
+      {
+        questions: [
+          {
+            id: 'choice',
+            question: 'Choose one?',
+            options: [
+              { label: 'A', description: 'Option A' },
+              { label: 'B', description: 'Option B' },
+            ],
+            multiSelect: false,
+          },
+        ],
+      },
+      {
+        signal: new AbortController().signal,
+        toolUseID: 'tool-invalid-answer',
+        requestId: 'request-invalid-answer',
+      },
+    )
+    await flushPromises()
+    await runtime.respondQuestion({
+      requestId: 'request-invalid-answer',
+      answer: { answers: { choice: 'A' } },
+    })
+
+    await expect(question).resolves.toMatchObject({
+      behavior: 'deny',
+      interrupt: true,
+    })
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'message_upsert',
+          message: expect.objectContaining({
+            role: 'tool',
+            toolCalls: [
+              expect.objectContaining({
+                response: expect.objectContaining({
+                  status: ToolCallResponseStatus.Error,
+                }),
               }),
             ],
           }),

--- a/src/core/cli-runtime/claude/ClaudeCliRuntime.ts
+++ b/src/core/cli-runtime/claude/ClaudeCliRuntime.ts
@@ -4,7 +4,7 @@ import type {
   PermissionUpdate,
   SDKMessage,
   SDKUserMessage,
-} from '@anthropic-ai/claude-agent-sdk'
+} from '@yolo/claude-agent-sdk-runtime'
 import { v4 as uuidv4 } from 'uuid'
 
 import type { ChatAssistantMessage, ChatToolMessage } from '../../../types/chat'
@@ -13,7 +13,6 @@ import {
   type ToolCallRequest,
   type ToolCallResponse,
   ToolCallResponseStatus,
-  createCompleteToolCallArguments,
   createPartialToolCallArguments,
 } from '../../../types/tool-call.types'
 import { assertCliRuntimeAvailable } from '../desktop'
@@ -31,6 +30,11 @@ import type {
   CliTurnInput,
 } from '../types'
 
+import {
+  CLAUDE_ASK_USER_QUESTION_TOOL,
+  convertYoloAnswerPayloadToClaude,
+  mapClaudeAskUserQuestionInput,
+} from './askUserQuestion'
 import { AsyncPushQueue } from './asyncQueue'
 import {
   extractTextContent,
@@ -50,8 +54,6 @@ import type {
   ClaudeSdkModule,
   ClaudeSdkQuery,
 } from './types'
-
-const ASK_USER_QUESTION_TOOL = 'AskUserQuestion'
 
 type PendingPermission = {
   requestId: string
@@ -450,9 +452,28 @@ export class ClaudeCliRuntime implements CliRuntime {
       return
     }
 
+    const converted = convertYoloAnswerPayloadToClaude({
+      payload: response.answer,
+      nativeInput: pending.input,
+    })
+    if (!converted.ok) {
+      this.settlePending(pending, {
+        behavior: 'deny',
+        message: converted.error,
+        interrupt: true,
+        toolUseID: pending.toolUseId,
+      })
+      this.upsertTool(pending.toolUseId, {
+        status: ToolCallResponseStatus.Error,
+        error: converted.error,
+      })
+      this.emit({ type: 'run_state', state: 'error', error: converted.error })
+      return
+    }
+
     this.settlePending(pending, {
       behavior: 'allow',
-      updatedInput: { ...pending.input, answers: response.answer },
+      updatedInput: { ...pending.input, answers: converted.answers },
       toolUseID: pending.toolUseId,
       decisionClassification: 'user_temporary',
     })
@@ -507,9 +528,21 @@ export class ClaudeCliRuntime implements CliRuntime {
 
   private createCanUseTool(): CanUseTool {
     return async (toolName, input, options) => {
-      const kind = toolName === ASK_USER_QUESTION_TOOL ? 'question' : 'approval'
+      const kind =
+        toolName === CLAUDE_ASK_USER_QUESTION_TOOL ? 'question' : 'approval'
       const normalizedInput =
         kind === 'question' ? normalizeAskUserQuestionInput(input) : input
+      if (
+        kind === 'question' &&
+        mapClaudeAskUserQuestionInput(normalizedInput) === null
+      ) {
+        return {
+          behavior: 'deny',
+          message: 'Claude AskUserQuestion input is invalid.',
+          interrupt: true,
+          toolUseID: options.toolUseID,
+        }
+      }
       this.ensureToolRequest(options.toolUseID, toolName, normalizedInput)
       this.upsertTool(
         options.toolUseID,
@@ -792,6 +825,7 @@ export class ClaudeCliRuntime implements CliRuntime {
   }
 
   private ensurePartialToolRequest(tool: StreamedToolInput): void {
+    if (tool.name === CLAUDE_ASK_USER_QUESTION_TOOL) return
     const request: ToolCallRequest = {
       id: tool.id,
       name: tool.name,
@@ -814,11 +848,11 @@ export class ClaudeCliRuntime implements CliRuntime {
     toolName: string,
     input: Record<string, unknown>,
   ): void {
-    const request: ToolCallRequest = {
+    const request = toToolCallRequest({
       id: toolUseId,
       name: toolName,
-      arguments: createCompleteToolCallArguments({ value: input }),
-    }
+      input,
+    })
     this.setAssistantToolRequest(request)
     const existing = this.tools.get(toolUseId)
     this.tools.set(toolUseId, {

--- a/src/core/cli-runtime/claude/ClaudeCliRuntime.ts
+++ b/src/core/cli-runtime/claude/ClaudeCliRuntime.ts
@@ -1,0 +1,925 @@
+import type {
+  CanUseTool,
+  PermissionResult,
+  PermissionUpdate,
+  SDKMessage,
+  SDKUserMessage,
+} from '@anthropic-ai/claude-agent-sdk'
+import { v4 as uuidv4 } from 'uuid'
+
+import type { ChatAssistantMessage, ChatToolMessage } from '../../../types/chat'
+import type { ContentPart } from '../../../types/llm/request'
+import {
+  type ToolCallRequest,
+  type ToolCallResponse,
+  ToolCallResponseStatus,
+  createCompleteToolCallArguments,
+  createPartialToolCallArguments,
+} from '../../../types/tool-call.types'
+import { assertCliRuntimeAvailable } from '../desktop'
+import type {
+  CliApprovalResponse,
+  CliAssistantBinding,
+  CliQuestionResponse,
+  CliRuntime,
+  CliRuntimeEvent,
+  CliRuntimeEventListener,
+  CliRuntimeReadyInput,
+  CliSessionHydration,
+  CliSessionMetadata,
+  CliSessionRef,
+  CliTurnInput,
+} from '../types'
+
+import { AsyncPushQueue } from './asyncQueue'
+import {
+  extractTextContent,
+  extractThinkingContent,
+  extractToolResults,
+  extractToolUses,
+  hydrateClaudeSessionMessages,
+  reconcileFinalText,
+  toToolCallRequest,
+} from './messages'
+import { resolveClaudeProcessSupport } from './process'
+import { loadClaudeAgentSdk } from './sdk-loader'
+import type {
+  ClaudePluginPathProvider,
+  ClaudeProcessSupportResolver,
+  ClaudeSdkLoader,
+  ClaudeSdkModule,
+  ClaudeSdkQuery,
+} from './types'
+
+const ASK_USER_QUESTION_TOOL = 'AskUserQuestion'
+
+type PendingPermission = {
+  requestId: string
+  toolUseId: string
+  toolName: string
+  input: Record<string, unknown>
+  suggestions?: PermissionUpdate[]
+  kind: 'approval' | 'question'
+  resolve: (result: PermissionResult) => void
+  settled: boolean
+}
+
+type ToolState = {
+  request: ToolCallRequest
+  response: ToolCallResponse
+}
+
+type StreamedToolInput = {
+  id: string
+  name: string
+  rawInput: string
+}
+
+export type ClaudeCliRuntimeOptions = {
+  vaultPath: string
+  configuredCliPath?: string
+  loadSdk?: ClaudeSdkLoader
+  resolveProcessSupport?: ClaudeProcessSupportResolver
+  resolvePluginPaths?: ClaudePluginPathProvider
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const cloneToolMessage = (message: ChatToolMessage): ChatToolMessage => ({
+  ...message,
+  toolCalls: message.toolCalls.map((toolCall) => ({
+    request: {
+      ...toolCall.request,
+      arguments: toolCall.request.arguments
+        ? { ...toolCall.request.arguments }
+        : undefined,
+    },
+    response: { ...toolCall.response },
+  })),
+})
+
+const cloneAssistantMessage = (
+  message: ChatAssistantMessage,
+): ChatAssistantMessage => ({
+  ...message,
+  toolCallRequests: message.toolCallRequests?.map((request) => ({
+    ...request,
+    arguments: request.arguments ? { ...request.arguments } : undefined,
+  })),
+  metadata: message.metadata ? { ...message.metadata } : undefined,
+})
+
+const toSessionPermissionUpdates = (
+  toolName: string,
+  suggestions?: PermissionUpdate[],
+): PermissionUpdate[] => {
+  const updates = (suggestions ?? []).map((suggestion) => ({
+    ...suggestion,
+    destination: 'session',
+  })) as PermissionUpdate[]
+  const hasRuleUpdate = updates.some(
+    (update) => update.type === 'addRules' || update.type === 'replaceRules',
+  )
+  if (!hasRuleUpdate) {
+    updates.unshift({
+      type: 'addRules',
+      rules: [{ toolName }],
+      behavior: 'allow',
+      destination: 'session',
+    })
+  }
+  return updates
+}
+
+const normalizeAskUserQuestionInput = (
+  input: Record<string, unknown>,
+): Record<string, unknown> => {
+  if (!Array.isArray(input.questions)) return input
+  return {
+    ...input,
+    questions: input.questions.map((question) =>
+      isRecord(question) && !('isOther' in question)
+        ? { ...question, isOther: true }
+        : question,
+    ),
+  }
+}
+
+const contentPartToClaudeBlock = (
+  part: ContentPart,
+): Record<string, unknown> => {
+  if (part.type === 'text') return part
+  if (part.type === 'document') {
+    return {
+      type: 'document',
+      source: {
+        type: 'base64',
+        media_type: part.mediaType,
+        data: part.data,
+      },
+      title: part.name,
+    }
+  }
+
+  const dataUrl = part.image_url.url.match(
+    /^data:([^;,]+);base64,([A-Za-z0-9+/=\r\n]+)$/,
+  )
+  if (dataUrl) {
+    return {
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: dataUrl[1],
+        data: dataUrl[2].replace(/[\r\n]/g, ''),
+      },
+    }
+  }
+  return {
+    type: 'image',
+    source: { type: 'url', url: part.image_url.url },
+  }
+}
+
+const toSdkUserMessage = (
+  content: string | ContentPart[],
+  sessionId?: string,
+): SDKUserMessage =>
+  ({
+    type: 'user',
+    message: {
+      role: 'user',
+      content:
+        typeof content === 'string'
+          ? content
+          : content.map(contentPartToClaudeBlock),
+    },
+    parent_tool_use_id: null,
+    uuid: uuidv4(),
+    ...(sessionId ? { session_id: sessionId } : {}),
+  }) as SDKUserMessage
+
+export class ClaudeCliRuntime implements CliRuntime {
+  readonly runtimeId = 'claude-code' as const
+
+  private readonly vaultPath: string
+  private readonly configuredCliPath?: string
+  private readonly loadSdk: ClaudeSdkLoader
+  private readonly resolveProcessSupport: ClaudeProcessSupportResolver
+  private readonly resolvePluginPaths?: ClaudePluginPathProvider
+  private readonly listeners = new Set<CliRuntimeEventListener>()
+  private readonly pendingPermissions = new Map<string, PendingPermission>()
+  private readonly tools = new Map<string, ToolState>()
+  private readonly streamedToolInputs = new Map<number, StreamedToolInput>()
+
+  private sdkPromise?: Promise<ClaudeSdkModule>
+  private query?: ClaudeSdkQuery
+  private inputQueue?: AsyncPushQueue<SDKUserMessage>
+  private consumePromise?: Promise<void>
+  private readyKey?: string
+  private currentSessionRef?: CliSessionRef
+  private activeAssistant?: ChatAssistantMessage
+  private activeAssistantKey?: string
+  private disposed = false
+  private resetting = false
+  private cancelRequested = false
+
+  constructor(options: ClaudeCliRuntimeOptions) {
+    this.vaultPath = options.vaultPath
+    this.configuredCliPath = options.configuredCliPath
+    this.loadSdk = options.loadSdk ?? loadClaudeAgentSdk
+    this.resolveProcessSupport =
+      options.resolveProcessSupport ??
+      (() =>
+        resolveClaudeProcessSupport({
+          configuredCliPath: this.configuredCliPath,
+        }))
+    this.resolvePluginPaths = options.resolvePluginPaths
+  }
+
+  async listSessions(): Promise<CliSessionMetadata[]> {
+    this.assertUsable()
+    const sdk = await this.getSdk()
+    const sessions = await sdk.listSessions({ dir: this.vaultPath })
+    return sessions.map((session) => ({
+      ref: {
+        runtimeId: 'claude-code',
+        nativeSessionId: session.sessionId,
+      },
+      title:
+        session.customTitle ||
+        session.summary ||
+        session.firstPrompt ||
+        session.sessionId,
+      ...(session.firstPrompt && session.firstPrompt !== session.summary
+        ? { preview: session.firstPrompt }
+        : {}),
+      ...(session.createdAt !== undefined
+        ? { createdAt: session.createdAt }
+        : {}),
+      updatedAt: session.lastModified,
+      ...(session.cwd ? { cwd: session.cwd } : {}),
+    }))
+  }
+
+  async openSession(ref: CliSessionRef): Promise<CliSessionHydration> {
+    this.assertUsable()
+    this.assertClaudeRef(ref)
+    const sdk = await this.getSdk()
+    const messages = await sdk.getSessionMessages(ref.nativeSessionId, {
+      dir: this.vaultPath,
+    })
+    return { ref, messages: hydrateClaudeSessionMessages(messages) }
+  }
+
+  async ensureReady(input: CliRuntimeReadyInput): Promise<void> {
+    this.assertUsable()
+    if (input.sessionRef) this.assertClaudeRef(input.sessionRef)
+
+    const [sdk, processSupport, pluginPaths] = await Promise.all([
+      this.getSdk(),
+      this.resolveProcessSupport(),
+      this.resolveAssistantPluginPaths(input.assistant),
+    ])
+    const readyKey = JSON.stringify({
+      sessionId: input.sessionRef?.nativeSessionId,
+      systemPrompt: input.assistant.systemPrompt,
+      cliPath: processSupport.cliPath,
+      pluginPaths,
+    })
+    if (this.query && this.readyKey === readyKey) return
+
+    await this.resetQuery()
+    this.currentSessionRef = input.sessionRef
+    this.readyKey = readyKey
+    this.inputQueue = new AsyncPushQueue<SDKUserMessage>()
+    this.query = sdk.query({
+      prompt: this.inputQueue,
+      options: {
+        cwd: this.vaultPath,
+        pathToClaudeCodeExecutable: processSupport.cliPath,
+        env: processSupport.env,
+        spawnClaudeCodeProcess: processSupport.spawnClaudeCodeProcess,
+        includePartialMessages: true,
+        permissionMode: 'default',
+        canUseTool: this.createCanUseTool(),
+        systemPrompt: {
+          type: 'preset',
+          preset: 'claude_code',
+          ...(input.assistant.systemPrompt
+            ? { append: input.assistant.systemPrompt }
+            : {}),
+        },
+        ...(input.sessionRef
+          ? { resume: input.sessionRef.nativeSessionId }
+          : {}),
+        ...(pluginPaths.length > 0
+          ? {
+              plugins: pluginPaths.map((path) => ({
+                type: 'local' as const,
+                path,
+              })),
+            }
+          : {}),
+      },
+    })
+    const query = this.query
+    this.consumePromise = this.consume(query)
+    try {
+      await query.initializationResult()
+    } catch (error) {
+      await this.resetQuery()
+      throw error
+    }
+  }
+
+  async sendTurn(input: CliTurnInput): Promise<void> {
+    this.assertUsable()
+    if (!this.query || !this.inputQueue) {
+      throw new Error('Claude CLI runtime is not ready.')
+    }
+    if (input.sessionRef) {
+      this.assertClaudeRef(input.sessionRef)
+      if (
+        this.currentSessionRef &&
+        input.sessionRef.nativeSessionId !==
+          this.currentSessionRef.nativeSessionId
+      ) {
+        throw new Error('Claude turn does not match the active native session.')
+      }
+    }
+
+    this.activeAssistant = undefined
+    this.activeAssistantKey = undefined
+    this.streamedToolInputs.clear()
+    this.cancelRequested = false
+    this.emit({ type: 'run_state', state: 'running' })
+    this.inputQueue.push(
+      toSdkUserMessage(input.content, this.currentSessionRef?.nativeSessionId),
+    )
+  }
+
+  async cancel(): Promise<void> {
+    this.assertUsable()
+    this.cancelRequested = true
+    this.settleAllPending({
+      behavior: 'deny',
+      message: 'User interrupted the Claude turn.',
+      interrupt: true,
+      decisionClassification: 'user_reject',
+    })
+    if (this.query) {
+      await this.query.interrupt()
+    }
+    this.markActiveAssistant('aborted')
+    for (const [toolUseId, tool] of this.tools) {
+      if (
+        tool.response.status === ToolCallResponseStatus.Running ||
+        tool.response.status === ToolCallResponseStatus.PendingApproval ||
+        tool.response.status === ToolCallResponseStatus.AwaitingUserInput
+      ) {
+        this.upsertTool(toolUseId, {
+          status: ToolCallResponseStatus.Aborted,
+        })
+      }
+    }
+    this.emit({ type: 'run_state', state: 'aborted' })
+  }
+
+  async respondApproval(response: CliApprovalResponse): Promise<void> {
+    const pending = this.pendingPermissions.get(response.requestId)
+    if (!pending || pending.kind !== 'approval' || pending.settled) return
+
+    if (response.decision === 'reject') {
+      this.settlePending(pending, {
+        behavior: 'deny',
+        message: 'User denied this action.',
+        toolUseID: pending.toolUseId,
+        decisionClassification: 'user_reject',
+      })
+      this.upsertTool(pending.toolUseId, {
+        status: ToolCallResponseStatus.Rejected,
+        reason: 'User denied this action.',
+      })
+      this.emitPendingRunStateOrRunning()
+      return
+    }
+
+    this.settlePending(pending, {
+      behavior: 'allow',
+      updatedInput: pending.input,
+      toolUseID: pending.toolUseId,
+      ...(response.decision === 'approve_for_session'
+        ? {
+            updatedPermissions: toSessionPermissionUpdates(
+              pending.toolName,
+              pending.suggestions,
+            ),
+          }
+        : {}),
+      decisionClassification:
+        response.decision === 'approve_for_session'
+          ? 'user_permanent'
+          : 'user_temporary',
+    })
+    this.upsertTool(pending.toolUseId, {
+      status: ToolCallResponseStatus.Running,
+    })
+    this.emitPendingRunStateOrRunning()
+  }
+
+  async respondQuestion(response: CliQuestionResponse): Promise<void> {
+    const pending = this.pendingPermissions.get(response.requestId)
+    if (!pending || pending.kind !== 'question' || pending.settled) return
+
+    if (response.answer === null || response.answer === undefined) {
+      this.settlePending(pending, {
+        behavior: 'deny',
+        message: 'User declined to answer.',
+        interrupt: true,
+        toolUseID: pending.toolUseId,
+        decisionClassification: 'user_reject',
+      })
+      this.upsertTool(pending.toolUseId, {
+        status: ToolCallResponseStatus.Rejected,
+        reason: 'User declined to answer.',
+      })
+      return
+    }
+
+    this.settlePending(pending, {
+      behavior: 'allow',
+      updatedInput: { ...pending.input, answers: response.answer },
+      toolUseID: pending.toolUseId,
+      decisionClassification: 'user_temporary',
+    })
+    this.upsertTool(pending.toolUseId, {
+      status: ToolCallResponseStatus.Running,
+    })
+    this.emitPendingRunStateOrRunning()
+  }
+
+  subscribe(listener: CliRuntimeEventListener): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return
+    this.disposed = true
+    await this.resetQuery()
+    this.listeners.clear()
+  }
+
+  private assertUsable(): void {
+    assertCliRuntimeAvailable('claude-code')
+    if (this.disposed) {
+      throw new Error('Claude CLI runtime has been disposed.')
+    }
+  }
+
+  private assertClaudeRef(ref: CliSessionRef): void {
+    if (ref.runtimeId !== 'claude-code') {
+      throw new Error(`Claude adapter cannot open ${ref.runtimeId} sessions.`)
+    }
+  }
+
+  private getSdk(): Promise<ClaudeSdkModule> {
+    assertCliRuntimeAvailable('claude-code')
+    this.sdkPromise ??= this.loadSdk()
+    return this.sdkPromise
+  }
+
+  private async resolveAssistantPluginPaths(
+    assistant: CliAssistantBinding,
+  ): Promise<string[]> {
+    if (!this.resolvePluginPaths || assistant.enabledSkillNames.length === 0) {
+      return []
+    }
+    return this.resolvePluginPaths({
+      assistantId: assistant.assistantId,
+      enabledSkillNames: [...assistant.enabledSkillNames],
+    })
+  }
+
+  private createCanUseTool(): CanUseTool {
+    return async (toolName, input, options) => {
+      const kind = toolName === ASK_USER_QUESTION_TOOL ? 'question' : 'approval'
+      const normalizedInput =
+        kind === 'question' ? normalizeAskUserQuestionInput(input) : input
+      this.ensureToolRequest(options.toolUseID, toolName, normalizedInput)
+      this.upsertTool(
+        options.toolUseID,
+        kind === 'question'
+          ? { status: ToolCallResponseStatus.AwaitingUserInput }
+          : { status: ToolCallResponseStatus.PendingApproval },
+      )
+      this.emit({
+        type: 'run_state',
+        state:
+          kind === 'question' ? 'waiting_for_user' : 'waiting_for_approval',
+      })
+
+      return new Promise<PermissionResult>((resolve) => {
+        const pending: PendingPermission = {
+          requestId: options.requestId,
+          toolUseId: options.toolUseID,
+          toolName,
+          input: normalizedInput,
+          suggestions: options.suggestions,
+          kind,
+          resolve,
+          settled: false,
+        }
+        this.pendingPermissions.set(options.requestId, pending)
+        this.pendingPermissions.set(options.toolUseID, pending)
+
+        const abort = (): void => {
+          this.settlePending(pending, {
+            behavior: 'deny',
+            message: 'Claude permission request was aborted.',
+            interrupt: true,
+          })
+        }
+        if (options.signal.aborted) abort()
+        else options.signal.addEventListener('abort', abort, { once: true })
+      })
+    }
+  }
+
+  private settlePending(
+    pending: PendingPermission,
+    result: PermissionResult,
+  ): void {
+    if (pending.settled) return
+    pending.settled = true
+    this.pendingPermissions.delete(pending.requestId)
+    this.pendingPermissions.delete(pending.toolUseId)
+    pending.resolve(result)
+  }
+
+  private settleAllPending(result: PermissionResult): void {
+    for (const pending of new Set(this.pendingPermissions.values())) {
+      this.settlePending(pending, result)
+    }
+  }
+
+  private async consume(query: ClaudeSdkQuery): Promise<void> {
+    try {
+      for await (const message of query) {
+        this.handleSdkMessage(message)
+      }
+      if (!this.resetting && !this.disposed) {
+        this.readyKey = undefined
+        this.emit({
+          type: 'run_state',
+          state: 'error',
+          error: 'Claude Code process exited unexpectedly.',
+        })
+      }
+    } catch (error) {
+      if (this.resetting || this.disposed) return
+      this.readyKey = undefined
+      this.emit({
+        type: 'run_state',
+        state: 'error',
+        error: getErrorMessage(error),
+      })
+    }
+  }
+
+  private handleSdkMessage(message: SDKMessage): void {
+    if (message.type === 'system' && message.subtype === 'init') {
+      const ref: CliSessionRef = {
+        runtimeId: 'claude-code',
+        nativeSessionId: message.session_id,
+      }
+      this.currentSessionRef = ref
+      this.emit({ type: 'session_bound', ref })
+      return
+    }
+    if (message.type === 'stream_event') {
+      this.handleStreamEvent(message)
+      return
+    }
+    if (message.type === 'assistant' && message.parent_tool_use_id === null) {
+      this.handleFinalAssistant(message)
+      return
+    }
+    if (message.type === 'user' && message.parent_tool_use_id === null) {
+      if (isRecord(message.message)) {
+        for (const result of extractToolResults(message.message.content)) {
+          this.upsertTool(
+            result.id,
+            result.isError
+              ? {
+                  status: ToolCallResponseStatus.Error,
+                  error: result.content,
+                }
+              : {
+                  status: ToolCallResponseStatus.Success,
+                  data: { type: 'text', text: result.content },
+                },
+          )
+        }
+      }
+      return
+    }
+    if (message.type === 'result') {
+      this.handleResult(message)
+    }
+  }
+
+  private handleStreamEvent(
+    message: Extract<SDKMessage, { type: 'stream_event' }>,
+  ): void {
+    if (message.parent_tool_use_id !== null) return
+    const event = message.event
+    if (event.type === 'message_start') {
+      this.ensureActiveAssistant(
+        event.message.id,
+        `claude-assistant-${event.message.id}`,
+      )
+      return
+    }
+    if (event.type === 'content_block_start') {
+      if (event.content_block.type === 'text' && event.content_block.text) {
+        this.appendAssistantText(event.content_block.text)
+      } else if (
+        event.content_block.type === 'thinking' &&
+        event.content_block.thinking
+      ) {
+        this.appendAssistantReasoning(event.content_block.thinking)
+      } else if (event.content_block.type === 'tool_use') {
+        const toolUse = {
+          id: event.content_block.id,
+          name: event.content_block.name,
+          rawInput: '',
+        }
+        this.streamedToolInputs.set(event.index, toolUse)
+        this.ensurePartialToolRequest(toolUse)
+      }
+      return
+    }
+    if (event.type !== 'content_block_delta') return
+
+    if (event.delta.type === 'text_delta') {
+      this.appendAssistantText(event.delta.text)
+    } else if (event.delta.type === 'thinking_delta') {
+      this.appendAssistantReasoning(event.delta.thinking)
+    } else if (event.delta.type === 'input_json_delta') {
+      const toolInput = this.streamedToolInputs.get(event.index)
+      if (!toolInput) return
+      toolInput.rawInput += event.delta.partial_json
+      this.ensurePartialToolRequest(toolInput)
+    }
+  }
+
+  private handleFinalAssistant(
+    message: Extract<SDKMessage, { type: 'assistant' }>,
+  ): void {
+    const nativeMessage = message.message
+    const assistant = this.ensureActiveAssistant(
+      nativeMessage.id,
+      `claude-assistant-${nativeMessage.id}`,
+    )
+    assistant.content = reconcileFinalText(
+      assistant.content,
+      extractTextContent(nativeMessage.content),
+    )
+    const finalReasoning = extractThinkingContent(nativeMessage.content)
+    if (finalReasoning) {
+      assistant.reasoning = reconcileFinalText(
+        assistant.reasoning ?? '',
+        finalReasoning,
+      )
+    }
+
+    for (const toolUse of extractToolUses(nativeMessage.content)) {
+      const request = toToolCallRequest(toolUse)
+      this.setAssistantToolRequest(request)
+      const existing = this.tools.get(toolUse.id)
+      this.tools.set(toolUse.id, {
+        request,
+        response:
+          existing?.response ??
+          ({ status: ToolCallResponseStatus.Running } as ToolCallResponse),
+      })
+      this.emitTool(toolUse.id)
+    }
+    assistant.metadata = {
+      ...assistant.metadata,
+      generationState: 'completed',
+    }
+    this.emitAssistant()
+  }
+
+  private handleResult(message: Extract<SDKMessage, { type: 'result' }>): void {
+    if (message.subtype === 'success') {
+      if (message.result) {
+        const assistant =
+          this.activeAssistant ??
+          this.ensureActiveAssistant(
+            message.uuid,
+            `claude-assistant-${message.uuid}`,
+          )
+        if (!assistant.content) assistant.content = message.result
+      }
+      if (this.cancelRequested) {
+        this.markActiveAssistant('aborted')
+        this.emit({ type: 'run_state', state: 'aborted' })
+      } else {
+        this.markActiveAssistant('completed')
+        this.emit({ type: 'run_state', state: 'completed' })
+      }
+      this.cancelRequested = false
+      return
+    }
+
+    const error = message.errors.filter(Boolean).join('\n') || message.subtype
+    if (this.activeAssistant) {
+      this.activeAssistant.metadata = {
+        ...this.activeAssistant.metadata,
+        generationState: 'error',
+        errorMessage: error,
+      }
+      this.emitAssistant()
+    }
+    this.emit({ type: 'run_state', state: 'error', error })
+  }
+
+  private ensureActiveAssistant(key: string, id: string): ChatAssistantMessage {
+    if (!this.activeAssistant || this.activeAssistantKey !== key) {
+      if (this.activeAssistant) {
+        this.activeAssistant.metadata = {
+          ...this.activeAssistant.metadata,
+          generationState: 'completed',
+        }
+        this.emitAssistant()
+      }
+      this.activeAssistantKey = key
+      this.activeAssistant = {
+        role: 'assistant',
+        id,
+        content: '',
+        metadata: { generationState: 'streaming' },
+      }
+    }
+    return this.activeAssistant
+  }
+
+  private appendAssistantText(text: string): void {
+    if (!text) return
+    const id = uuidv4()
+    const assistant =
+      this.activeAssistant ??
+      this.ensureActiveAssistant(id, `claude-assistant-${id}`)
+    assistant.content += text
+    this.emitAssistant()
+  }
+
+  private appendAssistantReasoning(reasoning: string): void {
+    if (!reasoning) return
+    const id = uuidv4()
+    const assistant =
+      this.activeAssistant ??
+      this.ensureActiveAssistant(id, `claude-assistant-${id}`)
+    assistant.reasoning = (assistant.reasoning ?? '') + reasoning
+    this.emitAssistant()
+  }
+
+  private ensurePartialToolRequest(tool: StreamedToolInput): void {
+    const request: ToolCallRequest = {
+      id: tool.id,
+      name: tool.name,
+      arguments: createPartialToolCallArguments(tool.rawInput),
+    }
+    this.setAssistantToolRequest(request)
+    const existing = this.tools.get(tool.id)
+    this.tools.set(tool.id, {
+      request,
+      response:
+        existing?.response ??
+        ({ status: ToolCallResponseStatus.Running } as ToolCallResponse),
+    })
+    this.emitAssistant()
+    this.emitTool(tool.id)
+  }
+
+  private ensureToolRequest(
+    toolUseId: string,
+    toolName: string,
+    input: Record<string, unknown>,
+  ): void {
+    const request: ToolCallRequest = {
+      id: toolUseId,
+      name: toolName,
+      arguments: createCompleteToolCallArguments({ value: input }),
+    }
+    this.setAssistantToolRequest(request)
+    const existing = this.tools.get(toolUseId)
+    this.tools.set(toolUseId, {
+      request,
+      response:
+        existing?.response ??
+        ({ status: ToolCallResponseStatus.Running } as ToolCallResponse),
+    })
+    this.emitAssistant()
+  }
+
+  private setAssistantToolRequest(request: ToolCallRequest): void {
+    const id = uuidv4()
+    const assistant =
+      this.activeAssistant ??
+      this.ensureActiveAssistant(id, `claude-assistant-${id}`)
+    const requests = assistant.toolCallRequests ?? []
+    const index = requests.findIndex((candidate) => candidate.id === request.id)
+    if (index >= 0) requests[index] = request
+    else requests.push(request)
+    assistant.toolCallRequests = requests
+  }
+
+  private upsertTool(toolUseId: string, response: ToolCallResponse): void {
+    const existing = this.tools.get(toolUseId)
+    const request = existing?.request ?? {
+      id: toolUseId,
+      name: 'unknown',
+    }
+    this.tools.set(toolUseId, { request, response })
+    this.emitTool(toolUseId)
+  }
+
+  private emitTool(toolUseId: string): void {
+    const tool = this.tools.get(toolUseId)
+    if (!tool) return
+    this.emit({
+      type: 'message_upsert',
+      message: cloneToolMessage({
+        role: 'tool',
+        id: `claude-tool-${toolUseId}`,
+        toolCalls: [tool],
+      }),
+    })
+  }
+
+  private emitAssistant(): void {
+    if (!this.activeAssistant) return
+    this.emit({
+      type: 'message_upsert',
+      message: cloneAssistantMessage(this.activeAssistant),
+    })
+  }
+
+  private markActiveAssistant(generationState: 'completed' | 'aborted'): void {
+    if (!this.activeAssistant) return
+    this.activeAssistant.metadata = {
+      ...this.activeAssistant.metadata,
+      generationState,
+    }
+    this.emitAssistant()
+  }
+
+  private emit(event: CliRuntimeEvent): void {
+    for (const listener of this.listeners) listener(event)
+  }
+
+  private emitPendingRunStateOrRunning(): void {
+    const pending = Array.from(new Set(this.pendingPermissions.values()))
+    const state = pending.some((request) => request.kind === 'question')
+      ? 'waiting_for_user'
+      : pending.some((request) => request.kind === 'approval')
+        ? 'waiting_for_approval'
+        : 'running'
+    this.emit({ type: 'run_state', state })
+  }
+
+  private async resetQuery(): Promise<void> {
+    const query = this.query
+    const consumePromise = this.consumePromise
+    this.resetting = true
+    this.settleAllPending({
+      behavior: 'deny',
+      message: 'Claude runtime was reset.',
+      interrupt: true,
+    })
+    this.inputQueue?.close()
+    query?.close()
+    if (query?.return) {
+      await query.return()
+    }
+    await consumePromise?.catch(() => undefined)
+
+    this.query = undefined
+    this.inputQueue = undefined
+    this.consumePromise = undefined
+    this.readyKey = undefined
+    this.activeAssistant = undefined
+    this.activeAssistantKey = undefined
+    this.tools.clear()
+    this.streamedToolInputs.clear()
+    this.resetting = false
+  }
+}

--- a/src/core/cli-runtime/claude/askUserQuestion.ts
+++ b/src/core/cli-runtime/claude/askUserQuestion.ts
@@ -1,0 +1,236 @@
+export const CLAUDE_ASK_USER_QUESTION_TOOL = 'AskUserQuestion'
+export const YOLO_ASK_USER_QUESTION_TOOL = 'yolo_local__ask_user_question'
+
+const YOLO_OTHER_OPTION_ID = '__other__'
+
+type InputType = 'free_text' | 'single_select' | 'multi_select'
+
+type NativeQuestionMapping = {
+  uiId: string
+  nativeKey: string
+  inputType: InputType
+  optionIds: Set<string>
+  yoloQuestion: {
+    id: string
+    prompt: string
+    inputType: InputType
+    options?: Array<{ id: string; label: string }>
+  }
+}
+
+export type ClaudeQuestionAnswerMap = Record<string, string | string[]>
+
+export type ClaudeAnswerConversion =
+  | { ok: true; answers: ClaudeQuestionAnswerMap }
+  | { ok: false; error: string }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+const getNonEmptyString = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim() ? value : null
+
+const parseOption = (value: unknown): { id: string; label: string } | null => {
+  if (typeof value === 'string' && value.trim()) {
+    return { id: value, label: value }
+  }
+  if (!isRecord(value)) return null
+
+  const label =
+    getNonEmptyString(value.label) ??
+    getNonEmptyString(value.value) ??
+    getNonEmptyString(value.text)
+  if (!label) return null
+  const id =
+    getNonEmptyString(value.value) ?? getNonEmptyString(value.id) ?? label
+  return { id, label }
+}
+
+const resolveInputType = (
+  question: Record<string, unknown>,
+  optionCount: number,
+): InputType => {
+  if (
+    question.inputType === 'free_text' ||
+    question.inputType === 'single_select' ||
+    question.inputType === 'multi_select'
+  ) {
+    return question.inputType
+  }
+  if (optionCount === 0) return 'free_text'
+  return question.multiSelect === true ? 'multi_select' : 'single_select'
+}
+
+const buildQuestionMappings = (
+  input: Record<string, unknown>,
+): NativeQuestionMapping[] | null => {
+  if (!Array.isArray(input.questions) || input.questions.length === 0) {
+    return null
+  }
+
+  const mappings: NativeQuestionMapping[] = []
+  const nativeKeys = new Set<string>()
+  for (const rawQuestion of input.questions) {
+    if (!isRecord(rawQuestion)) return null
+    const prompt =
+      getNonEmptyString(rawQuestion.question) ??
+      getNonEmptyString(rawQuestion.prompt)
+    if (!prompt) return null
+    const nativeKey = getNonEmptyString(rawQuestion.id) ?? prompt
+    if (nativeKeys.has(nativeKey)) return null
+    nativeKeys.add(nativeKey)
+
+    const rawOptions = Array.isArray(rawQuestion.options)
+      ? rawQuestion.options
+      : []
+    const options = rawOptions.map(parseOption)
+    if (options.some((option) => option === null)) return null
+    const concreteOptions = options.filter(
+      (option): option is { id: string; label: string } => option !== null,
+    )
+    const optionIds = new Set(concreteOptions.map((option) => option.id))
+    if (optionIds.size !== concreteOptions.length) return null
+
+    const inputType = resolveInputType(rawQuestion, concreteOptions.length)
+    if (inputType !== 'free_text' && concreteOptions.length < 2) {
+      return null
+    }
+    mappings.push({
+      uiId: nativeKey,
+      nativeKey,
+      inputType,
+      optionIds,
+      yoloQuestion: {
+        id: nativeKey,
+        prompt,
+        inputType,
+        ...(inputType === 'free_text' ? {} : { options: concreteOptions }),
+      },
+    })
+  }
+  return mappings
+}
+
+export const mapClaudeAskUserQuestionInput = (
+  input: Record<string, unknown>,
+): Record<string, unknown> | null => {
+  const mappings = buildQuestionMappings(input)
+  if (!mappings) return null
+  return { questions: mappings.map((mapping) => mapping.yoloQuestion) }
+}
+
+export const mapClaudeToolForTimeline = ({
+  name,
+  input,
+}: {
+  name: string
+  input: Record<string, unknown>
+}): { name: string; input: Record<string, unknown> } => {
+  if (name !== CLAUDE_ASK_USER_QUESTION_TOOL) return { name, input }
+  const mappedInput = mapClaudeAskUserQuestionInput(input)
+  if (!mappedInput) return { name, input }
+  return {
+    name: YOLO_ASK_USER_QUESTION_TOOL,
+    input: mappedInput,
+  }
+}
+
+const parseAnswerValue = ({
+  answer,
+  mapping,
+}: {
+  answer: Record<string, unknown>
+  mapping: NativeQuestionMapping
+}): string | string[] | null => {
+  if (answer.inputType !== mapping.inputType) return null
+  const otherText =
+    typeof answer.otherText === 'string' ? answer.otherText.trim() : ''
+
+  if (mapping.inputType === 'free_text') {
+    return typeof answer.value === 'string' ? answer.value : null
+  }
+  if (mapping.inputType === 'single_select') {
+    if (typeof answer.value !== 'string') return null
+    if (answer.value === YOLO_OTHER_OPTION_ID) return otherText || null
+    return mapping.optionIds.has(answer.value) ? answer.value : null
+  }
+  if (
+    !Array.isArray(answer.value) ||
+    !answer.value.every((value): value is string => typeof value === 'string')
+  ) {
+    return null
+  }
+
+  const values: string[] = []
+  for (const value of answer.value) {
+    if (value === YOLO_OTHER_OPTION_ID) {
+      if (!otherText) return null
+      values.push(otherText)
+    } else if (mapping.optionIds.has(value)) {
+      values.push(value)
+    } else {
+      return null
+    }
+  }
+  if (otherText && !answer.value.includes(YOLO_OTHER_OPTION_ID)) {
+    values.push(otherText)
+  }
+  return values.length > 0 ? values : null
+}
+
+export const convertYoloAnswerPayloadToClaude = ({
+  payload,
+  nativeInput,
+}: {
+  payload: unknown
+  nativeInput: Record<string, unknown>
+}): ClaudeAnswerConversion => {
+  const mappings = buildQuestionMappings(nativeInput)
+  if (!mappings) {
+    return { ok: false, error: 'Claude question input is invalid.' }
+  }
+  if (
+    !isRecord(payload) ||
+    payload.type !== 'user_answers' ||
+    !Array.isArray(payload.answers)
+  ) {
+    return { ok: false, error: 'Question response payload is invalid.' }
+  }
+
+  const answersById = new Map<string, Record<string, unknown>>()
+  for (const rawAnswer of payload.answers) {
+    if (!isRecord(rawAnswer) || typeof rawAnswer.id !== 'string') {
+      return {
+        ok: false,
+        error: 'Question response contains an invalid answer.',
+      }
+    }
+    if (answersById.has(rawAnswer.id)) {
+      return {
+        ok: false,
+        error: `Question "${rawAnswer.id}" was answered twice.`,
+      }
+    }
+    answersById.set(rawAnswer.id, rawAnswer)
+  }
+
+  const answers: ClaudeQuestionAnswerMap = {}
+  for (const mapping of mappings) {
+    const answer = answersById.get(mapping.uiId)
+    if (!answer) {
+      return { ok: false, error: `Question "${mapping.uiId}" has no answer.` }
+    }
+    const value = parseAnswerValue({ answer, mapping })
+    if (value === null) {
+      return {
+        ok: false,
+        error: `Question "${mapping.uiId}" has an invalid answer.`,
+      }
+    }
+    answers[mapping.nativeKey] = value
+  }
+  if (answersById.size !== mappings.length) {
+    return { ok: false, error: 'Question response contains an unknown answer.' }
+  }
+  return { ok: true, answers }
+}

--- a/src/core/cli-runtime/claude/asyncQueue.ts
+++ b/src/core/cli-runtime/claude/asyncQueue.ts
@@ -1,0 +1,56 @@
+export class AsyncPushQueue<T> implements AsyncIterableIterator<T> {
+  private readonly values: T[] = []
+  private readonly waiters: Array<(result: IteratorResult<T, void>) => void> =
+    []
+  private closed = false
+
+  push(value: T): void {
+    if (this.closed) {
+      throw new Error('Cannot push to a closed Claude input stream.')
+    }
+
+    const waiter = this.waiters.shift()
+    if (waiter) {
+      waiter({ done: false, value })
+      return
+    }
+    this.values.push(value)
+  }
+
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    for (const waiter of this.waiters.splice(0)) {
+      waiter({ done: true, value: undefined })
+    }
+  }
+
+  next(): Promise<IteratorResult<T, void>> {
+    const value = this.values.shift()
+    if (value !== undefined) {
+      return Promise.resolve({ done: false, value })
+    }
+    if (this.closed) {
+      return Promise.resolve({ done: true, value: undefined })
+    }
+    return new Promise((resolve) => {
+      this.waiters.push(resolve)
+    })
+  }
+
+  return(): Promise<IteratorResult<T, void>> {
+    this.close()
+    return Promise.resolve({ done: true, value: undefined })
+  }
+
+  throw(error?: unknown): Promise<IteratorResult<T, void>> {
+    this.close()
+    return Promise.reject(
+      error instanceof Error ? error : new Error(String(error)),
+    )
+  }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<T> {
+    return this
+  }
+}

--- a/src/core/cli-runtime/claude/index.ts
+++ b/src/core/cli-runtime/claude/index.ts
@@ -1,0 +1,3 @@
+export * from './ClaudeCliRuntime'
+export * from './process'
+export * from './types'

--- a/src/core/cli-runtime/claude/messages.ts
+++ b/src/core/cli-runtime/claude/messages.ts
@@ -1,4 +1,4 @@
-import type { SessionMessage } from '@anthropic-ai/claude-agent-sdk'
+import type { SessionMessage } from '@yolo/claude-agent-sdk-runtime'
 
 import type {
   ChatAssistantMessage,
@@ -11,6 +11,8 @@ import {
   ToolCallResponseStatus,
   createCompleteToolCallArguments,
 } from '../../../types/tool-call.types'
+
+import { mapClaudeToolForTimeline } from './askUserQuestion'
 
 type ContentBlock = Record<string, unknown> & { type?: unknown }
 
@@ -98,11 +100,14 @@ export const extractToolResults = (value: unknown): ClaudeToolResult[] =>
     ]
   })
 
-export const toToolCallRequest = (toolUse: ClaudeToolUse): ToolCallRequest => ({
-  id: toolUse.id,
-  name: toolUse.name,
-  arguments: createCompleteToolCallArguments({ value: toolUse.input }),
-})
+export const toToolCallRequest = (toolUse: ClaudeToolUse): ToolCallRequest => {
+  const mapped = mapClaudeToolForTimeline(toolUse)
+  return {
+    id: toolUse.id,
+    name: mapped.name,
+    arguments: createCompleteToolCallArguments({ value: mapped.input }),
+  }
+}
 
 const createUserMessage = (
   message: SessionMessage,

--- a/src/core/cli-runtime/claude/messages.ts
+++ b/src/core/cli-runtime/claude/messages.ts
@@ -1,0 +1,225 @@
+import type { SessionMessage } from '@anthropic-ai/claude-agent-sdk'
+
+import type {
+  ChatAssistantMessage,
+  ChatMessage,
+  ChatToolMessage,
+  ChatUserMessage,
+} from '../../../types/chat'
+import {
+  type ToolCallRequest,
+  ToolCallResponseStatus,
+  createCompleteToolCallArguments,
+} from '../../../types/tool-call.types'
+
+type ContentBlock = Record<string, unknown> & { type?: unknown }
+
+export type ClaudeToolUse = {
+  id: string
+  name: string
+  input: Record<string, unknown>
+}
+
+export type ClaudeToolResult = {
+  id: string
+  content: string
+  isError: boolean
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+export const getContentBlocks = (value: unknown): ContentBlock[] =>
+  Array.isArray(value)
+    ? value.filter((block): block is ContentBlock => isRecord(block))
+    : []
+
+export const extractTextContent = (value: unknown): string => {
+  if (typeof value === 'string') return value
+  return getContentBlocks(value)
+    .flatMap((block) =>
+      block.type === 'text' && typeof block.text === 'string'
+        ? [block.text]
+        : [],
+    )
+    .join('')
+}
+
+export const extractThinkingContent = (value: unknown): string =>
+  getContentBlocks(value)
+    .flatMap((block) =>
+      block.type === 'thinking' && typeof block.thinking === 'string'
+        ? [block.thinking]
+        : [],
+    )
+    .join('')
+
+export const extractToolUses = (value: unknown): ClaudeToolUse[] =>
+  getContentBlocks(value).flatMap((block) => {
+    if (
+      block.type !== 'tool_use' ||
+      typeof block.id !== 'string' ||
+      typeof block.name !== 'string'
+    ) {
+      return []
+    }
+    return [
+      {
+        id: block.id,
+        name: block.name,
+        input: isRecord(block.input) ? block.input : {},
+      },
+    ]
+  })
+
+const stringifyToolResult = (content: unknown): string => {
+  if (typeof content === 'string') return content
+  const text = extractTextContent(content)
+  if (text) return text
+  if (content === undefined) return ''
+  try {
+    return JSON.stringify(content, null, 2)
+  } catch {
+    return '[Unserializable tool result]'
+  }
+}
+
+export const extractToolResults = (value: unknown): ClaudeToolResult[] =>
+  getContentBlocks(value).flatMap((block) => {
+    if (block.type !== 'tool_result' || typeof block.tool_use_id !== 'string') {
+      return []
+    }
+    return [
+      {
+        id: block.tool_use_id,
+        content: stringifyToolResult(block.content),
+        isError: block.is_error === true,
+      },
+    ]
+  })
+
+export const toToolCallRequest = (toolUse: ClaudeToolUse): ToolCallRequest => ({
+  id: toolUse.id,
+  name: toolUse.name,
+  arguments: createCompleteToolCallArguments({ value: toolUse.input }),
+})
+
+const createUserMessage = (
+  message: SessionMessage,
+  promptContent: string,
+): ChatUserMessage => ({
+  role: 'user',
+  id: message.uuid,
+  content: null,
+  promptContent,
+  mentionables: [],
+})
+
+const createAssistantMessage = (
+  message: SessionMessage,
+  nativeMessage: Record<string, unknown>,
+  toolUses: ClaudeToolUse[],
+): ChatAssistantMessage => ({
+  role: 'assistant',
+  id: message.uuid,
+  content: extractTextContent(nativeMessage.content),
+  ...(extractThinkingContent(nativeMessage.content)
+    ? { reasoning: extractThinkingContent(nativeMessage.content) }
+    : {}),
+  ...(toolUses.length > 0
+    ? { toolCallRequests: toolUses.map(toToolCallRequest) }
+    : {}),
+  metadata: { generationState: 'completed' },
+})
+
+const createToolMessage = ({
+  id,
+  requests,
+  results,
+}: {
+  id: string
+  requests: Map<string, ToolCallRequest>
+  results: ClaudeToolResult[]
+}): ChatToolMessage => ({
+  role: 'tool',
+  id,
+  toolCalls: results.map((result) => ({
+    request:
+      requests.get(result.id) ??
+      ({ id: result.id, name: 'unknown' } satisfies ToolCallRequest),
+    response: result.isError
+      ? {
+          status: ToolCallResponseStatus.Error,
+          error: result.content,
+        }
+      : {
+          status: ToolCallResponseStatus.Success,
+          data: { type: 'text', text: result.content },
+        },
+  })),
+})
+
+export const hydrateClaudeSessionMessages = (
+  messages: SessionMessage[],
+): ChatMessage[] => {
+  const hydrated: ChatMessage[] = []
+  const requests = new Map<string, ToolCallRequest>()
+  const completedTools = new Set<string>()
+
+  for (const message of messages) {
+    if (message.parent_tool_use_id !== null || !isRecord(message.message)) {
+      continue
+    }
+    const nativeMessage = message.message
+    if (message.type === 'assistant') {
+      const toolUses = extractToolUses(nativeMessage.content)
+      for (const toolUse of toolUses) {
+        requests.set(toolUse.id, toToolCallRequest(toolUse))
+      }
+      hydrated.push(createAssistantMessage(message, nativeMessage, toolUses))
+      continue
+    }
+    if (message.type !== 'user') continue
+
+    const toolResults = extractToolResults(nativeMessage.content)
+    if (toolResults.length > 0) {
+      for (const result of toolResults) completedTools.add(result.id)
+      hydrated.push(
+        createToolMessage({ id: message.uuid, requests, results: toolResults }),
+      )
+      continue
+    }
+
+    const promptContent = extractTextContent(nativeMessage.content)
+    if (promptContent) {
+      hydrated.push(createUserMessage(message, promptContent))
+    }
+  }
+
+  for (const [toolUseId, request] of requests) {
+    if (completedTools.has(toolUseId)) continue
+    hydrated.push({
+      role: 'tool',
+      id: `claude-tool-${toolUseId}`,
+      toolCalls: [
+        {
+          request,
+          response: { status: ToolCallResponseStatus.Running },
+        },
+      ],
+    })
+  }
+
+  return hydrated
+}
+
+export const reconcileFinalText = (
+  streamed: string,
+  finalText: string,
+): string => {
+  if (!finalText) return streamed
+  if (!streamed) return finalText
+  if (finalText.startsWith(streamed)) return finalText
+  if (streamed.startsWith(finalText)) return streamed
+  return finalText
+}

--- a/src/core/cli-runtime/claude/process.test.ts
+++ b/src/core/cli-runtime/claude/process.test.ts
@@ -1,4 +1,4 @@
-import type { SpawnOptions } from '@anthropic-ai/claude-agent-sdk'
+import type { SpawnOptions } from '@yolo/claude-agent-sdk-runtime'
 
 import {
   createElectronSpawnFunction,

--- a/src/core/cli-runtime/claude/process.test.ts
+++ b/src/core/cli-runtime/claude/process.test.ts
@@ -1,0 +1,132 @@
+import type { SpawnOptions } from '@anthropic-ai/claude-agent-sdk'
+
+import {
+  createElectronSpawnFunction,
+  resolveClaudeProcessSupport,
+} from './process'
+
+describe('Claude desktop process support', () => {
+  it('resolves the local CLI and a full Node path from the desktop environment', async () => {
+    const spawn = jest.fn(() => ({
+      stdin: {},
+      stdout: {},
+      stderr: undefined,
+      kill: jest.fn(),
+    }))
+    const support = await resolveClaudeProcessSupport({
+      configuredCliPath: undefined,
+      loadEnvironment: async () => ({
+        PATH: '/home/me/.local/bin:/usr/local/bin:/usr/bin',
+      }),
+      platform: 'linux',
+      homedir: '/home/me',
+      fileExists: async (path) =>
+        path === '/home/me/.local/bin/claude' || path === '/usr/local/bin/node',
+      spawn,
+    })
+
+    expect(support.cliPath).toBe('/home/me/.local/bin/claude')
+    const spawnOptions = {
+      command: 'node',
+      args: ['cli.js'],
+      cwd: '/vault',
+      env: support.env,
+      signal: new AbortController().signal,
+    } as SpawnOptions
+    support.spawnClaudeCodeProcess(spawnOptions)
+    expect(spawn).toHaveBeenCalledWith(
+      '/usr/local/bin/node',
+      ['cli.js'],
+      expect.objectContaining({
+        cwd: '/vault',
+        stdio: ['pipe', 'pipe', 'ignore'],
+        windowsHide: true,
+      }),
+    )
+  })
+
+  it('wraps JavaScript CLI entrypoints with the resolved Node executable', () => {
+    const child = {
+      stdin: {},
+      stdout: {},
+      stderr: undefined,
+      kill: jest.fn(),
+    }
+    const spawn = jest.fn(() => child)
+    const customSpawn = createElectronSpawnFunction({
+      spawn,
+      nodePath: '/usr/bin/node',
+    })
+
+    customSpawn({
+      command: '/npm/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+      args: ['--version'],
+      cwd: '/vault',
+      env: {},
+      signal: new AbortController().signal,
+    })
+
+    expect(spawn).toHaveBeenCalledWith(
+      '/usr/bin/node',
+      ['/npm/lib/node_modules/@anthropic-ai/claude-code/cli.js', '--version'],
+      expect.any(Object),
+    )
+  })
+
+  it('does not require Node when Claude is a native executable', async () => {
+    const child = {
+      stdin: {},
+      stdout: {},
+      stderr: undefined,
+      kill: jest.fn(),
+    }
+    const spawn = jest.fn(() => child)
+    const support = await resolveClaudeProcessSupport({
+      loadEnvironment: async () => ({ PATH: '/home/me/.local/bin' }),
+      platform: 'linux',
+      homedir: '/home/me',
+      fileExists: async (path) => path === '/home/me/.local/bin/claude',
+      spawn,
+    })
+
+    support.spawnClaudeCodeProcess({
+      command: '/home/me/.local/bin/claude',
+      args: ['--version'],
+      cwd: '/vault',
+      env: support.env,
+      signal: new AbortController().signal,
+    })
+
+    expect(spawn).toHaveBeenCalledWith(
+      '/home/me/.local/bin/claude',
+      ['--version'],
+      expect.any(Object),
+    )
+  })
+
+  it('resolves Windows npm cmd shims to the Node package entrypoint', async () => {
+    const spawn = jest.fn(() => ({
+      stdin: {},
+      stdout: {},
+      stderr: undefined,
+      kill: jest.fn(),
+    }))
+    const support = await resolveClaudeProcessSupport({
+      configuredCliPath: 'C:\\Users\\me\\AppData\\Roaming\\npm\\claude.cmd',
+      loadEnvironment: async () => ({
+        Path: 'C:\\Program Files\\nodejs',
+      }),
+      platform: 'win32',
+      homedir: 'C:\\Users\\me',
+      fileExists: async (path) =>
+        path ===
+          'C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\cli.js' ||
+        path === 'C:\\Program Files\\nodejs\\node.exe',
+      spawn,
+    })
+
+    expect(support.cliPath).toBe(
+      'C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\cli.js',
+    )
+  })
+})

--- a/src/core/cli-runtime/claude/process.ts
+++ b/src/core/cli-runtime/claude/process.ts
@@ -1,7 +1,7 @@
 import type {
   SpawnOptions,
   SpawnedProcess,
-} from '@anthropic-ai/claude-agent-sdk'
+} from '@yolo/claude-agent-sdk-runtime'
 
 import { assertCliRuntimeAvailable } from '../desktop'
 

--- a/src/core/cli-runtime/claude/process.ts
+++ b/src/core/cli-runtime/claude/process.ts
@@ -1,0 +1,348 @@
+import type {
+  SpawnOptions,
+  SpawnedProcess,
+} from '@anthropic-ai/claude-agent-sdk'
+
+import { assertCliRuntimeAvailable } from '../desktop'
+
+import type { ClaudeProcessSupport } from './types'
+
+type SpawnedChild = {
+  stdin?: unknown
+  stdout?: unknown
+  stderr?: unknown
+  kill(signal?: string | number): boolean | undefined
+}
+
+type SpawnImplementation = (
+  command: string,
+  args: readonly string[],
+  options: {
+    cwd?: string
+    env?: Record<string, string | undefined>
+    stdio: ['pipe', 'pipe', 'pipe' | 'ignore']
+    windowsHide: boolean
+  },
+) => SpawnedChild
+
+type ResolveClaudeProcessSupportOptions = {
+  configuredCliPath?: string
+  loadEnvironment?: () => Promise<Record<string, string | undefined>>
+  platform?: NodeJS.Platform
+  homedir?: string
+  fileExists?: (path: string) => Promise<boolean>
+  spawn?: SpawnImplementation
+}
+
+const isJavaScriptEntrypoint = (command: string): boolean =>
+  /\.(?:c|m)?js$/i.test(command)
+
+const getPathValue = (
+  env: Record<string, string | undefined>,
+  platform: NodeJS.Platform,
+): string => {
+  if (platform === 'win32') {
+    return env.PATH ?? env.Path ?? env.path ?? ''
+  }
+  return env.PATH ?? env.path ?? ''
+}
+
+const joinPath = (platform: NodeJS.Platform, ...parts: string[]): string => {
+  const separator = platform === 'win32' ? '\\' : '/'
+  const [head = '', ...tail] = parts
+  const normalizedHead = head.replace(/[\\/]+$/, '')
+  const normalizedTail = tail.map((part) =>
+    part.replace(/^[\\/]+|[\\/]+$/g, ''),
+  )
+  return [normalizedHead, ...normalizedTail].filter(Boolean).join(separator)
+}
+
+const basename = (value: string): string =>
+  value.split(/[\\/]/).filter(Boolean).at(-1) ?? value
+
+const dirname = (value: string): string => {
+  const separatorIndex = Math.max(
+    value.lastIndexOf('/'),
+    value.lastIndexOf('\\'),
+  )
+  return separatorIndex <= 0
+    ? value.slice(0, separatorIndex + 1)
+    : value.slice(0, separatorIndex)
+}
+
+const dedupePaths = (values: string[], platform: NodeJS.Platform): string[] => {
+  const seen = new Set<string>()
+  return values.filter((value) => {
+    if (!value) return false
+    const key = platform === 'win32' ? value.toLowerCase() : value
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+const findExisting = async (
+  candidates: string[],
+  fileExists: (path: string) => Promise<boolean>,
+  platform: NodeJS.Platform,
+): Promise<string | null> => {
+  for (const candidate of dedupePaths(candidates, platform)) {
+    if (await fileExists(candidate)) return candidate
+  }
+  return null
+}
+
+const getClaudeCandidates = ({
+  configuredCliPath,
+  env,
+  homedir,
+  platform,
+}: {
+  configuredCliPath?: string
+  env: Record<string, string | undefined>
+  homedir: string
+  platform: NodeJS.Platform
+}): string[] => {
+  const pathSeparator = platform === 'win32' ? ';' : ':'
+  const pathEntries = getPathValue(env, platform)
+    .split(pathSeparator)
+    .filter(Boolean)
+  const executableNames =
+    platform === 'win32' ? ['claude.exe', 'claude'] : ['claude']
+  const configuredPath = configuredCliPath?.trim()
+  const candidates: string[] = []
+  if (configuredPath) {
+    if (platform === 'win32' && /\.(?:cmd|bat)$/i.test(configuredPath)) {
+      const configuredDirectory = dirname(configuredPath)
+      candidates.push(
+        joinPath(
+          platform,
+          configuredDirectory,
+          'node_modules',
+          '@anthropic-ai',
+          'claude-code',
+          'cli-wrapper.cjs',
+        ),
+        joinPath(
+          platform,
+          configuredDirectory,
+          'node_modules',
+          '@anthropic-ai',
+          'claude-code',
+          'cli.js',
+        ),
+      )
+    } else {
+      candidates.push(configuredPath)
+    }
+  }
+
+  for (const entry of pathEntries) {
+    for (const name of executableNames) {
+      candidates.push(joinPath(platform, entry, name))
+    }
+
+    const prefix =
+      basename(entry).toLowerCase() === 'bin' ? dirname(entry) : entry
+    const packageParent =
+      platform === 'win32' ? prefix : joinPath(platform, prefix, 'lib')
+    candidates.push(
+      joinPath(
+        platform,
+        packageParent,
+        'node_modules',
+        '@anthropic-ai',
+        'claude-code',
+        'cli-wrapper.cjs',
+      ),
+      joinPath(
+        platform,
+        packageParent,
+        'node_modules',
+        '@anthropic-ai',
+        'claude-code',
+        'cli.js',
+      ),
+    )
+  }
+
+  if (platform === 'win32') {
+    candidates.push(
+      joinPath(platform, homedir, '.claude', 'local', 'claude.exe'),
+      joinPath(platform, homedir, '.local', 'bin', 'claude.exe'),
+      joinPath(platform, homedir, 'AppData', 'Local', 'Claude', 'claude.exe'),
+    )
+  } else {
+    candidates.push(
+      joinPath(platform, homedir, '.claude', 'local', 'claude'),
+      joinPath(platform, homedir, '.local', 'bin', 'claude'),
+      joinPath(platform, homedir, '.volta', 'bin', 'claude'),
+      '/usr/local/bin/claude',
+      '/opt/homebrew/bin/claude',
+    )
+  }
+
+  return candidates
+}
+
+const getNodeCandidates = ({
+  env,
+  homedir,
+  platform,
+}: {
+  env: Record<string, string | undefined>
+  homedir: string
+  platform: NodeJS.Platform
+}): string[] => {
+  const pathSeparator = platform === 'win32' ? ';' : ':'
+  const nodeName = platform === 'win32' ? 'node.exe' : 'node'
+  const candidates = getPathValue(env, platform)
+    .split(pathSeparator)
+    .filter(Boolean)
+    .map((entry) => joinPath(platform, entry, nodeName))
+
+  if (platform === 'win32') {
+    candidates.push(
+      joinPath(
+        platform,
+        env.ProgramFiles ?? 'C:\\Program Files',
+        'nodejs',
+        'node.exe',
+      ),
+      joinPath(platform, homedir, '.volta', 'bin', 'node.exe'),
+    )
+  } else {
+    candidates.push(
+      joinPath(platform, homedir, '.volta', 'bin', 'node'),
+      joinPath(platform, homedir, '.nvm', 'current', 'bin', 'node'),
+      '/usr/local/bin/node',
+      '/opt/homebrew/bin/node',
+      '/usr/bin/node',
+    )
+  }
+  return candidates
+}
+
+const loadDesktopEnvironment = async (): Promise<
+  Record<string, string | undefined>
+> => {
+  const inherited = { ...process.env }
+  try {
+    const { shellEnvSync } = await import('shell-env')
+    return { ...inherited, ...shellEnvSync() }
+  } catch {
+    return inherited
+  }
+}
+
+const defaultFileExists = async (filePath: string): Promise<boolean> => {
+  // eslint-disable-next-line import/no-nodejs-modules -- evaluated only after the shared Desktop capability gate
+  const { stat } = await import('node:fs/promises')
+  try {
+    return (await stat(filePath)).isFile()
+  } catch {
+    return false
+  }
+}
+
+export const createElectronSpawnFunction = ({
+  spawn,
+  nodePath,
+}: {
+  spawn: SpawnImplementation
+  nodePath?: string
+}): ((options: SpawnOptions) => SpawnedProcess) => {
+  return (options) => {
+    let command = options.command
+    let args = [...options.args]
+    if (command === 'node' || isJavaScriptEntrypoint(command)) {
+      if (!nodePath) {
+        throw new Error(
+          'A full Node.js executable path is required to launch this Claude Code installation.',
+        )
+      }
+    }
+    if (command === 'node' && nodePath) {
+      command = nodePath
+    } else if (isJavaScriptEntrypoint(command) && nodePath) {
+      args = [command, ...args]
+      command = nodePath
+    }
+
+    const pipeStderr = Boolean(options.env?.DEBUG_CLAUDE_AGENT_SDK)
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['pipe', 'pipe', pipeStderr ? 'pipe' : 'ignore'],
+      windowsHide: true,
+    })
+
+    const abort = (): void => {
+      child.kill('SIGTERM')
+    }
+    if (options.signal.aborted) {
+      abort()
+    } else {
+      options.signal.addEventListener('abort', abort, { once: true })
+    }
+
+    if (!child.stdin || !child.stdout) {
+      throw new Error('Claude CLI process did not expose stdin/stdout streams.')
+    }
+    return child as SpawnedProcess
+  }
+}
+
+export const resolveClaudeProcessSupport = async (
+  options: ResolveClaudeProcessSupportOptions = {},
+): Promise<ClaudeProcessSupport> => {
+  assertCliRuntimeAvailable('claude-code')
+
+  const platform = options.platform ?? process.platform
+  const homedir =
+    options.homedir ??
+    // eslint-disable-next-line import/no-nodejs-modules -- evaluated only after the shared Desktop capability gate
+    (await import('node:os')).homedir()
+  const fileExists = options.fileExists ?? defaultFileExists
+  const environment = await (
+    options.loadEnvironment ?? loadDesktopEnvironment
+  )()
+  const env = {
+    ...environment,
+    CLAUDE_AGENT_SDK_CLIENT_APP: 'obsidian-yolo',
+  }
+  const cliPath = await findExisting(
+    getClaudeCandidates({
+      configuredCliPath: options.configuredCliPath,
+      env,
+      homedir,
+      platform,
+    }),
+    fileExists,
+    platform,
+  )
+  if (!cliPath) {
+    throw new Error('Claude Code CLI was not found on this device.')
+  }
+
+  const nodePath = await findExisting(
+    getNodeCandidates({ env, homedir, platform }),
+    fileExists,
+    platform,
+  )
+
+  const spawn =
+    options.spawn ??
+    // eslint-disable-next-line import/no-nodejs-modules -- evaluated only after the shared Desktop capability gate
+    ((await import('node:child_process'))
+      .spawn as unknown as SpawnImplementation)
+
+  return {
+    cliPath,
+    env,
+    spawnClaudeCodeProcess: createElectronSpawnFunction({
+      spawn,
+      nodePath: nodePath ?? undefined,
+    }),
+  }
+}

--- a/src/core/cli-runtime/claude/sdk-loader.ts
+++ b/src/core/cli-runtime/claude/sdk-loader.ts
@@ -1,0 +1,11 @@
+import { assertCliRuntimeAvailable } from '../desktop'
+
+import type { ClaudeSdkLoader, ClaudeSdkModule } from './types'
+
+let sdkModulePromise: Promise<ClaudeSdkModule> | undefined
+
+export const loadClaudeAgentSdk: ClaudeSdkLoader = () => {
+  assertCliRuntimeAvailable('claude-code')
+  sdkModulePromise ??= import('./sdk-module')
+  return sdkModulePromise
+}

--- a/src/core/cli-runtime/claude/sdk-module.ts
+++ b/src/core/cli-runtime/claude/sdk-module.ts
@@ -1,0 +1,5 @@
+export {
+  getSessionMessages,
+  listSessions,
+  query,
+} from '@anthropic-ai/claude-agent-sdk'

--- a/src/core/cli-runtime/claude/sdk-module.ts
+++ b/src/core/cli-runtime/claude/sdk-module.ts
@@ -2,4 +2,4 @@ export {
   getSessionMessages,
   listSessions,
   query,
-} from '@anthropic-ai/claude-agent-sdk'
+} from '@yolo/claude-agent-sdk-runtime'

--- a/src/core/cli-runtime/claude/sdk-runtime/index.d.ts
+++ b/src/core/cli-runtime/claude/sdk-runtime/index.d.ts
@@ -1,0 +1,1 @@
+export * from '@anthropic-ai/claude-agent-sdk'

--- a/src/core/cli-runtime/claude/sdk-runtime/index.mjs
+++ b/src/core/cli-runtime/claude/sdk-runtime/index.mjs
@@ -1,0 +1,1 @@
+export * from '@anthropic-ai/claude-agent-sdk'

--- a/src/core/cli-runtime/claude/sdk-runtime/package.json
+++ b/src/core/cli-runtime/claude/sdk-runtime/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@yolo/claude-agent-sdk-runtime",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.mjs",
+  "types": "index.d.ts",
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+    "@anthropic-ai/sdk": "^0.115.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.0.0"
+  }
+}

--- a/src/core/cli-runtime/claude/types.ts
+++ b/src/core/cli-runtime/claude/types.ts
@@ -1,0 +1,45 @@
+import type {
+  Options,
+  SDKMessage,
+  SDKSessionInfo,
+  SDKUserMessage,
+  SessionMessage,
+  SpawnOptions,
+  SpawnedProcess,
+} from '@anthropic-ai/claude-agent-sdk'
+
+export type ClaudeSdkQuery = AsyncGenerator<SDKMessage, void> & {
+  interrupt(): Promise<unknown>
+  initializationResult(): Promise<unknown>
+  close(): void
+}
+
+export type ClaudeSdkModule = {
+  query(input: {
+    prompt: string | AsyncIterable<SDKUserMessage>
+    options?: Options
+  }): ClaudeSdkQuery
+  listSessions(options?: { dir?: string }): Promise<SDKSessionInfo[]>
+  getSessionMessages(
+    sessionId: string,
+    options?: { dir?: string },
+  ): Promise<SessionMessage[]>
+}
+
+export type ClaudeProcessSupport = {
+  cliPath: string
+  env: Record<string, string | undefined>
+  spawnClaudeCodeProcess: (options: SpawnOptions) => SpawnedProcess
+}
+
+export type ClaudePluginPathInput = {
+  assistantId?: string
+  enabledSkillNames: string[]
+}
+
+export type ClaudePluginPathProvider = (
+  input: ClaudePluginPathInput,
+) => Promise<string[]>
+
+export type ClaudeSdkLoader = () => Promise<ClaudeSdkModule>
+export type ClaudeProcessSupportResolver = () => Promise<ClaudeProcessSupport>

--- a/src/core/cli-runtime/claude/types.ts
+++ b/src/core/cli-runtime/claude/types.ts
@@ -6,7 +6,7 @@ import type {
   SessionMessage,
   SpawnOptions,
   SpawnedProcess,
-} from '@anthropic-ai/claude-agent-sdk'
+} from '@yolo/claude-agent-sdk-runtime'
 
 export type ClaudeSdkQuery = AsyncGenerator<SDKMessage, void> & {
   interrupt(): Promise<unknown>

--- a/src/core/cli-runtime/index.ts
+++ b/src/core/cli-runtime/index.ts
@@ -1,4 +1,5 @@
 export * from './actions'
+export * from './claude'
 export * from './codex'
 export * from './conversation-controller'
 export * from './desktop'


### PR DESCRIPTION
## Summary
- integrate Claude Agent SDK behind the desktop capability gate with a persistent native query/session lifecycle
- discover and hydrate Claude-native sessions without copying transcripts into YOLO persistence
- map streaming text, tools, approvals, AskUserQuestion, cancellation, and assistant plugin paths into the shared CLI runtime contract
- isolate the Agent SDK peer dependency graph from YOLO’s existing Anthropic SDK and Zod versions

## Verification
- `npx jest src/core/cli-runtime --runInBand` (12 suites / 50 tests)
- `npm run type:check`
- `npm run build` including runtime boundary verification
- `npm ls @yolo/claude-agent-sdk-runtime @anthropic-ai/claude-agent-sdk @anthropic-ai/sdk zod` (no invalid peers)
- local Claude Code 2.1.215 / Agent SDK 0.3.220 initialization probe