### PR TITLE
feat(chat): 添加本机 CLI 会话列表区块

### DIFF
--- a/src/components/chat-view/CliSessionListSection.test.tsx
+++ b/src/components/chat-view/CliSessionListSection.test.tsx
@@ -49,6 +49,7 @@ const claudeSession: CliSessionListItem = {
   preview: 'Claude native preview',
   updatedAt: 200,
   isPinned: true,
+  hasOverlay: true,
 }
 
 const codexSession: CliSessionListItem = {
@@ -60,6 +61,7 @@ const codexSession: CliSessionListItem = {
   preview: 'Codex native preview',
   updatedAt: 100,
   isPinned: false,
+  hasOverlay: true,
 }
 
 const discoveryResult: CliSessionDiscoveryResult = {
@@ -239,6 +241,27 @@ describe('CliSessionListSection', () => {
     expect(listHtml).toContain('forget from yolo')
     expect(listHtml).not.toContain('delete')
     expect(listHtml).not.toContain('transcript')
+  })
+
+  it('does not offer an overlay action for a provider-only discovery', () => {
+    const root = renderComponentTree(
+      createProps({
+        discoveryResult: {
+          sessions: [{ ...codexSession, hasOverlay: false }],
+          errors: {},
+        },
+      }),
+    )
+    const row = findSessionRow(root, 'codex')
+
+    expect(
+      walkElements(row).some(
+        (element) =>
+          element.type === 'button' &&
+          (element.props as { 'data-action'?: string })['data-action'] ===
+            'request-forget-overlay',
+      ),
+    ).toBe(false)
   })
 
   it('renders nothing on mobile', () => {

--- a/src/components/chat-view/CliSessionListSection.test.tsx
+++ b/src/components/chat-view/CliSessionListSection.test.tsx
@@ -1,0 +1,254 @@
+jest.mock('../../contexts/language-context', () => ({
+  useLanguage: () => ({
+    t: (key: string) =>
+      (
+        ({
+          'common.retry': 'Retry',
+          'sidebar.runtimeSelector.claudeCodeLabel': 'Claude Code',
+          'sidebar.runtimeSelector.codexLabel': 'Codex',
+          'sidebar.cliSessions.sectionLabel': 'CLI sessions',
+          'sidebar.cliSessions.title': 'Local CLI sessions',
+          'sidebar.cliSessions.loading': 'Loading CLI sessions…',
+          'sidebar.cliSessions.empty': 'No Claude Code or Codex sessions found',
+          'sidebar.cliSessions.current': 'Current',
+          'sidebar.cliSessions.pin': 'Pin in YOLO',
+          'sidebar.cliSessions.unpin': 'Unpin in YOLO',
+          'sidebar.cliSessions.forgetFromYolo': 'Forget from YOLO',
+          'sidebar.cliSessions.retryProvider': 'Retry {provider}',
+        }) as Record<string, string>
+      )[key] ?? key,
+  }),
+}))
+
+import { Platform } from 'obsidian'
+import {
+  Children,
+  type ReactElement,
+  type ReactNode,
+  isValidElement,
+} from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import type {
+  CliRuntimeId,
+  CliSessionDiscoveryResult,
+  CliSessionListItem,
+} from '../../core/cli-runtime'
+
+import {
+  CliSessionListSection,
+  type CliSessionListSectionProps,
+} from './CliSessionListSection'
+
+const claudeSession: CliSessionListItem = {
+  ref: {
+    runtimeId: 'claude-code',
+    nativeSessionId: 'shared/id',
+  },
+  title: 'Claude native title',
+  preview: 'Claude native preview',
+  updatedAt: 200,
+  isPinned: true,
+}
+
+const codexSession: CliSessionListItem = {
+  ref: {
+    runtimeId: 'codex',
+    nativeSessionId: 'shared/id',
+  },
+  title: 'Codex native title',
+  preview: 'Codex native preview',
+  updatedAt: 100,
+  isPinned: false,
+}
+
+const discoveryResult: CliSessionDiscoveryResult = {
+  sessions: [claudeSession, codexSession],
+  errors: {},
+}
+
+const createProps = (
+  overrides: Partial<CliSessionListSectionProps> = {},
+): CliSessionListSectionProps => ({
+  discoveryResult,
+  loading: false,
+  currentRef: codexSession.ref,
+  onSelect: jest.fn(),
+  onTogglePinned: jest.fn(),
+  onRequestForgetOverlay: jest.fn(),
+  onRetryProvider: jest.fn(),
+  ...overrides,
+})
+
+const walkElements = (node: ReactNode): ReactElement[] => {
+  if (!isValidElement(node)) return []
+  const element = node as ReactElement<{ children?: ReactNode }>
+  return [
+    element,
+    ...Children.toArray(element.props.children).flatMap(walkElements),
+  ]
+}
+
+const renderComponentTree = (
+  props: CliSessionListSectionProps,
+): ReactElement => {
+  const element = CliSessionListSection(props)
+  if (!element) throw new Error('Expected desktop section to render')
+  return element
+}
+
+const findSessionRow = (
+  root: ReactElement,
+  runtimeId: CliRuntimeId,
+): ReactElement => {
+  const rowComponent = walkElements(root).find(
+    (element) =>
+      typeof element.type === 'function' &&
+      (element.props as { session?: CliSessionListItem }).session?.ref
+        .runtimeId === runtimeId,
+  )
+  if (!rowComponent) throw new Error(`Missing ${runtimeId} session row`)
+
+  const rowProps = rowComponent.props
+  return (rowComponent.type as (props: typeof rowProps) => ReactElement)(
+    rowProps,
+  )
+}
+
+const findAction = (row: ReactElement, action: string): ReactElement => {
+  const button = walkElements(row).find(
+    (element) =>
+      element.type === 'button' &&
+      (element.props as { 'data-action'?: string })['data-action'] === action,
+  )
+  if (!button) throw new Error(`Missing ${action} action`)
+  return button
+}
+
+describe('CliSessionListSection', () => {
+  const originalIsDesktop = Platform.isDesktop
+
+  beforeEach(() => {
+    Platform.isDesktop = true
+  })
+
+  afterEach(() => {
+    Platform.isDesktop = originalIsDesktop
+  })
+
+  it('shows provider-native titles and previews with clear runtime badges', () => {
+    const html = renderToStaticMarkup(
+      <CliSessionListSection {...createProps()} />,
+    )
+
+    expect(html).toContain('data-runtime-id="claude-code"')
+    expect(html).toContain('>Claude Code<')
+    expect(html).toContain('Claude native title')
+    expect(html).toContain('Claude native preview')
+    expect(html).toContain('data-runtime-id="codex"')
+    expect(html).toContain('>Codex<')
+    expect(html).toContain('Codex native title')
+    expect(html).toContain('Codex native preview')
+  })
+
+  it('keeps the same native id stable and distinct across providers', () => {
+    const html = renderToStaticMarkup(
+      <CliSessionListSection {...createProps()} />,
+    )
+
+    expect(html).toContain('data-session-key="claude-code:shared%2Fid"')
+    expect(html).toContain('data-session-key="codex:shared%2Fid"')
+    expect(html.match(/data-session-key=/g)).toHaveLength(2)
+  })
+
+  it('routes select, pin, and confirmation-boundary forget callbacks by full ref', () => {
+    const onSelect = jest.fn()
+    const onTogglePinned = jest.fn()
+    const onRequestForgetOverlay = jest.fn()
+    const root = renderComponentTree(
+      createProps({ onSelect, onTogglePinned, onRequestForgetOverlay }),
+    )
+    const codexRow = findSessionRow(root, 'codex')
+
+    ;(findAction(codexRow, 'select').props as { onClick: () => void }).onClick()
+    ;(
+      findAction(codexRow, 'toggle-pin').props as { onClick: () => void }
+    ).onClick()
+    ;(
+      findAction(codexRow, 'request-forget-overlay').props as {
+        onClick: () => void
+      }
+    ).onClick()
+
+    expect(onSelect).toHaveBeenCalledWith(codexSession.ref)
+    expect(onTogglePinned).toHaveBeenCalledWith(codexSession.ref, true)
+    expect(onRequestForgetOverlay).toHaveBeenCalledWith(codexSession.ref)
+  })
+
+  it('surfaces provider errors independently and retries the matching provider', () => {
+    const onRetryProvider = jest.fn()
+    const props = createProps({
+      discoveryResult: {
+        sessions: [],
+        errors: {
+          'claude-code': 'Claude command unavailable',
+          codex: 'Codex index unreadable',
+        },
+      },
+      onRetryProvider,
+    })
+    const root = renderComponentTree(props)
+    const html = renderToStaticMarkup(<CliSessionListSection {...props} />)
+    const retryButtons = walkElements(root).filter(
+      (element) =>
+        element.type === 'button' &&
+        (element.props as { 'data-action'?: string })['data-action'] ===
+          'retry-provider',
+    )
+
+    expect(html).toContain('Claude command unavailable')
+    expect(html).toContain('Codex index unreadable')
+    expect(retryButtons).toHaveLength(2)
+    ;(
+      retryButtons[1].props as {
+        onClick: () => void
+      }
+    ).onClick()
+    expect(onRetryProvider).toHaveBeenCalledWith('codex')
+  })
+
+  it('renders loading and empty states without native transcript actions', () => {
+    const loadingHtml = renderToStaticMarkup(
+      <CliSessionListSection
+        {...createProps({ discoveryResult: undefined, loading: true })}
+      />,
+    )
+    const emptyHtml = renderToStaticMarkup(
+      <CliSessionListSection
+        {...createProps({
+          discoveryResult: { sessions: [], errors: {} },
+        })}
+      />,
+    )
+    const listHtml = renderToStaticMarkup(
+      <CliSessionListSection {...createProps()} />,
+    ).toLowerCase()
+
+    expect(loadingHtml).toContain('Loading CLI sessions…')
+    expect(emptyHtml).toContain('No Claude Code or Codex sessions found')
+    expect(listHtml).toContain('forget from yolo')
+    expect(listHtml).not.toContain('delete')
+    expect(listHtml).not.toContain('transcript')
+  })
+
+  it('renders nothing on mobile', () => {
+    Platform.isDesktop = false
+
+    const html = renderToStaticMarkup(
+      <CliSessionListSection {...createProps()} />,
+    )
+
+    expect(html).toBe('')
+    expect(html).not.toContain('yolo-cli-session-list')
+  })
+})

--- a/src/components/chat-view/CliSessionListSection.tsx
+++ b/src/components/chat-view/CliSessionListSection.tsx
@@ -123,16 +123,18 @@ const CliSessionRow = ({
             <Pin size={14} aria-hidden="true" />
           )}
         </button>
-        <button
-          type="button"
-          className="clickable-icon yolo-cli-session-list__action yolo-cli-session-list__forget"
-          data-action="request-forget-overlay"
-          aria-label={t('sidebar.cliSessions.forgetFromYolo')}
-          title={t('sidebar.cliSessions.forgetFromYolo')}
-          onClick={() => onRequestForgetOverlay(session.ref)}
-        >
-          <Unlink size={14} aria-hidden="true" />
-        </button>
+        {session.hasOverlay ? (
+          <button
+            type="button"
+            className="clickable-icon yolo-cli-session-list__action yolo-cli-session-list__forget"
+            data-action="request-forget-overlay"
+            aria-label={t('sidebar.cliSessions.forgetFromYolo')}
+            title={t('sidebar.cliSessions.forgetFromYolo')}
+            onClick={() => onRequestForgetOverlay(session.ref)}
+          >
+            <Unlink size={14} aria-hidden="true" />
+          </button>
+        ) : null}
       </span>
     </li>
   )

--- a/src/components/chat-view/CliSessionListSection.tsx
+++ b/src/components/chat-view/CliSessionListSection.tsx
@@ -1,0 +1,254 @@
+import {
+  Asterisk,
+  LoaderCircle,
+  Pin,
+  PinOff,
+  RefreshCw,
+  SquareTerminal,
+  Unlink,
+} from 'lucide-react'
+
+import { useLanguage } from '../../contexts/language-context'
+import {
+  CLI_RUNTIME_IDS,
+  type CliRuntimeId,
+  type CliSessionDiscoveryResult,
+  type CliSessionListItem,
+  type CliSessionRef,
+  getCliSessionIndexKey,
+  isCliRuntimeAvailable,
+} from '../../core/cli-runtime'
+
+export type CliSessionListSectionProps = {
+  discoveryResult?: CliSessionDiscoveryResult
+  loading: boolean
+  currentRef?: CliSessionRef
+  onSelect: (ref: CliSessionRef) => void
+  onTogglePinned: (ref: CliSessionRef, pinned: boolean) => void
+  /**
+   * Requests the confirmation flow that may forget YOLO-owned metadata.
+   * The receiver must confirm before calling CliSessionService.removeOverlay.
+   */
+  onRequestForgetOverlay: (ref: CliSessionRef) => void
+  onRetryProvider: (runtimeId: CliRuntimeId) => void
+}
+
+const getRuntimeLabelKey = (runtimeId: CliRuntimeId): string =>
+  runtimeId === 'claude-code'
+    ? 'sidebar.runtimeSelector.claudeCodeLabel'
+    : 'sidebar.runtimeSelector.codexLabel'
+
+const RuntimeBadge = ({ runtimeId }: { runtimeId: CliRuntimeId }) => {
+  const { t } = useLanguage()
+
+  return (
+    <span
+      className={`yolo-cli-session-list__runtime-badge yolo-cli-session-list__runtime-badge--${runtimeId}`}
+      data-runtime-id={runtimeId}
+    >
+      <span className="yolo-cli-session-list__runtime-icon" aria-hidden="true">
+        {runtimeId === 'claude-code' ? (
+          <Asterisk size={11} strokeWidth={2.2} />
+        ) : (
+          <SquareTerminal size={11} strokeWidth={2.2} />
+        )}
+      </span>
+      {t(getRuntimeLabelKey(runtimeId))}
+    </span>
+  )
+}
+
+const CliSessionRow = ({
+  session,
+  isCurrent,
+  onSelect,
+  onTogglePinned,
+  onRequestForgetOverlay,
+}: {
+  session: CliSessionListItem
+  isCurrent: boolean
+  onSelect: (ref: CliSessionRef) => void
+  onTogglePinned: (ref: CliSessionRef, pinned: boolean) => void
+  onRequestForgetOverlay: (ref: CliSessionRef) => void
+}) => {
+  const { t } = useLanguage()
+  const sessionKey = getCliSessionIndexKey(session.ref)
+  const pinLabel = t(
+    session.isPinned ? 'sidebar.cliSessions.unpin' : 'sidebar.cliSessions.pin',
+  )
+
+  return (
+    <li
+      className={`yolo-cli-session-list__item${isCurrent ? ' is-current' : ''}`}
+      data-session-key={sessionKey}
+    >
+      <button
+        type="button"
+        className="yolo-cli-session-list__select"
+        data-action="select"
+        aria-current={isCurrent ? 'true' : undefined}
+        onClick={() => onSelect(session.ref)}
+      >
+        <span className="yolo-cli-session-list__heading">
+          <RuntimeBadge runtimeId={session.ref.runtimeId} />
+          {isCurrent ? (
+            <span className="yolo-cli-session-list__current-badge">
+              {t('sidebar.cliSessions.current')}
+            </span>
+          ) : null}
+        </span>
+        <span className="yolo-cli-session-list__title">{session.title}</span>
+        {session.preview ? (
+          <span className="yolo-cli-session-list__preview">
+            {session.preview}
+          </span>
+        ) : null}
+      </button>
+
+      <span className="yolo-cli-session-list__actions">
+        <button
+          type="button"
+          className={`clickable-icon yolo-cli-session-list__action yolo-cli-session-list__pin${
+            session.isPinned ? ' is-pinned' : ''
+          }`}
+          data-action="toggle-pin"
+          aria-label={pinLabel}
+          title={pinLabel}
+          aria-pressed={session.isPinned}
+          onClick={() => onTogglePinned(session.ref, !session.isPinned)}
+        >
+          {session.isPinned ? (
+            <PinOff size={14} aria-hidden="true" />
+          ) : (
+            <Pin size={14} aria-hidden="true" />
+          )}
+        </button>
+        <button
+          type="button"
+          className="clickable-icon yolo-cli-session-list__action yolo-cli-session-list__forget"
+          data-action="request-forget-overlay"
+          aria-label={t('sidebar.cliSessions.forgetFromYolo')}
+          title={t('sidebar.cliSessions.forgetFromYolo')}
+          onClick={() => onRequestForgetOverlay(session.ref)}
+        >
+          <Unlink size={14} aria-hidden="true" />
+        </button>
+      </span>
+    </li>
+  )
+}
+
+export function CliSessionListSection({
+  discoveryResult,
+  loading,
+  currentRef,
+  onSelect,
+  onTogglePinned,
+  onRequestForgetOverlay,
+  onRetryProvider,
+}: CliSessionListSectionProps) {
+  const { t } = useLanguage()
+
+  if (!isCliRuntimeAvailable()) {
+    return null
+  }
+
+  const sessions = discoveryResult?.sessions ?? []
+  const errors = discoveryResult?.errors ?? {}
+  const currentKey = currentRef ? getCliSessionIndexKey(currentRef) : undefined
+  const hasErrors = CLI_RUNTIME_IDS.some((runtimeId) => errors[runtimeId])
+
+  return (
+    <section
+      className="yolo-cli-session-list"
+      aria-label={t('sidebar.cliSessions.sectionLabel')}
+      aria-busy={loading}
+    >
+      <div className="yolo-cli-session-list__header">
+        <h3 className="yolo-cli-session-list__section-title">
+          {t('sidebar.cliSessions.title')}
+        </h3>
+        {loading && sessions.length > 0 ? (
+          <LoaderCircle
+            className="yolo-cli-session-list__refresh-spinner"
+            size={13}
+            aria-label={t('sidebar.cliSessions.loading')}
+          />
+        ) : null}
+      </div>
+
+      {hasErrors ? (
+        <div className="yolo-cli-session-list__errors">
+          {CLI_RUNTIME_IDS.map((runtimeId) => {
+            const error = errors[runtimeId]
+            if (!error) return null
+            const provider = t(getRuntimeLabelKey(runtimeId))
+
+            return (
+              <div
+                key={runtimeId}
+                className="yolo-cli-session-list__error"
+                data-runtime-id={runtimeId}
+                role="alert"
+              >
+                <span className="yolo-cli-session-list__error-copy">
+                  <span className="yolo-cli-session-list__error-provider">
+                    {provider}
+                  </span>
+                  <span className="yolo-cli-session-list__error-message">
+                    {error}
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  className="yolo-cli-session-list__retry"
+                  data-action="retry-provider"
+                  data-runtime-id={runtimeId}
+                  aria-label={t('sidebar.cliSessions.retryProvider').replace(
+                    '{provider}',
+                    provider,
+                  )}
+                  onClick={() => onRetryProvider(runtimeId)}
+                >
+                  <RefreshCw size={12} aria-hidden="true" />
+                  {t('common.retry')}
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      ) : null}
+
+      {loading && sessions.length === 0 ? (
+        <div className="yolo-cli-session-list__state" role="status">
+          <LoaderCircle
+            className="yolo-cli-session-list__state-spinner"
+            size={16}
+            aria-hidden="true"
+          />
+          {t('sidebar.cliSessions.loading')}
+        </div>
+      ) : sessions.length > 0 ? (
+        <ul className="yolo-cli-session-list__items">
+          {sessions.map((session) => {
+            const sessionKey = getCliSessionIndexKey(session.ref)
+            return (
+              <CliSessionRow
+                key={sessionKey}
+                session={session}
+                isCurrent={sessionKey === currentKey}
+                onSelect={onSelect}
+                onTogglePinned={onTogglePinned}
+                onRequestForgetOverlay={onRequestForgetOverlay}
+              />
+            )
+          })}
+        </ul>
+      ) : !hasErrors ? (
+        <div className="yolo-cli-session-list__state">
+          {t('sidebar.cliSessions.empty')}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/src/core/cli-runtime/session-service.test.ts
+++ b/src/core/cli-runtime/session-service.test.ts
@@ -1,14 +1,14 @@
 import type {
-  CliRuntime,
-  CliRuntimeEventListener,
-  CliSessionMetadata,
-} from './types'
-import type {
   CliSessionIndexEntry,
   CliSessionIndexStore,
 } from './session-index'
 import { getCliSessionIndexKey } from './session-index'
 import { CliSessionService } from './session-service'
+import type {
+  CliRuntime,
+  CliRuntimeEventListener,
+  CliSessionMetadata,
+} from './types'
 
 class MemoryIndex implements CliSessionIndexStore {
   entries = new Map<string, CliSessionIndexEntry>()
@@ -88,8 +88,13 @@ describe('CliSessionService', () => {
 
     await expect(service.listSessions()).resolves.toMatchObject({
       sessions: [
-        { title: 'Codex', isPinned: true, assistantId: 'assistant-1' },
-        { title: 'Claude', isPinned: false },
+        {
+          title: 'Codex',
+          isPinned: true,
+          hasOverlay: true,
+          assistantId: 'assistant-1',
+        },
+        { title: 'Claude', isPinned: false, hasOverlay: false },
       ],
       errors: {},
     })
@@ -98,7 +103,10 @@ describe('CliSessionService', () => {
   it('keeps one provider failure isolated from the other provider list', async () => {
     const service = new CliSessionService({
       runtimes: [
-        runtime({ runtimeId: 'claude-code', listError: new Error('missing claude') }),
+        runtime({
+          runtimeId: 'claude-code',
+          listError: new Error('missing claude'),
+        }),
         runtime({
           runtimeId: 'codex',
           sessions: [

--- a/src/core/cli-runtime/session-service.ts
+++ b/src/core/cli-runtime/session-service.ts
@@ -1,3 +1,9 @@
+import {
+  type CliSessionIndexEntry,
+  type CliSessionIndexStore,
+  createCliSessionIndexEntry,
+  getCliSessionIndexKey,
+} from './session-index'
 import type {
   CliRuntime,
   CliRuntimeId,
@@ -5,14 +11,9 @@ import type {
   CliSessionMetadata,
   CliSessionRef,
 } from './types'
-import {
-  createCliSessionIndexEntry,
-  type CliSessionIndexEntry,
-  type CliSessionIndexStore,
-  getCliSessionIndexKey,
-} from './session-index'
 
 export type CliSessionListItem = CliSessionMetadata & {
+  hasOverlay: boolean
   assistantId?: string
   lastOpenedAt?: number
   isPinned: boolean
@@ -37,6 +38,7 @@ const mergeOverlay = (
   overlay: CliSessionIndexEntry | undefined,
 ): CliSessionListItem => ({
   ...metadata,
+  hasOverlay: overlay !== undefined,
   ...(overlay?.assistantId ? { assistantId: overlay.assistantId } : {}),
   ...(overlay?.lastOpenedAt !== undefined
     ? { lastOpenedAt: overlay.lastOpenedAt }
@@ -150,8 +152,10 @@ export class CliSessionService {
       createCliSessionIndexEntry({
         runtimeId: ref.runtimeId,
         nativeSessionId: ref.nativeSessionId,
-        ...(ref.sessionPathHint ?? existing?.sessionPathHint
-          ? { sessionPathHint: ref.sessionPathHint ?? existing?.sessionPathHint }
+        ...((ref.sessionPathHint ?? existing?.sessionPathHint)
+          ? {
+              sessionPathHint: ref.sessionPathHint ?? existing?.sessionPathHint,
+            }
           : {}),
         ...(assistantId ? { assistantId } : {}),
         ...(existing?.lastOpenedAt !== undefined
@@ -177,8 +181,10 @@ export class CliSessionService {
       createCliSessionIndexEntry({
         runtimeId: ref.runtimeId,
         nativeSessionId: ref.nativeSessionId,
-        ...(ref.sessionPathHint ?? existing?.sessionPathHint
-          ? { sessionPathHint: ref.sessionPathHint ?? existing?.sessionPathHint }
+        ...((ref.sessionPathHint ?? existing?.sessionPathHint)
+          ? {
+              sessionPathHint: ref.sessionPathHint ?? existing?.sessionPathHint,
+            }
           : {}),
         ...(existing?.assistantId ? { assistantId: existing.assistantId } : {}),
         ...(existing?.lastOpenedAt !== undefined

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -78,6 +78,17 @@ export const en: TranslationKeys = {
       codexLabel: 'Codex',
       codexDescription: 'Codex on this device',
     },
+    cliSessions: {
+      sectionLabel: 'CLI sessions',
+      title: 'Local CLI sessions',
+      loading: 'Loading CLI sessions…',
+      empty: 'No Claude Code or Codex sessions found',
+      current: 'Current',
+      pin: 'Pin in YOLO',
+      unpin: 'Unpin in YOLO',
+      forgetFromYolo: 'Forget from YOLO',
+      retryProvider: 'Retry {provider}',
+    },
     chatList: {
       searchPlaceholder: 'Search conversations',
       empty: 'No conversations',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -94,6 +94,17 @@ export const it: DeepPartial<TranslationKeys> = {
       codexLabel: 'Codex',
       codexDescription: 'Codex su questo dispositivo',
     },
+    cliSessions: {
+      sectionLabel: 'Sessioni CLI',
+      title: 'Sessioni CLI locali',
+      loading: 'Caricamento delle sessioni CLI…',
+      empty: 'Nessuna sessione Claude Code o Codex trovata',
+      current: 'Attuale',
+      pin: 'Fissa in YOLO',
+      unpin: 'Rimuovi il fissaggio in YOLO',
+      forgetFromYolo: 'Dimentica da YOLO',
+      retryProvider: 'Riprova {provider}',
+    },
     chatList: {
       searchPlaceholder: 'Cerca conversazioni',
       empty: 'Nessuna conversazione',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -78,6 +78,17 @@ export const zh: TranslationKeys = {
       codexLabel: 'Codex',
       codexDescription: '本机 Codex 运行时',
     },
+    cliSessions: {
+      sectionLabel: 'CLI 会话',
+      title: '本机 CLI 会话',
+      loading: '正在加载 CLI 会话…',
+      empty: '未找到 Claude Code 或 Codex 会话',
+      current: '当前',
+      pin: '在 YOLO 中置顶',
+      unpin: '在 YOLO 中取消置顶',
+      forgetFromYolo: '从 YOLO 中移除记录',
+      retryProvider: '重试 {provider}',
+    },
     chatList: {
       searchPlaceholder: '搜索聊天记录',
       empty: '暂无聊天记录',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -87,6 +87,17 @@ export type TranslationKeys = {
       codexLabel: string
       codexDescription: string
     }
+    cliSessions: {
+      sectionLabel: string
+      title: string
+      loading: string
+      empty: string
+      current: string
+      pin: string
+      unpin: string
+      forgetFromYolo: string
+      retryProvider: string
+    }
     chatList?: {
       searchPlaceholder?: string
       empty?: string

--- a/src/styles/chat/cli-session-list.css
+++ b/src/styles/chat/cli-session-list.css
@@ -1,0 +1,291 @@
+.yolo-cli-session-list {
+  --yolo-cli-session-border: color-mix(
+    in srgb,
+    var(--background-modifier-border) 65%,
+    transparent
+  );
+
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  border-top: 1px solid var(--yolo-cli-session-border);
+}
+
+.yolo-cli-session-list__header {
+  display: flex;
+  min-height: 30px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 10px 2px;
+  color: var(--text-muted);
+}
+
+.yolo-cli-session-list__section-title {
+  margin: 0;
+  color: inherit;
+  font-size: var(--font-ui-smaller);
+  font-weight: var(--font-semibold);
+  line-height: 1.3;
+  letter-spacing: 0.02em;
+}
+
+.yolo-cli-session-list__refresh-spinner,
+.yolo-cli-session-list__state-spinner {
+  flex: 0 0 auto;
+  animation: yolo-cli-session-list-spin 850ms linear infinite;
+}
+
+.yolo-cli-session-list__errors {
+  display: grid;
+  gap: 4px;
+  padding: 4px 8px 6px;
+}
+
+.yolo-cli-session-list__error {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 1px solid color-mix(in srgb, var(--color-red) 24%, transparent);
+  border-radius: var(--radius-s);
+  background: color-mix(in srgb, var(--color-red) 7%, transparent);
+}
+
+.yolo-cli-session-list__error-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.yolo-cli-session-list__error-provider {
+  color: var(--text-normal);
+  font-size: 11px;
+  font-weight: var(--font-semibold);
+  line-height: 1.25;
+}
+
+.yolo-cli-session-list__error-message {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+button.yolo-cli-session-list__retry {
+  display: inline-flex;
+  min-height: 24px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border: 0;
+  border-radius: var(--radius-s);
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1;
+}
+
+button.yolo-cli-session-list__retry:is(:hover, :focus-visible) {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+.yolo-cli-session-list__items {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  margin: 0;
+  padding: 0 0 4px;
+  list-style: none;
+}
+
+.yolo-cli-session-list__item {
+  position: relative;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.yolo-cli-session-list__item:is(:hover, :focus-within),
+.yolo-cli-session-list__item.is-current {
+  background: color-mix(
+    in srgb,
+    var(--background-modifier-hover) 92%,
+    transparent
+  );
+}
+
+button.yolo-cli-session-list__select {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  min-height: 62px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  margin: 0;
+  padding: 7px 70px 7px 10px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-normal);
+  font: inherit;
+  text-align: left;
+}
+
+button.yolo-cli-session-list__select:is(:hover, :focus-visible) {
+  background: transparent;
+  box-shadow: none;
+}
+
+button.yolo-cli-session-list__select:focus-visible {
+  outline: 2px solid
+    color-mix(in srgb, var(--interactive-accent) 52%, transparent);
+  outline-offset: -2px;
+}
+
+.yolo-cli-session-list__heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+}
+
+.yolo-cli-session-list__runtime-badge,
+.yolo-cli-session-list__current-badge {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 5px;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: var(--font-semibold);
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.yolo-cli-session-list__runtime-badge--claude-code {
+  background: color-mix(in srgb, var(--color-orange) 15%, transparent);
+  color: color-mix(in srgb, var(--color-orange) 82%, var(--text-normal));
+}
+
+.yolo-cli-session-list__runtime-badge--codex {
+  background: color-mix(in srgb, var(--color-cyan) 14%, transparent);
+  color: color-mix(in srgb, var(--color-cyan) 82%, var(--text-normal));
+}
+
+.yolo-cli-session-list__current-badge {
+  background: color-mix(in srgb, var(--color-green) 13%, transparent);
+  color: var(--color-green);
+}
+
+.yolo-cli-session-list__runtime-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.yolo-cli-session-list__title,
+.yolo-cli-session-list__preview {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.yolo-cli-session-list__title {
+  font-size: var(--font-ui-small);
+  font-weight: var(--font-medium);
+  line-height: 1.35;
+}
+
+.yolo-cli-session-list__preview {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+  line-height: 1.35;
+}
+
+.yolo-cli-session-list__actions {
+  position: absolute;
+  top: 50%;
+  right: 7px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  transform: translateY(-50%);
+}
+
+button.yolo-cli-session-list__action {
+  width: 26px;
+  height: 26px;
+  padding: 5px;
+  border: 0;
+  border-radius: var(--radius-s);
+  background: color-mix(in srgb, var(--background-primary) 88%, transparent);
+  box-shadow: none;
+  color: var(--text-muted);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(3px);
+  transition:
+    opacity 120ms ease,
+    transform 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 120ms ease,
+    background-color 120ms ease;
+}
+
+button.yolo-cli-session-list__pin.is-pinned,
+.yolo-cli-session-list__item:is(:hover, :focus-within)
+  button.yolo-cli-session-list__action {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+}
+
+button.yolo-cli-session-list__pin.is-pinned {
+  color: var(--interactive-accent);
+}
+
+button.yolo-cli-session-list__action:is(:hover, :focus-visible) {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+button.yolo-cli-session-list__forget:is(:hover, :focus-visible) {
+  color: var(--color-orange);
+}
+
+.yolo-cli-session-list__state {
+  display: flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 10px;
+  color: var(--text-faint);
+  font-size: var(--font-ui-smaller);
+  text-align: center;
+}
+
+@keyframes yolo-cli-session-list-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .yolo-cli-session-list__refresh-spinner,
+  .yolo-cli-session-list__state-spinner,
+  button.yolo-cli-session-list__action {
+    animation: none;
+    transition: none;
+  }
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -25,6 +25,7 @@
 @import './chat/todo-list-panel.css';
 @import './chat/ask-user-question-panel.css';
 @import './chat/new-tab-action.css';
+@import './chat/cli-session-list.css';
 
 @import './panels/smart-space.css';
 @import './panels/quick-ask.css';

--- a/styles.css
+++ b/styles.css
@@ -20337,6 +20337,298 @@ button.yolo-todo-panel__icon-button svg {
   height: 100%;
 }
 
+.yolo-cli-session-list {
+  --yolo-cli-session-border: color-mix(
+    in srgb,
+    var(--background-modifier-border) 65%,
+    transparent
+  );
+
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  border-top: 1px solid var(--yolo-cli-session-border);
+}
+
+.yolo-cli-session-list__header {
+  display: flex;
+  min-height: 30px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 10px 2px;
+  color: var(--text-muted);
+}
+
+.yolo-cli-session-list__section-title {
+  margin: 0;
+  color: inherit;
+  font-size: var(--font-ui-smaller);
+  font-weight: var(--font-semibold);
+  line-height: 1.3;
+  letter-spacing: 0.02em;
+}
+
+.yolo-cli-session-list__refresh-spinner,
+.yolo-cli-session-list__state-spinner {
+  flex: 0 0 auto;
+  animation: yolo-cli-session-list-spin 850ms linear infinite;
+}
+
+.yolo-cli-session-list__errors {
+  display: grid;
+  gap: 4px;
+  padding: 4px 8px 6px;
+}
+
+.yolo-cli-session-list__error {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 1px solid color-mix(in srgb, var(--color-red) 24%, transparent);
+  border-radius: var(--radius-s);
+  background: color-mix(in srgb, var(--color-red) 7%, transparent);
+}
+
+.yolo-cli-session-list__error-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.yolo-cli-session-list__error-provider {
+  color: var(--text-normal);
+  font-size: 11px;
+  font-weight: var(--font-semibold);
+  line-height: 1.25;
+}
+
+.yolo-cli-session-list__error-message {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+button.yolo-cli-session-list__retry {
+  display: inline-flex;
+  min-height: 24px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border: 0;
+  border-radius: var(--radius-s);
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1;
+}
+
+button.yolo-cli-session-list__retry:is(:hover, :focus-visible) {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+.yolo-cli-session-list__items {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  margin: 0;
+  padding: 0 0 4px;
+  list-style: none;
+}
+
+.yolo-cli-session-list__item {
+  position: relative;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.yolo-cli-session-list__item:is(:hover, :focus-within),
+.yolo-cli-session-list__item.is-current {
+  background: color-mix(
+    in srgb,
+    var(--background-modifier-hover) 92%,
+    transparent
+  );
+}
+
+button.yolo-cli-session-list__select {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  min-height: 62px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  margin: 0;
+  padding: 7px 70px 7px 10px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-normal);
+  font: inherit;
+  text-align: left;
+}
+
+button.yolo-cli-session-list__select:is(:hover, :focus-visible) {
+  background: transparent;
+  box-shadow: none;
+}
+
+button.yolo-cli-session-list__select:focus-visible {
+  outline: 2px solid
+    color-mix(in srgb, var(--interactive-accent) 52%, transparent);
+  outline-offset: -2px;
+}
+
+.yolo-cli-session-list__heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+}
+
+.yolo-cli-session-list__runtime-badge,
+.yolo-cli-session-list__current-badge {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 5px;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: var(--font-semibold);
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.yolo-cli-session-list__runtime-badge--claude-code {
+  background: color-mix(in srgb, var(--color-orange) 15%, transparent);
+  color: color-mix(in srgb, var(--color-orange) 82%, var(--text-normal));
+}
+
+.yolo-cli-session-list__runtime-badge--codex {
+  background: color-mix(in srgb, var(--color-cyan) 14%, transparent);
+  color: color-mix(in srgb, var(--color-cyan) 82%, var(--text-normal));
+}
+
+.yolo-cli-session-list__current-badge {
+  background: color-mix(in srgb, var(--color-green) 13%, transparent);
+  color: var(--color-green);
+}
+
+.yolo-cli-session-list__runtime-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.yolo-cli-session-list__title,
+.yolo-cli-session-list__preview {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.yolo-cli-session-list__title {
+  font-size: var(--font-ui-small);
+  font-weight: var(--font-medium);
+  line-height: 1.35;
+}
+
+.yolo-cli-session-list__preview {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+  line-height: 1.35;
+}
+
+.yolo-cli-session-list__actions {
+  position: absolute;
+  top: 50%;
+  right: 7px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  transform: translateY(-50%);
+}
+
+button.yolo-cli-session-list__action {
+  width: 26px;
+  height: 26px;
+  padding: 5px;
+  border: 0;
+  border-radius: var(--radius-s);
+  background: color-mix(in srgb, var(--background-primary) 88%, transparent);
+  box-shadow: none;
+  color: var(--text-muted);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(3px);
+  transition:
+    opacity 120ms ease,
+    transform 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 120ms ease,
+    background-color 120ms ease;
+}
+
+button.yolo-cli-session-list__pin.is-pinned,
+.yolo-cli-session-list__item:is(:hover, :focus-within)
+  button.yolo-cli-session-list__action {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+}
+
+button.yolo-cli-session-list__pin.is-pinned {
+  color: var(--interactive-accent);
+}
+
+button.yolo-cli-session-list__action:is(:hover, :focus-visible) {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+button.yolo-cli-session-list__forget:is(:hover, :focus-visible) {
+  color: var(--color-orange);
+}
+
+.yolo-cli-session-list__state {
+  display: flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 10px;
+  color: var(--text-faint);
+  font-size: var(--font-ui-smaller);
+  text-align: center;
+}
+
+@keyframes yolo-cli-session-list-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .yolo-cli-session-list__refresh-spinner,
+  .yolo-cli-session-list__state-spinner,
+  button.yolo-cli-session-list__action {
+    animation: none;
+    transition: none;
+  }
+}
+
 /* Custom continue inline panel */
 
 .yolo-smart-space-overlay-host {


### PR DESCRIPTION
## Summary
- add a desktop-only controlled section for Claude Code and Codex native sessions
- show provider titles/previews, runtime badges, current/pinned state, isolated provider errors, and retry
- expose only YOLO overlay pin/forget actions; never offer native transcript deletion
- distinguish provider-only discoveries from sessions that actually have a YOLO overlay

## Verification
- focused session UI/service: 11 tests
- `npm run type:check`
- `npm run styles:build`
- focused ESLint/Prettier/diff-check