### PR TITLE
feat(cli-runtime): 接通异步运行时交互桥

### DIFF
--- a/src/components/chat-view/AskUserQuestionPanel.tsx
+++ b/src/components/chat-view/AskUserQuestionPanel.tsx
@@ -308,10 +308,7 @@ export function AskUserQuestionPanel({
 
   const handleCancel = () => {
     if (submitting) return
-    actions.cancelQuestion({
-      conversation,
-      toolCallId: request.id,
-    })
+    void actions.cancelQuestion({ conversation, toolCallId: request.id })
   }
 
   // Pending (AwaitingUserInput) — interactive form.

--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -1072,8 +1072,9 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
     [currentConversationId],
   )
   const cancelRuntimeRun = useCallback(
-    (conversationId: string) =>
-      runtimeActions.cancelRun({ runtimeId: 'yolo', conversationId }),
+    (conversationId: string) => {
+      void runtimeActions.cancelRun({ runtimeId: 'yolo', conversationId })
+    },
     [runtimeActions],
   )
   const resolveRuntimeActionConversation = useCallback(

--- a/src/components/chat-view/ToolMessage.test.ts
+++ b/src/components/chat-view/ToolMessage.test.ts
@@ -12,12 +12,12 @@ jest.mock('clsx', () => ({
 jest.mock('./chat-runtime-actions-context', () => ({
   useChatRuntimeActions: (conversationId = 'conversation-1') => ({
     actions: {
-      cancelRun: jest.fn(),
+      cancelRun: jest.fn(async () => undefined),
       approveTool: jest.fn(async () => ({ kind: 'handled' })),
-      rejectTool: jest.fn(() => ({ kind: 'handled' })),
+      rejectTool: jest.fn(async () => ({ kind: 'handled' })),
       abortTool: jest.fn(async () => ({ kind: 'handled' })),
       answerQuestion: jest.fn(async () => ({ kind: 'handled' })),
-      cancelQuestion: jest.fn(() => ({ kind: 'handled' })),
+      cancelQuestion: jest.fn(async () => ({ kind: 'handled' })),
     },
     conversation: { runtimeId: 'yolo', conversationId },
   }),

--- a/src/components/chat-view/ToolMessage.tsx
+++ b/src/components/chat-view/ToolMessage.tsx
@@ -1782,7 +1782,7 @@ function useToolCall(
   ])
 
   const handleReject = useCallback(() => {
-    handleRuntimeToolRejection({
+    void handleRuntimeToolRejection({
       actions,
       conversation,
       toolCallId: request.id,

--- a/src/components/chat-view/chat-runtime-actions-context.test.tsx
+++ b/src/components/chat-view/chat-runtime-actions-context.test.tsx
@@ -12,12 +12,12 @@ import {
 } from './chat-runtime-actions-context'
 
 const actions: ChatRuntimeActions = {
-  cancelRun: () => {},
+  cancelRun: async () => {},
   approveTool: async () => ({ kind: 'handled' }),
-  rejectTool: () => ({ kind: 'handled' }),
+  rejectTool: async () => ({ kind: 'handled' }),
   abortTool: async () => ({ kind: 'handled' }),
   answerQuestion: async () => ({ kind: 'handled' }),
-  cancelQuestion: () => ({ kind: 'handled' }),
+  cancelQuestion: async () => ({ kind: 'handled' }),
 }
 
 describe('ChatRuntimeActionsProvider', () => {

--- a/src/components/chat-view/runtime-action-handlers.test.ts
+++ b/src/components/chat-view/runtime-action-handlers.test.ts
@@ -15,12 +15,12 @@ const conversation = {
 
 const createActions = (): jest.Mocked<ChatRuntimeActions> =>
   ({
-    cancelRun: jest.fn(),
+    cancelRun: jest.fn(async () => undefined),
     approveTool: jest.fn(async () => ({ kind: 'handled' })),
-    rejectTool: jest.fn(() => ({ kind: 'handled' })),
+    rejectTool: jest.fn(async () => ({ kind: 'handled' })),
     abortTool: jest.fn(async () => ({ kind: 'handled' })),
     answerQuestion: jest.fn(async () => ({ kind: 'handled' })),
-    cancelQuestion: jest.fn(() => ({ kind: 'handled' })),
+    cancelQuestion: jest.fn(async () => ({ kind: 'handled' })),
   }) as unknown as jest.Mocked<ChatRuntimeActions>
 
 describe('runtime action handlers', () => {
@@ -75,12 +75,12 @@ describe('runtime action handlers', () => {
 
   it('keeps stale reject and abort fallbacks at the UI boundary', async () => {
     const actions = createActions()
-    actions.rejectTool.mockReturnValue({ kind: 'stale' })
+    actions.rejectTool.mockResolvedValue({ kind: 'stale' })
     actions.abortTool.mockResolvedValue({ kind: 'stale' })
     const onRejectStale = jest.fn()
     const onAbortStale = jest.fn()
 
-    handleRuntimeToolRejection({
+    await handleRuntimeToolRejection({
       actions,
       conversation,
       toolCallId: 'tool-1',

--- a/src/components/chat-view/runtime-action-handlers.ts
+++ b/src/components/chat-view/runtime-action-handlers.ts
@@ -34,13 +34,13 @@ export async function handleRuntimeToolApproval({
   if (!recovered) onStale?.()
 }
 
-export function handleRuntimeToolRejection({
+export async function handleRuntimeToolRejection({
   actions,
   conversation,
   toolCallId,
   onStale,
-}: RuntimeToolActionTarget & { onStale?: () => void }): void {
-  const result = actions.rejectTool({ conversation, toolCallId })
+}: RuntimeToolActionTarget & { onStale?: () => void }): Promise<void> {
+  const result = await actions.rejectTool({ conversation, toolCallId })
   if (result.kind === 'stale') onStale?.()
 }
 

--- a/src/components/chat-view/tool-cards/SubagentApprovalBlock.tsx
+++ b/src/components/chat-view/tool-cards/SubagentApprovalBlock.tsx
@@ -39,7 +39,7 @@ export function SubagentApprovalBlock({
 
   const handleReject = useCallback(
     (toolCallId: string) => {
-      handleRuntimeToolRejection({
+      void handleRuntimeToolRejection({
         actions,
         conversation,
         toolCallId,

--- a/src/core/cli-runtime/actions.ts
+++ b/src/core/cli-runtime/actions.ts
@@ -22,14 +22,16 @@ export type ChatRuntimeQuestionActionResult =
   | { kind: 'needs_recovery'; resolvedMessages: ChatMessage[] }
 
 export interface ChatRuntimeActions {
-  cancelRun(conversation: ConversationRef): void
+  cancelRun(conversation: ConversationRef): Promise<void>
   approveTool(
     action: ChatRuntimeApprovalAction,
   ): Promise<ChatRuntimeActionResult>
-  rejectTool(action: ChatRuntimeToolAction): ChatRuntimeActionResult
+  rejectTool(action: ChatRuntimeToolAction): Promise<ChatRuntimeActionResult>
   abortTool(action: ChatRuntimeToolAction): Promise<ChatRuntimeActionResult>
   answerQuestion(
     action: ChatRuntimeQuestionAction,
   ): Promise<ChatRuntimeQuestionActionResult>
-  cancelQuestion(action: ChatRuntimeToolAction): ChatRuntimeActionResult
+  cancelQuestion(
+    action: ChatRuntimeToolAction,
+  ): Promise<ChatRuntimeActionResult>
 }

--- a/src/core/cli-runtime/claude/ClaudeCliRuntime.ts
+++ b/src/core/cli-runtime/claude/ClaudeCliRuntime.ts
@@ -391,9 +391,9 @@ export class ClaudeCliRuntime implements CliRuntime {
     this.emit({ type: 'run_state', state: 'aborted' })
   }
 
-  async respondApproval(response: CliApprovalResponse): Promise<void> {
+  async respondApproval(response: CliApprovalResponse): Promise<boolean> {
     const pending = this.pendingPermissions.get(response.requestId)
-    if (!pending || pending.kind !== 'approval' || pending.settled) return
+    if (!pending || pending.kind !== 'approval' || pending.settled) return false
 
     if (response.decision === 'reject') {
       this.settlePending(pending, {
@@ -407,7 +407,7 @@ export class ClaudeCliRuntime implements CliRuntime {
         reason: 'User denied this action.',
       })
       this.emitPendingRunStateOrRunning()
-      return
+      return true
     }
 
     this.settlePending(pending, {
@@ -431,11 +431,12 @@ export class ClaudeCliRuntime implements CliRuntime {
       status: ToolCallResponseStatus.Running,
     })
     this.emitPendingRunStateOrRunning()
+    return true
   }
 
-  async respondQuestion(response: CliQuestionResponse): Promise<void> {
+  async respondQuestion(response: CliQuestionResponse): Promise<boolean> {
     const pending = this.pendingPermissions.get(response.requestId)
-    if (!pending || pending.kind !== 'question' || pending.settled) return
+    if (!pending || pending.kind !== 'question' || pending.settled) return false
 
     if (response.answer === null || response.answer === undefined) {
       this.settlePending(pending, {
@@ -449,7 +450,7 @@ export class ClaudeCliRuntime implements CliRuntime {
         status: ToolCallResponseStatus.Rejected,
         reason: 'User declined to answer.',
       })
-      return
+      return true
     }
 
     const converted = convertYoloAnswerPayloadToClaude({
@@ -468,7 +469,7 @@ export class ClaudeCliRuntime implements CliRuntime {
         error: converted.error,
       })
       this.emit({ type: 'run_state', state: 'error', error: converted.error })
-      return
+      return true
     }
 
     this.settlePending(pending, {
@@ -481,6 +482,7 @@ export class ClaudeCliRuntime implements CliRuntime {
       status: ToolCallResponseStatus.Running,
     })
     this.emitPendingRunStateOrRunning()
+    return true
   }
 
   subscribe(listener: CliRuntimeEventListener): () => void {

--- a/src/core/cli-runtime/cli-actions.test.ts
+++ b/src/core/cli-runtime/cli-actions.test.ts
@@ -1,0 +1,112 @@
+import { createCliChatRuntimeActions } from './cli-actions'
+import type { CliRuntime } from './types'
+
+const conversation = {
+  runtimeId: 'codex',
+  nativeSessionId: 'session-1',
+} as const
+
+const createRuntime = (): jest.Mocked<CliRuntime> =>
+  ({
+    runtimeId: 'codex',
+    listSessions: jest.fn(async () => []),
+    openSession: jest.fn(),
+    ensureReady: jest.fn(),
+    sendTurn: jest.fn(),
+    cancel: jest.fn(async () => undefined),
+    respondApproval: jest.fn(async () => true),
+    respondQuestion: jest.fn(async () => true),
+    subscribe: jest.fn(() => () => undefined),
+    dispose: jest.fn(),
+  }) as unknown as jest.Mocked<CliRuntime>
+
+describe('createCliChatRuntimeActions', () => {
+  it('maps tool approvals and rejection to the provider runtime', async () => {
+    const runtime = createRuntime()
+    const actions = createCliChatRuntimeActions(() => runtime)
+
+    await expect(
+      actions.approveTool({ conversation, toolCallId: 'approval-1' }),
+    ).resolves.toEqual({ kind: 'handled' })
+    await expect(
+      actions.approveTool({
+        conversation,
+        toolCallId: 'approval-2',
+        allowForConversation: true,
+      }),
+    ).resolves.toEqual({ kind: 'handled' })
+    await expect(
+      actions.rejectTool({ conversation, toolCallId: 'approval-3' }),
+    ).resolves.toEqual({ kind: 'handled' })
+
+    expect(runtime.respondApproval.mock.calls).toEqual([
+      [{ requestId: 'approval-1', decision: 'approve_once' }],
+      [{ requestId: 'approval-2', decision: 'approve_for_session' }],
+      [{ requestId: 'approval-3', decision: 'reject' }],
+    ])
+  })
+
+  it('reports stale provider requests without treating them as success', async () => {
+    const runtime = createRuntime()
+    runtime.respondApproval.mockResolvedValueOnce(false)
+    runtime.respondQuestion.mockResolvedValueOnce(false)
+    const actions = createCliChatRuntimeActions(() => runtime)
+
+    await expect(
+      actions.rejectTool({ conversation, toolCallId: 'stale-approval' }),
+    ).resolves.toEqual({ kind: 'stale' })
+    await expect(
+      actions.answerQuestion({
+        conversation,
+        toolCallId: 'stale-question',
+        payload: { type: 'user_answers', answers: [] },
+      }),
+    ).resolves.toEqual({ kind: 'stale' })
+  })
+
+  it('answers questions and cancels an accepted question by ending the turn', async () => {
+    const runtime = createRuntime()
+    const actions = createCliChatRuntimeActions(() => runtime)
+    const payload = { type: 'user_answers', answers: [] }
+
+    await expect(
+      actions.answerQuestion({
+        conversation,
+        toolCallId: 'question-1',
+        payload,
+      }),
+    ).resolves.toEqual({ kind: 'handled' })
+    await expect(
+      actions.cancelQuestion({ conversation, toolCallId: 'question-2' }),
+    ).resolves.toEqual({ kind: 'handled' })
+
+    expect(runtime.respondQuestion.mock.calls).toEqual([
+      [{ requestId: 'question-1', answer: payload }],
+      [{ requestId: 'question-2', answer: null }],
+    ])
+    expect(runtime.cancel.mock.calls).toHaveLength(1)
+  })
+
+  it('uses runtime cancellation for run and tool aborts', async () => {
+    const runtime = createRuntime()
+    const actions = createCliChatRuntimeActions(() => runtime)
+
+    await actions.cancelRun(conversation)
+    await expect(
+      actions.abortTool({ conversation, toolCallId: 'tool-1' }),
+    ).resolves.toEqual({ kind: 'handled' })
+
+    expect(runtime.cancel.mock.calls).toHaveLength(2)
+  })
+
+  it('rejects unavailable and YOLO conversations', async () => {
+    const actions = createCliChatRuntimeActions(() => undefined)
+
+    await expect(actions.cancelRun(conversation)).rejects.toThrow(
+      'codex CLI runtime is not available',
+    )
+    await expect(
+      actions.cancelRun({ runtimeId: 'yolo', conversationId: 'chat-1' }),
+    ).rejects.toThrow('cannot handle YOLO')
+  })
+})

--- a/src/core/cli-runtime/cli-actions.ts
+++ b/src/core/cli-runtime/cli-actions.ts
@@ -1,0 +1,82 @@
+import type { ChatRuntimeActionResult, ChatRuntimeActions } from './actions'
+import type { CliRuntime, CliRuntimeId, ConversationRef } from './types'
+
+export type CliRuntimeResolver = (
+  runtimeId: CliRuntimeId,
+) => CliRuntime | undefined
+
+const HANDLED = { kind: 'handled' } as const
+const STALE = { kind: 'stale' } as const
+
+const toActionResult = (handled: boolean): ChatRuntimeActionResult =>
+  handled ? HANDLED : STALE
+
+const getCliRuntime = (
+  conversation: ConversationRef,
+  resolveRuntime: CliRuntimeResolver,
+): CliRuntime => {
+  if (conversation.runtimeId === 'yolo') {
+    throw new Error('CLI runtime actions cannot handle YOLO conversations.')
+  }
+  const runtime = resolveRuntime(conversation.runtimeId)
+  if (!runtime || runtime.runtimeId !== conversation.runtimeId) {
+    throw new Error(`${conversation.runtimeId} CLI runtime is not available.`)
+  }
+  return runtime
+}
+
+export const createCliChatRuntimeActions = (
+  resolveRuntime: CliRuntimeResolver,
+): ChatRuntimeActions => ({
+  async cancelRun(conversation) {
+    await getCliRuntime(conversation, resolveRuntime).cancel()
+  },
+
+  async approveTool(action) {
+    const handled = await getCliRuntime(
+      action.conversation,
+      resolveRuntime,
+    ).respondApproval({
+      requestId: action.toolCallId,
+      decision: action.allowForConversation
+        ? 'approve_for_session'
+        : 'approve_once',
+    })
+    return toActionResult(handled)
+  },
+
+  async rejectTool(action) {
+    const handled = await getCliRuntime(
+      action.conversation,
+      resolveRuntime,
+    ).respondApproval({ requestId: action.toolCallId, decision: 'reject' })
+    return toActionResult(handled)
+  },
+
+  async abortTool(action) {
+    await getCliRuntime(action.conversation, resolveRuntime).cancel()
+    return HANDLED
+  },
+
+  async answerQuestion(action) {
+    const handled = await getCliRuntime(
+      action.conversation,
+      resolveRuntime,
+    ).respondQuestion({
+      requestId: action.toolCallId,
+      answer: action.payload,
+    })
+    return toActionResult(handled)
+  },
+
+  async cancelQuestion(action) {
+    const runtime = getCliRuntime(action.conversation, resolveRuntime)
+    const handled = await runtime.respondQuestion({
+      requestId: action.toolCallId,
+      answer: null,
+    })
+    if (!handled) return STALE
+    await runtime.cancel()
+    return HANDLED
+  },
+})

--- a/src/core/cli-runtime/codex/runtime.test.ts
+++ b/src/core/cli-runtime/codex/runtime.test.ts
@@ -1,3 +1,5 @@
+import { ToolCallResponseStatus } from '../../../types/tool-call.types'
+
 import type { CodexProcessExitListener, CodexProcessLike } from './process'
 import { CodexCliRuntime } from './runtime'
 
@@ -31,14 +33,20 @@ class RpcFakeProcess implements CodexProcessLike {
         ? { data: [this.thread], nextCursor: null }
         : request.method === 'thread/read'
           ? { thread: this.thread }
-          : request.method === 'thread/start' || request.method === 'thread/resume'
+          : request.method === 'thread/start' ||
+              request.method === 'thread/resume'
             ? { thread: this.thread }
             : request.method === 'turn/start'
-              ? { turn: { id: 'turn-1', items: [], status: 'inProgress', error: null } }
+              ? {
+                  turn: {
+                    id: 'turn-1',
+                    items: [],
+                    status: 'inProgress',
+                    error: null,
+                  },
+                }
               : {}
-    queueMicrotask(() =>
-      this.emit({ jsonrpc: '2.0', id: request.id, result }),
-    )
+    queueMicrotask(() => this.emit({ jsonrpc: '2.0', id: request.id, result }))
   }
   onLine(listener: (line: string) => void): () => void {
     this.lineListener = listener
@@ -101,14 +109,88 @@ describe('CodexCliRuntime', () => {
       jsonrpc: '2.0',
       id: 91,
       method: 'item/commandExecution/requestApproval',
-      params: { itemId: 'command-1', command: 'pwd', cwd: '/vault' },
+      params: {
+        approvalId: 'approval-1',
+        itemId: 'command-1',
+        command: 'pwd',
+        cwd: '/vault',
+      },
     })
     expect(events).toContain('waiting_for_approval')
 
-    await runtime.respondApproval({
-      requestId: 'command-1',
-      decision: 'approve_for_session',
-    })
+    await expect(
+      runtime.respondApproval({
+        requestId: 'command-1',
+        decision: 'approve_for_session',
+      }),
+    ).resolves.toBe(true)
     expect(process.responses).toContainEqual({ decision: 'acceptForSession' })
+    await expect(
+      runtime.respondApproval({
+        requestId: 'approval-1',
+        decision: 'reject',
+      }),
+    ).resolves.toBe(false)
+  })
+
+  it('maps Codex user input requests to the shared Ask User card contract', async () => {
+    const process = new RpcFakeProcess()
+    const runtime = new CodexCliRuntime({
+      cwd: '/vault',
+      createProcess: async () => process,
+    })
+    const events: unknown[] = []
+    runtime.subscribe((event) => events.push(event))
+    await runtime.ensureReady({
+      assistant: { systemPrompt: '', enabledSkillNames: [] },
+    })
+
+    process.emit({
+      jsonrpc: '2.0',
+      id: 92,
+      method: 'item/tool/requestUserInput',
+      params: {
+        itemId: 'question-tool',
+        questions: [
+          {
+            id: 'choice',
+            question: 'Choose one?',
+            options: [{ label: 'A' }, { label: 'B' }],
+          },
+        ],
+      },
+    })
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'message_upsert',
+          message: expect.objectContaining({
+            role: 'tool',
+            toolCalls: [
+              expect.objectContaining({
+                request: expect.objectContaining({
+                  id: 'question-tool',
+                  name: 'yolo_local__ask_user_question',
+                }),
+                response: { status: ToolCallResponseStatus.AwaitingUserInput },
+              }),
+            ],
+          }),
+        }),
+      ]),
+    )
+    await expect(
+      runtime.respondQuestion({
+        requestId: 'question-tool',
+        answer: {
+          type: 'user_answers',
+          answers: [{ id: 'choice', value: 'A' }],
+        },
+      }),
+    ).resolves.toBe(true)
+    expect(process.responses).toContainEqual({
+      answers: { choice: { answers: ['A'] } },
+    })
   })
 })

--- a/src/core/cli-runtime/codex/runtime.ts
+++ b/src/core/cli-runtime/codex/runtime.ts
@@ -13,7 +13,16 @@ import type {
   CliTurnInput,
 } from '../types'
 
-import { buildPendingToolMessages, mapCodexItem, mapCodexTurns } from './mapping'
+import {
+  buildPendingToolMessages,
+  mapCodexItem,
+  mapCodexTurns,
+} from './mapping'
+import {
+  CodexAppServerProcess,
+  type CodexProcessLike,
+  type CodexProcessOptions,
+} from './process'
 import type {
   CodexServerRequest,
   CodexThread,
@@ -25,16 +34,12 @@ import type {
   ThreadStartResponse,
   TurnStartResponse,
 } from './protocol'
-import {
-  CodexAppServerProcess,
-  type CodexProcessLike,
-  type CodexProcessOptions,
-} from './process'
 import { CodexRpcTransport, initializeCodexTransport } from './transport'
 
 type PendingServerRequest = {
   request: CodexServerRequest
   toolCallId: string
+  kind: 'approval' | 'question'
 }
 
 export type CodexCliRuntimeOptions = CodexProcessOptions & {
@@ -124,13 +129,14 @@ export class CodexCliRuntime implements CliRuntime {
     const sessions: CliSessionMetadata[] = []
     let cursor: string | null = null
     do {
-      const response: ThreadListResponse = await transport.request<ThreadListResponse>('thread/list', {
-        cursor,
-        limit: 100,
-        sortKey: 'updated_at',
-        sortDirection: 'desc',
-        cwd: this.options.cwd,
-      })
+      const response: ThreadListResponse =
+        await transport.request<ThreadListResponse>('thread/list', {
+          cursor,
+          limit: 100,
+          sortKey: 'updated_at',
+          sortDirection: 'desc',
+          cwd: this.options.cwd,
+        })
       sessions.push(...response.data.map(toSessionMetadata))
       cursor = response.nextCursor
     } while (cursor)
@@ -138,13 +144,20 @@ export class CodexCliRuntime implements CliRuntime {
   }
 
   async openSession(ref: CliSessionRef): Promise<CliSessionHydration> {
-    if (ref.runtimeId !== 'codex') throw new Error('Cannot open a non-Codex session.')
+    if (ref.runtimeId !== 'codex')
+      throw new Error('Cannot open a non-Codex session.')
     const transport = await this.getTransport()
-    const response = await transport.request<ThreadReadResponse>('thread/read', {
-      threadId: ref.nativeSessionId,
-      includeTurns: true,
-    })
-    return { ref: toSessionRef(response.thread), messages: mapCodexTurns(response.thread.turns) }
+    const response = await transport.request<ThreadReadResponse>(
+      'thread/read',
+      {
+        threadId: ref.nativeSessionId,
+        includeTurns: true,
+      },
+    )
+    return {
+      ref: toSessionRef(response.thread),
+      messages: mapCodexTurns(response.thread.turns),
+    }
   }
 
   async ensureReady(input: CliRuntimeReadyInput): Promise<void> {
@@ -152,7 +165,8 @@ export class CodexCliRuntime implements CliRuntime {
     const assistantKey = JSON.stringify(input.assistant)
     if (
       this.activeSessionRef &&
-      input.sessionRef?.nativeSessionId === this.activeSessionRef.nativeSessionId &&
+      input.sessionRef?.nativeSessionId ===
+        this.activeSessionRef.nativeSessionId &&
       assistantKey === this.assistantKey
     ) {
       return
@@ -180,14 +194,19 @@ export class CodexCliRuntime implements CliRuntime {
     if (input.sessionRef) {
       if (
         !this.activeSessionRef ||
-        input.sessionRef.nativeSessionId !== this.activeSessionRef.nativeSessionId
+        input.sessionRef.nativeSessionId !==
+          this.activeSessionRef.nativeSessionId
       ) {
-        throw new Error('Codex session must be resumed with ensureReady before sending.')
+        throw new Error(
+          'Codex session must be resumed with ensureReady before sending.',
+        )
       }
     }
     if (!this.activeSessionRef) throw new Error('Codex runtime is not ready.')
     this.emit({ type: 'run_state', state: 'running' })
-    const response = await (await this.getTransport()).request<TurnStartResponse>(
+    const response = await (
+      await this.getTransport()
+    ).request<TurnStartResponse>(
       'turn/start',
       {
         threadId: this.activeSessionRef.nativeSessionId,
@@ -200,28 +219,32 @@ export class CodexCliRuntime implements CliRuntime {
 
   async cancel(): Promise<void> {
     if (!this.activeSessionRef || !this.activeTurnId) return
-    await (await this.getTransport()).request('turn/interrupt', {
+    await (
+      await this.getTransport()
+    ).request('turn/interrupt', {
       threadId: this.activeSessionRef.nativeSessionId,
       turnId: this.activeTurnId,
     })
   }
 
-  async respondApproval(response: CliApprovalResponse): Promise<void> {
+  async respondApproval(response: CliApprovalResponse): Promise<boolean> {
     const pending = this.pendingRequests.get(response.requestId)
-    if (!pending) throw new Error('Codex approval request is no longer pending.')
-    this.pendingRequests.delete(response.requestId)
+    if (!pending || pending.kind !== 'approval') return false
+    this.deletePendingRequest(pending)
     ;(await this.getTransport()).respond(pending.request.id, {
       decision: approvalDecision(response.decision),
     })
+    return true
   }
 
-  async respondQuestion(response: CliQuestionResponse): Promise<void> {
+  async respondQuestion(response: CliQuestionResponse): Promise<boolean> {
     const pending = this.pendingRequests.get(response.requestId)
-    if (!pending) throw new Error('Codex question is no longer pending.')
-    this.pendingRequests.delete(response.requestId)
+    if (!pending || pending.kind !== 'question') return false
+    this.deletePendingRequest(pending)
     ;(await this.getTransport()).respond(pending.request.id, {
       answers: toCodexQuestionAnswers(response.answer),
     })
+    return true
   }
 
   subscribe(listener: CliRuntimeEventListener): () => void {
@@ -258,7 +281,9 @@ export class CodexCliRuntime implements CliRuntime {
   }
 
   private async createTransport(): Promise<CodexRpcTransport> {
-    const createProcess = this.options.createProcess ?? CodexAppServerProcess.start
+    const createProcess =
+      this.options.createProcess ??
+      ((options: CodexProcessOptions) => CodexAppServerProcess.start(options))
     this.process = await createProcess(this.options)
     const transport = new CodexRpcTransport(this.process)
     transport.onNotification((notification) =>
@@ -287,7 +312,8 @@ export class CodexCliRuntime implements CliRuntime {
       return
     }
     if (method === 'item/agentMessage/delta') {
-      const itemId = typeof params.itemId === 'string' ? params.itemId : 'stream'
+      const itemId =
+        typeof params.itemId === 'string' ? params.itemId : 'stream'
       const delta = typeof params.delta === 'string' ? params.delta : ''
       const existing = this.streamingAssistantText.get(itemId) ?? ''
       const content = `${existing}${delta}`
@@ -304,7 +330,8 @@ export class CodexCliRuntime implements CliRuntime {
       return
     }
     if (method === 'item/reasoning/summaryTextDelta') {
-      const itemId = typeof params.itemId === 'string' ? params.itemId : 'reasoning'
+      const itemId =
+        typeof params.itemId === 'string' ? params.itemId : 'reasoning'
       const delta = typeof params.delta === 'string' ? params.delta : ''
       const reasoning = `${this.streamingReasoningText.get(itemId) ?? ''}${delta}`
       this.streamingReasoningText.set(itemId, reasoning)
@@ -340,12 +367,20 @@ export class CodexCliRuntime implements CliRuntime {
       return
     }
     if (method === 'turn/completed') {
-      const turn = params.turn as { status?: unknown; error?: { message?: unknown } } | undefined
-      const status = typeof turn?.status === 'string' ? turn.status : 'completed'
+      const turn = params.turn as
+        | { status?: unknown; error?: { message?: unknown } }
+        | undefined
+      const status =
+        typeof turn?.status === 'string' ? turn.status : 'completed'
       const isError = status === 'failed'
       this.emit({
         type: 'run_state',
-        state: status === 'interrupted' ? 'aborted' : isError ? 'error' : 'completed',
+        state:
+          status === 'interrupted'
+            ? 'aborted'
+            : isError
+              ? 'error'
+              : 'completed',
         ...(isError && typeof turn?.error?.message === 'string'
           ? { error: turn.error.message }
           : {}),
@@ -371,7 +406,11 @@ export class CodexCliRuntime implements CliRuntime {
       request.method === 'item/fileChange/requestApproval' ||
       request.method === 'item/permissions/requestApproval'
     ) {
-      this.pendingRequests.set(key, { request, toolCallId: itemId })
+      this.registerPendingRequest(key, {
+        request,
+        toolCallId: itemId,
+        kind: 'approval',
+      })
       const [assistant, tool] = buildPendingToolMessages({
         requestId: request.id,
         toolCallId: itemId,
@@ -390,7 +429,11 @@ export class CodexCliRuntime implements CliRuntime {
       return
     }
     if (request.method === 'item/tool/requestUserInput') {
-      this.pendingRequests.set(key, { request, toolCallId: itemId })
+      this.registerPendingRequest(key, {
+        request,
+        toolCallId: itemId,
+        kind: 'question',
+      })
       const rawQuestions = Array.isArray(request.params.questions)
         ? request.params.questions
         : []
@@ -404,7 +447,9 @@ export class CodexCliRuntime implements CliRuntime {
           ? question.options.map((option, optionIndex) => {
               const value = option as { label?: unknown; description?: unknown }
               const label =
-                typeof value.label === 'string' ? value.label : `Option ${optionIndex + 1}`
+                typeof value.label === 'string'
+                  ? value.label
+                  : `Option ${optionIndex + 1}`
               return {
                 id: label,
                 label,
@@ -417,7 +462,10 @@ export class CodexCliRuntime implements CliRuntime {
         const selectableOptions =
           options && options.length >= 2 ? options : undefined
         return {
-          id: typeof question.id === 'string' ? question.id : `question-${index + 1}`,
+          id:
+            typeof question.id === 'string'
+              ? question.id
+              : `question-${index + 1}`,
           prompt:
             typeof question.question === 'string'
               ? question.question
@@ -429,7 +477,7 @@ export class CodexCliRuntime implements CliRuntime {
       const [assistant, tool] = buildPendingToolMessages({
         requestId: request.id,
         toolCallId: itemId,
-        name: 'ask_user_question',
+        name: 'yolo_local__ask_user_question',
         argumentsValue: { questions },
         responseStatus: ToolCallResponseStatus.AwaitingUserInput,
       })
@@ -439,7 +487,25 @@ export class CodexCliRuntime implements CliRuntime {
       return
     }
     void this.getTransport().then((transport) =>
-      transport.respondError(request.id, -32601, `Unsupported Codex request: ${request.method}`),
+      transport.respondError(
+        request.id,
+        -32601,
+        `Unsupported Codex request: ${request.method}`,
+      ),
     )
+  }
+
+  private registerPendingRequest(
+    protocolKey: string,
+    pending: PendingServerRequest,
+  ): void {
+    this.pendingRequests.set(protocolKey, pending)
+    this.pendingRequests.set(pending.toolCallId, pending)
+  }
+
+  private deletePendingRequest(pending: PendingServerRequest): void {
+    for (const [key, candidate] of this.pendingRequests) {
+      if (candidate === pending) this.pendingRequests.delete(key)
+    }
   }
 }

--- a/src/core/cli-runtime/conversation-controller.test.ts
+++ b/src/core/cli-runtime/conversation-controller.test.ts
@@ -92,9 +92,13 @@ class FakeCliRuntime implements CliRuntime {
     return this.cancelImpl()
   }
 
-  async respondApproval(_response: CliApprovalResponse): Promise<void> {}
+  async respondApproval(_response: CliApprovalResponse): Promise<boolean> {
+    return false
+  }
 
-  async respondQuestion(_response: CliQuestionResponse): Promise<void> {}
+  async respondQuestion(_response: CliQuestionResponse): Promise<boolean> {
+    return false
+  }
 
   subscribe(listener: CliRuntimeEventListener): () => void {
     this.listeners.add(listener)

--- a/src/core/cli-runtime/index.ts
+++ b/src/core/cli-runtime/index.ts
@@ -1,5 +1,6 @@
 export * from './actions'
 export * from './claude'
+export * from './cli-actions'
 export * from './codex'
 export * from './conversation-controller'
 export * from './desktop'

--- a/src/core/cli-runtime/session-service.test.ts
+++ b/src/core/cli-runtime/session-service.test.ts
@@ -44,8 +44,8 @@ const runtime = ({
   ensureReady: async () => undefined,
   sendTurn: async () => undefined,
   cancel: async () => undefined,
-  respondApproval: async () => undefined,
-  respondQuestion: async () => undefined,
+  respondApproval: async () => false,
+  respondQuestion: async () => false,
   subscribe: (_listener: CliRuntimeEventListener) => () => undefined,
   dispose: async () => undefined,
 })

--- a/src/core/cli-runtime/types.ts
+++ b/src/core/cli-runtime/types.ts
@@ -19,9 +19,8 @@ export type CliSessionRef = {
 
 export type ConversationRef = YoloConversationRef | CliSessionRef
 
-export const isCliSessionRef = (
-  ref: ConversationRef,
-): ref is CliSessionRef => ref.runtimeId !== 'yolo'
+export const isCliSessionRef = (ref: ConversationRef): ref is CliSessionRef =>
+  ref.runtimeId !== 'yolo'
 
 export type CliSessionMetadata = {
   ref: CliSessionRef
@@ -107,8 +106,8 @@ export interface CliRuntime {
   ensureReady(input: CliRuntimeReadyInput): Promise<void>
   sendTurn(input: CliTurnInput): Promise<void>
   cancel(): Promise<void>
-  respondApproval(response: CliApprovalResponse): Promise<void>
-  respondQuestion(response: CliQuestionResponse): Promise<void>
+  respondApproval(response: CliApprovalResponse): Promise<boolean>
+  respondQuestion(response: CliQuestionResponse): Promise<boolean>
   subscribe(listener: CliRuntimeEventListener): () => void
   dispose(): Promise<void>
 }

--- a/src/core/cli-runtime/yolo-actions.test.ts
+++ b/src/core/cli-runtime/yolo-actions.test.ts
@@ -19,11 +19,11 @@ const createService = (): jest.Mocked<YoloChatRuntimeActionService> =>
   }) as unknown as jest.Mocked<YoloChatRuntimeActionService>
 
 describe('createYoloChatRuntimeActions', () => {
-  it('delegates run cancellation to AgentService', () => {
+  it('delegates run cancellation to AgentService', async () => {
     const service = createService()
     const actions = createYoloChatRuntimeActions(service)
 
-    actions.cancelRun(conversation)
+    await actions.cancelRun(conversation)
 
     expect(service.abortConversation).toHaveBeenCalledWith('conversation-1')
   })
@@ -65,13 +65,13 @@ describe('createYoloChatRuntimeActions', () => {
       listSubagentTasks,
     })
 
-    expect(
+    await expect(
       actions.rejectTool({ conversation, toolCallId: 'reject-1' }),
-    ).toEqual({ kind: 'handled' })
+    ).resolves.toEqual({ kind: 'handled' })
     service.rejectToolCall.mockReturnValueOnce(false)
-    expect(
+    await expect(
       actions.rejectTool({ conversation, toolCallId: 'reject-2' }),
-    ).toEqual({ kind: 'stale' })
+    ).resolves.toEqual({ kind: 'stale' })
 
     await expect(
       actions.abortTool({ conversation, toolCallId: 'abort-1' }),
@@ -154,26 +154,26 @@ describe('createYoloChatRuntimeActions', () => {
     ).resolves.toEqual({ kind: 'stale' })
   })
 
-  it('delegates question cancellation and reports stale requests', () => {
+  it('delegates question cancellation and reports stale requests', async () => {
     const service = createService()
     const actions = createYoloChatRuntimeActions(service)
 
-    expect(
+    await expect(
       actions.cancelQuestion({ conversation, toolCallId: 'question-1' }),
-    ).toEqual({ kind: 'handled' })
+    ).resolves.toEqual({ kind: 'handled' })
     service.cancelAskUserQuestion.mockReturnValueOnce(false)
-    expect(
+    await expect(
       actions.cancelQuestion({ conversation, toolCallId: 'question-2' }),
-    ).toEqual({ kind: 'stale' })
+    ).resolves.toEqual({ kind: 'stale' })
   })
 
-  it('rejects a non-YOLO conversation instead of dispatching it accidentally', () => {
+  it('rejects a non-YOLO conversation instead of dispatching it accidentally', async () => {
     const service = createService()
     const actions = createYoloChatRuntimeActions(service)
 
-    expect(() =>
+    await expect(
       actions.cancelRun({ runtimeId: 'codex', nativeSessionId: 'session-1' }),
-    ).toThrow('YOLO runtime actions cannot handle codex conversations')
+    ).rejects.toThrow('YOLO runtime actions cannot handle codex conversations')
     expect(service.abortConversation).not.toHaveBeenCalled()
   })
 })

--- a/src/core/cli-runtime/yolo-actions.ts
+++ b/src/core/cli-runtime/yolo-actions.ts
@@ -51,7 +51,7 @@ export const createYoloChatRuntimeActions = (
   agentService: YoloChatRuntimeActionService,
   options: YoloChatRuntimeActionsOptions = {},
 ): ChatRuntimeActions => ({
-  cancelRun(conversation) {
+  async cancelRun(conversation) {
     agentService.abortConversation(getYoloConversationId(conversation))
   },
 
@@ -65,7 +65,7 @@ export const createYoloChatRuntimeActions = (
     )
   },
 
-  rejectTool(action) {
+  async rejectTool(action) {
     return toActionResult(
       agentService.rejectToolCall({
         conversationId: getYoloConversationId(action.conversation),
@@ -111,7 +111,7 @@ export const createYoloChatRuntimeActions = (
     return HANDLED
   },
 
-  cancelQuestion(action) {
+  async cancelQuestion(action) {
     return toActionResult(
       agentService.cancelAskUserQuestion({
         conversationId: getYoloConversationId(action.conversation),


### PR DESCRIPTION
## Summary
- add provider-neutral CLI implementations of `ChatRuntimeActions`
- carry asynchronous handled/stale results through reject, question cancellation, and run cancellation
- make Claude and Codex pending responses report whether the native request is still live
- fix Codex approvalId/itemId aliases and map native user-input requests to the existing Ask User card

## Verification
- 16 focused suites / 94 tests
- `npm run type:check`
- focused ESLint, Prettier, and `git diff --check`