### PR TITLE
feat(cli-runtime): 派生 Claude 本地技能插件缓存

### DIFF
--- a/src/core/cli-runtime/claude/index.ts
+++ b/src/core/cli-runtime/claude/index.ts
@@ -1,3 +1,4 @@
 export * from './ClaudeCliRuntime'
+export * from './plugin-cache'
 export * from './process'
 export * from './types'

--- a/src/core/cli-runtime/claude/plugin-cache.test.ts
+++ b/src/core/cli-runtime/claude/plugin-cache.test.ts
@@ -504,4 +504,21 @@ describe('ClaudeLocalPluginCache', () => {
       nonFilesystemCache.resolvePluginPaths({ enabledSkillNames: ['alpha'] }),
     ).rejects.toThrow(/filesystem vault/)
   })
+
+  it('rejects a relative filesystem root before writing cache data', async () => {
+    const adapter = new MemoryFileSystemAdapter('relative/vault')
+    const cache = new ClaudeLocalPluginCache({
+      app: createApp(adapter),
+      getSettings: () => undefined,
+      getSkillPackageSource: async () =>
+        source('alpha', [
+          { kind: 'builtin', relativePath: 'SKILL.md', content: 'alpha' },
+        ]),
+    })
+
+    await expect(
+      cache.resolvePluginPaths({ enabledSkillNames: ['alpha'] }),
+    ).rejects.toThrow(/must be absolute/)
+    expect(await adapter.exists('YOLO/.derived')).toBe(false)
+  })
 })

--- a/src/core/cli-runtime/claude/plugin-cache.test.ts
+++ b/src/core/cli-runtime/claude/plugin-cache.test.ts
@@ -1,0 +1,424 @@
+import {
+  type App,
+  FileSystemAdapter,
+  type ListedFiles,
+  Platform,
+  type Stat,
+} from 'obsidian'
+
+import type { LiteSkillPackageSource } from '../../skills/liteSkills'
+
+import { ClaudeLocalPluginCache } from './plugin-cache'
+
+const CONFIG_DIR = ['.', 'obsidian'].join('')
+
+const encode = (value: string): ArrayBuffer =>
+  new TextEncoder().encode(value).buffer
+
+class MemoryFileSystemAdapter extends FileSystemAdapter {
+  private readonly files = new Map<string, string | ArrayBuffer>()
+  private readonly folders = new Set<string>()
+  readonly writeBinaryCalls: string[] = []
+
+  constructor(private readonly basePath = '/vault') {
+    super()
+  }
+
+  getName(): string {
+    return 'memory'
+  }
+
+  getBasePath(): string {
+    return this.basePath
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return this.files.has(path) || this.folders.has(path)
+  }
+
+  async stat(path: string): Promise<Stat | null> {
+    const value = this.files.get(path)
+    if (value !== undefined) {
+      return {
+        type: 'file',
+        ctime: 0,
+        mtime: 0,
+        size: typeof value === 'string' ? value.length : value.byteLength,
+      }
+    }
+    if (this.folders.has(path)) {
+      return { type: 'folder', ctime: 0, mtime: 0, size: 0 }
+    }
+    return null
+  }
+
+  async list(path: string): Promise<ListedFiles> {
+    const prefix = path ? `${path}/` : ''
+    const directChild = (candidate: string): boolean =>
+      candidate.startsWith(prefix) &&
+      candidate !== path &&
+      !candidate.slice(prefix.length).includes('/')
+    return {
+      files: [...this.files.keys()].filter(directChild).sort(),
+      folders: [...this.folders].filter(directChild).sort(),
+    }
+  }
+
+  async read(path: string): Promise<string> {
+    const value = this.files.get(path)
+    if (typeof value !== 'string') throw new Error(`Not text: ${path}`)
+    return value
+  }
+
+  async readBinary(path: string): Promise<ArrayBuffer> {
+    const value = this.files.get(path)
+    if (!(value instanceof ArrayBuffer)) throw new Error(`Not binary: ${path}`)
+    return value.slice(0)
+  }
+
+  async write(path: string, value: string): Promise<void> {
+    await this.ensureParent(path)
+    this.files.set(path, value)
+  }
+
+  async writeBinary(path: string, value: ArrayBuffer): Promise<void> {
+    await this.ensureParent(path)
+    this.files.set(path, value.slice(0))
+    this.writeBinaryCalls.push(path)
+  }
+
+  async mkdir(path: string): Promise<void> {
+    const segments = path.split('/').filter(Boolean)
+    let current = ''
+    for (const segment of segments) {
+      current = current ? `${current}/${segment}` : segment
+      this.folders.add(current)
+    }
+  }
+
+  async remove(path: string): Promise<void> {
+    this.files.delete(path)
+  }
+
+  async rmdir(path: string, recursive: boolean): Promise<void> {
+    const prefix = `${path}/`
+    if (
+      !recursive &&
+      ([...this.files.keys()].some((entry) => entry.startsWith(prefix)) ||
+        [...this.folders].some((entry) => entry.startsWith(prefix)))
+    ) {
+      throw new Error(`Directory is not empty: ${path}`)
+    }
+    for (const file of [...this.files.keys()]) {
+      if (file.startsWith(prefix)) this.files.delete(file)
+    }
+    for (const folder of [...this.folders]) {
+      if (folder === path || folder.startsWith(prefix)) {
+        this.folders.delete(folder)
+      }
+    }
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    if (await this.exists(to)) throw new Error(`Target exists: ${to}`)
+    const move = (path: string) =>
+      path === from ? to : `${to}${path.slice(from.length)}`
+    for (const [path, value] of [...this.files]) {
+      if (path === from || path.startsWith(`${from}/`)) {
+        this.files.delete(path)
+        this.files.set(move(path), value)
+      }
+    }
+    for (const path of [...this.folders]) {
+      if (path === from || path.startsWith(`${from}/`)) {
+        this.folders.delete(path)
+        this.folders.add(move(path))
+      }
+    }
+  }
+
+  async seedBinary(path: string, value: ArrayBuffer): Promise<void> {
+    await this.ensureParent(path)
+    this.files.set(path, value.slice(0))
+  }
+
+  async seedText(path: string, value: string): Promise<void> {
+    await this.write(path, value)
+  }
+
+  getBytes(path: string): number[] {
+    const value = this.files.get(path)
+    if (!(value instanceof ArrayBuffer)) throw new Error(`Not binary: ${path}`)
+    return [...new Uint8Array(value)]
+  }
+
+  private async ensureParent(path: string): Promise<void> {
+    const index = path.lastIndexOf('/')
+    if (index > 0) await this.mkdir(path.slice(0, index))
+  }
+}
+
+const createApp = (adapter: object): App =>
+  ({
+    vault: {
+      adapter,
+      configDir: CONFIG_DIR,
+    },
+  }) as unknown as App
+
+const source = (
+  name: string,
+  resources: LiteSkillPackageSource['resources'],
+): LiteSkillPackageSource => ({
+  entry: {
+    name,
+    description: `${name} description`,
+    mode: 'lazy',
+    path: `source://${name}/SKILL.md`,
+  },
+  resources,
+})
+
+describe('ClaudeLocalPluginCache', () => {
+  const originalDesktop = Platform.isDesktop
+
+  afterEach(() => {
+    Platform.isDesktop = originalDesktop
+  })
+
+  it('materializes enabled packages completely and deterministically reuses them', async () => {
+    const adapter = new MemoryFileSystemAdapter()
+    await adapter.seedBinary(
+      'sources/alpha/SKILL.md',
+      encode('---\nname: alpha\ndescription: Alpha\n---\n'),
+    )
+    await adapter.seedBinary(
+      'sources/alpha/assets/nested/icon.bin',
+      new Uint8Array([0, 255, 1, 128]).buffer,
+    )
+    const packages = new Map([
+      [
+        'alpha',
+        source('alpha', [
+          {
+            kind: 'vault',
+            relativePath: 'SKILL.md',
+            path: 'sources/alpha/SKILL.md',
+          },
+          {
+            kind: 'vault',
+            relativePath: 'assets/nested/icon.bin',
+            path: 'sources/alpha/assets/nested/icon.bin',
+          },
+        ]),
+      ],
+      [
+        'beta',
+        source('beta', [
+          {
+            kind: 'builtin',
+            relativePath: 'SKILL.md',
+            content: '---\nname: beta\ndescription: Beta\n---\n',
+          },
+        ]),
+      ],
+    ])
+    const getSkillPackageSource = jest.fn(
+      async ({ name }: { name?: string }) =>
+        name ? (packages.get(name) ?? null) : null,
+    )
+    const cache = new ClaudeLocalPluginCache({
+      app: createApp(adapter),
+      getSettings: () => ({ yolo: { baseDir: 'Custom' } }),
+      getSkillPackageSource,
+    })
+
+    const first = await cache.resolvePluginPaths({
+      assistantId: 'assistant-1',
+      enabledSkillNames: ['beta', 'alpha'],
+    })
+    const writesAfterFirst = adapter.writeBinaryCalls.length
+    const second = await cache.resolvePluginPaths({
+      enabledSkillNames: ['alpha', 'beta', 'alpha'],
+    })
+
+    expect(second).toEqual(first)
+    expect(first[0]).toMatch(
+      /^\/vault\/Custom\/\.derived\/claude-plugins\/[a-f0-9]{64}$/,
+    )
+    expect(adapter.writeBinaryCalls).toHaveLength(writesAfterFirst)
+    const relativeRoot = first[0].slice('/vault/'.length)
+    expect(
+      adapter.getBytes(`${relativeRoot}/skills/alpha/assets/nested/icon.bin`),
+    ).toEqual([0, 255, 1, 128])
+    expect(
+      new TextDecoder().decode(
+        new Uint8Array(
+          await adapter.readBinary(`${relativeRoot}/skills/beta/SKILL.md`),
+        ),
+      ),
+    ).toContain('name: beta')
+    expect(
+      JSON.parse(
+        await adapter.read(`${relativeRoot}/.claude-plugin/plugin.json`),
+      ),
+    ).toMatchObject({
+      name: expect.stringMatching(/^yolo-enabled-skills-[a-f0-9]{12}$/),
+      version: '1.0.0',
+      description: expect.any(String),
+    })
+    expect(
+      getSkillPackageSource.mock.calls.map(([input]) => input.name),
+    ).toEqual(['alpha', 'beta', 'alpha', 'beta'])
+  })
+
+  it('resolves only enabled names and reports all missing enabled skills', async () => {
+    const adapter = new MemoryFileSystemAdapter()
+    const getSkillPackageSource = jest.fn(
+      async ({ name }: { name?: string }) =>
+        name === 'alpha'
+          ? source('alpha', [
+              {
+                kind: 'builtin',
+                relativePath: 'SKILL.md',
+                content: 'alpha',
+              },
+            ])
+          : null,
+    )
+    const cache = new ClaudeLocalPluginCache({
+      app: createApp(adapter),
+      getSettings: () => undefined,
+      getSkillPackageSource,
+    })
+
+    await expect(
+      cache.resolvePluginPaths({
+        enabledSkillNames: ['missing-b', 'alpha', 'missing-a'],
+      }),
+    ).rejects.toThrow('missing-a, missing-b')
+    expect(
+      getSkillPackageSource.mock.calls.map(([input]) => input.name),
+    ).toEqual(['alpha', 'missing-a', 'missing-b'])
+  })
+
+  it.each([
+    ['traversal', ['SKILL.md', '../outside.md']],
+    [
+      'case-insensitive collision',
+      ['SKILL.md', 'docs/Guide.md', 'docs/guide.md'],
+    ],
+    ['file-directory collision', ['SKILL.md', 'docs', 'docs/guide.md']],
+  ])('rejects %s resource paths', async (_label, relativePaths) => {
+    const adapter = new MemoryFileSystemAdapter()
+    const cache = new ClaudeLocalPluginCache({
+      app: createApp(adapter),
+      getSettings: () => undefined,
+      getSkillPackageSource: async () =>
+        source(
+          'alpha',
+          relativePaths.map((relativePath) => ({
+            kind: 'builtin',
+            relativePath,
+            content: relativePath,
+          })) as unknown as LiteSkillPackageSource['resources'],
+        ),
+    })
+
+    await expect(
+      cache.resolvePluginPaths({ enabledSkillNames: ['alpha'] }),
+    ).rejects.toThrow(/Unsafe|collision/)
+  })
+
+  it('rejects a resolved package whose canonical name collides with the request', async () => {
+    const adapter = new MemoryFileSystemAdapter()
+    const cache = new ClaudeLocalPluginCache({
+      app: createApp(adapter),
+      getSettings: () => undefined,
+      getSkillPackageSource: async () =>
+        source('beta', [
+          { kind: 'builtin', relativePath: 'SKILL.md', content: 'beta' },
+        ]),
+    })
+
+    await expect(
+      cache.resolvePluginPaths({ enabledSkillNames: ['alpha'] }),
+    ).rejects.toThrow(/name collision/)
+  })
+
+  it('cleans only stale cache entries carrying a matching ownership marker', async () => {
+    const adapter = new MemoryFileSystemAdapter()
+    const staleHash = 'a'.repeat(64)
+    const unownedHash = 'b'.repeat(64)
+    const root = 'YOLO/.derived/claude-plugins'
+    await adapter.seedText(
+      `${root}/${staleHash}/.yolo-derived-plugin.json`,
+      `${JSON.stringify({ version: 1, contentHash: staleHash })}\n`,
+    )
+    await adapter.seedText(`${root}/${staleHash}/old.txt`, 'old')
+    await adapter.seedText(`${root}/${unownedHash}/keep.txt`, 'user data')
+    const cache = new ClaudeLocalPluginCache({
+      app: createApp(adapter),
+      getSettings: () => undefined,
+      getSkillPackageSource: async () =>
+        source('alpha', [
+          { kind: 'builtin', relativePath: 'SKILL.md', content: 'alpha' },
+        ]),
+    })
+
+    await cache.resolvePluginPaths({ enabledSkillNames: ['alpha'] })
+
+    expect(await adapter.exists(`${root}/${staleHash}`)).toBe(false)
+    expect(await adapter.exists(`${root}/${unownedHash}/keep.txt`)).toBe(true)
+  })
+
+  it('reads current settings on every call so base-directory changes take effect', async () => {
+    const adapter = new MemoryFileSystemAdapter()
+    let baseDir = 'First'
+    const seenBaseDirs: Array<string | undefined> = []
+    const cache = new ClaudeLocalPluginCache({
+      app: createApp(adapter),
+      getSettings: () => ({ yolo: { baseDir } }),
+      getSkillPackageSource: async ({ settings }) => {
+        seenBaseDirs.push(settings?.yolo?.baseDir)
+        return source('alpha', [
+          { kind: 'builtin', relativePath: 'SKILL.md', content: 'alpha' },
+        ])
+      },
+    })
+
+    const first = await cache.resolvePluginPaths({
+      enabledSkillNames: ['alpha'],
+    })
+    baseDir = 'Second'
+    const second = await cache.resolvePluginPaths({
+      enabledSkillNames: ['alpha'],
+    })
+
+    expect(first[0]).toContain('/vault/First/.derived/claude-plugins/')
+    expect(second[0]).toContain('/vault/Second/.derived/claude-plugins/')
+    expect(seenBaseDirs).toEqual(['First', 'Second'])
+  })
+
+  it('refuses mobile and non-filesystem vault adapters', async () => {
+    const filesystemCache = new ClaudeLocalPluginCache({
+      app: createApp(new MemoryFileSystemAdapter()),
+      getSettings: () => undefined,
+      getSkillPackageSource: async () => null,
+    })
+    Platform.isDesktop = false
+    await expect(
+      filesystemCache.resolvePluginPaths({ enabledSkillNames: ['alpha'] }),
+    ).rejects.toThrow(/only available on desktop/)
+
+    Platform.isDesktop = true
+    const nonFilesystemCache = new ClaudeLocalPluginCache({
+      app: createApp({}),
+      getSettings: () => undefined,
+      getSkillPackageSource: async () => null,
+    })
+    await expect(
+      nonFilesystemCache.resolvePluginPaths({ enabledSkillNames: ['alpha'] }),
+    ).rejects.toThrow(/filesystem vault/)
+  })
+})

--- a/src/core/cli-runtime/claude/plugin-cache.test.ts
+++ b/src/core/cli-runtime/claude/plugin-cache.test.ts
@@ -372,6 +372,89 @@ describe('ClaudeLocalPluginCache', () => {
     expect(await adapter.exists(`${root}/${unownedHash}/keep.txt`)).toBe(true)
   })
 
+  it('keeps every cache hash resolved during the current process lifetime', async () => {
+    const adapter = new MemoryFileSystemAdapter()
+    const cache = new ClaudeLocalPluginCache({
+      app: createApp(adapter),
+      getSettings: () => undefined,
+      getSkillPackageSource: async ({ name }) =>
+        name
+          ? source(name, [
+              {
+                kind: 'builtin',
+                relativePath: 'SKILL.md',
+                content: `skill:${name}`,
+              },
+            ])
+          : null,
+    })
+
+    const first = await cache.resolvePluginPaths({
+      enabledSkillNames: ['alpha'],
+    })
+    const second = await cache.resolvePluginPaths({
+      enabledSkillNames: ['beta'],
+    })
+
+    expect(second).not.toEqual(first)
+    expect(await adapter.exists(first[0].slice('/vault/'.length))).toBe(true)
+    expect(await adapter.exists(second[0].slice('/vault/'.length))).toBe(true)
+  })
+
+  it('cleans owned stale staging while preserving unowned staging', async () => {
+    const adapter = new MemoryFileSystemAdapter()
+    const ownedHash = 'c'.repeat(64)
+    const unownedHash = 'd'.repeat(64)
+    const root = 'YOLO/.derived/claude-plugins'
+    const ownedStaging = `${root}/.staging-${ownedHash}`
+    const unownedStaging = `${root}/.staging-${unownedHash}`
+    await adapter.seedText(
+      `${ownedStaging}/.yolo-derived-plugin.json`,
+      `${JSON.stringify({ version: 1, contentHash: ownedHash })}\n`,
+    )
+    await adapter.seedText(`${ownedStaging}/old.txt`, 'old')
+    await adapter.seedText(`${unownedStaging}/keep.txt`, 'user data')
+    const cache = new ClaudeLocalPluginCache({
+      app: createApp(adapter),
+      getSettings: () => undefined,
+      getSkillPackageSource: async () =>
+        source('alpha', [
+          { kind: 'builtin', relativePath: 'SKILL.md', content: 'alpha' },
+        ]),
+    })
+
+    await cache.resolvePluginPaths({ enabledSkillNames: ['alpha'] })
+
+    expect(await adapter.exists(ownedStaging)).toBe(false)
+    expect(await adapter.exists(`${unownedStaging}/keep.txt`)).toBe(true)
+  })
+
+  it('refuses to replace an unowned staging directory for the current hash', async () => {
+    const adapter = new MemoryFileSystemAdapter()
+    const cache = new ClaudeLocalPluginCache({
+      app: createApp(adapter),
+      getSettings: () => undefined,
+      getSkillPackageSource: async () =>
+        source('alpha', [
+          { kind: 'builtin', relativePath: 'SKILL.md', content: 'alpha' },
+        ]),
+    })
+    const [initialPath] = await cache.resolvePluginPaths({
+      enabledSkillNames: ['alpha'],
+    })
+    const targetDir = initialPath.slice('/vault/'.length)
+    const slashIndex = targetDir.lastIndexOf('/')
+    const hash = targetDir.slice(slashIndex + 1)
+    const stagingDir = `${targetDir.slice(0, slashIndex)}/.staging-${hash}`
+    await adapter.rmdir(targetDir, true)
+    await adapter.seedText(`${stagingDir}/keep.txt`, 'user data')
+
+    await expect(
+      cache.resolvePluginPaths({ enabledSkillNames: ['alpha'] }),
+    ).rejects.toThrow(/staging directory is not owned/)
+    expect(await adapter.read(`${stagingDir}/keep.txt`)).toBe('user data')
+  })
+
   it('reads current settings on every call so base-directory changes take effect', async () => {
     const adapter = new MemoryFileSystemAdapter()
     let baseDir = 'First'

--- a/src/core/cli-runtime/claude/plugin-cache.ts
+++ b/src/core/cli-runtime/claude/plugin-cache.ts
@@ -295,6 +295,10 @@ export class ClaudeLocalPluginCache {
     const targetDir = normalizePath(`${cacheRoot}/${hash}`)
     const stagingDir = normalizePath(`${cacheRoot}/.staging-${hash}`)
 
+    // Validate the host root and the derived vault path before the first
+    // cache write. A public cache instance must remain safe even when it is
+    // used without the higher-level runtime coordinator.
+    await this.toAbsolutePath(adapter, cacheRoot)
     await ensureDirectory(adapter, cacheRoot)
     if (await adapter.exists(targetDir)) {
       if (!(await isOwnedCacheEntry(adapter, targetDir, hash))) {

--- a/src/core/cli-runtime/claude/plugin-cache.ts
+++ b/src/core/cli-runtime/claude/plugin-cache.ts
@@ -204,6 +204,7 @@ export class ClaudeLocalPluginCache {
   private readonly app: App
   private readonly getSettings: ClaudeLocalPluginCacheOptions['getSettings']
   private readonly getSkillPackageSource: typeof getLiteSkillPackageSource
+  private readonly protectedHashes = new Map<string, Set<string>>()
   private writeQueue: Promise<void> = Promise.resolve()
 
   constructor(options: ClaudeLocalPluginCacheOptions) {
@@ -302,9 +303,22 @@ export class ClaudeLocalPluginCache {
         )
       }
     } else {
-      await removeDirectory(adapter, stagingDir)
+      if (await adapter.exists(stagingDir)) {
+        if (!(await isOwnedCacheEntry(adapter, stagingDir, hash))) {
+          throw new Error(
+            `Claude plugin staging directory is not owned by YOLO: ${stagingDir}`,
+          )
+        }
+        await removeDirectory(adapter, stagingDir)
+      }
       await ensureDirectory(adapter, stagingDir)
       try {
+        // Establish ownership before any other materialization write so only
+        // directories bearing this exact hash may ever be cleaned recursively.
+        await adapter.write(
+          normalizePath(`${stagingDir}/${CACHE_ENTRY_MARKER}`),
+          getMarker(hash),
+        )
         for (const resource of resources) {
           const targetPath = normalizePath(`${stagingDir}/${resource.path}`)
           await ensureParentDirectory(adapter, targetPath)
@@ -315,34 +329,45 @@ export class ClaudeLocalPluginCache {
         )
         await ensureParentDirectory(adapter, manifestPath)
         await adapter.write(manifestPath, getManifest(hash))
-        await adapter.write(
-          normalizePath(`${stagingDir}/${CACHE_ENTRY_MARKER}`),
-          getMarker(hash),
-        )
         await adapter.rename(stagingDir, targetDir)
       } finally {
-        await removeDirectory(adapter, stagingDir)
+        if (await isOwnedCacheEntry(adapter, stagingDir, hash)) {
+          await removeDirectory(adapter, stagingDir)
+        }
       }
     }
 
-    await this.cleanupOldEntries(adapter, cacheRoot, hash)
+    this.protectHash(cacheRoot, hash)
+    await this.cleanupOldEntries(adapter, cacheRoot)
     return [await this.toAbsolutePath(adapter, targetDir)]
+  }
+
+  private protectHash(cacheRoot: string, hash: string): void {
+    const hashes = this.protectedHashes.get(cacheRoot) ?? new Set<string>()
+    hashes.add(hash)
+    this.protectedHashes.set(cacheRoot, hashes)
   }
 
   private async cleanupOldEntries(
     adapter: DataAdapter,
     cacheRoot: string,
-    currentHash: string,
   ): Promise<void> {
+    const protectedHashes = this.protectedHashes.get(cacheRoot) ?? new Set()
     const listing = await adapter.list(cacheRoot)
     for (const folder of listing.folders) {
       const name = folder.slice(folder.lastIndexOf('/') + 1)
-      if (name === currentHash) continue
       if (name.startsWith('.staging-')) {
-        await removeDirectory(adapter, folder)
+        const stagingHash = name.slice('.staging-'.length)
+        if (
+          HASH_PATTERN.test(stagingHash) &&
+          (await isOwnedCacheEntry(adapter, folder, stagingHash))
+        ) {
+          await removeDirectory(adapter, folder)
+        }
         continue
       }
       if (
+        !protectedHashes.has(name) &&
         HASH_PATTERN.test(name) &&
         (await isOwnedCacheEntry(adapter, folder, name))
       ) {

--- a/src/core/cli-runtime/claude/plugin-cache.ts
+++ b/src/core/cli-runtime/claude/plugin-cache.ts
@@ -1,0 +1,371 @@
+import {
+  App,
+  type DataAdapter,
+  FileSystemAdapter,
+  Platform,
+  normalizePath,
+} from 'obsidian'
+
+import { getYoloBaseDir } from '../../paths/yoloPaths'
+import {
+  type LiteSkillPackageSource,
+  getLiteSkillPackageSource,
+} from '../../skills/liteSkills'
+import { validateSkillName } from '../../skills/skillValidation'
+
+import type { ClaudePluginPathInput, ClaudePluginPathProvider } from './types'
+
+const CACHE_RELATIVE_DIR = '.derived/claude-plugins'
+const CACHE_ENTRY_MARKER = '.yolo-derived-plugin.json'
+const CACHE_ENTRY_VERSION = 1
+const HASH_PATTERN = /^[a-f0-9]{64}$/
+
+export type ClaudePluginCacheSettings = {
+  yolo?: {
+    baseDir?: string
+  }
+}
+
+type MaterializedResource = {
+  path: string
+  bytes: ArrayBuffer
+}
+
+type ClaudeLocalPluginCacheOptions = {
+  app: App
+  getSettings: () => ClaudePluginCacheSettings | null | undefined
+  getSkillPackageSource?: typeof getLiteSkillPackageSource
+}
+
+const encodeUtf8 = (value: string): ArrayBuffer =>
+  new TextEncoder().encode(value).buffer
+
+const cloneArrayBuffer = (value: ArrayBuffer): ArrayBuffer =>
+  value.slice(0, value.byteLength)
+
+const ensureDirectory = async (
+  adapter: DataAdapter,
+  directory: string,
+): Promise<void> => {
+  const normalized = normalizePath(directory)
+  if (await adapter.exists(normalized)) {
+    const stat = await adapter.stat(normalized)
+    if (stat?.type !== 'folder') {
+      throw new Error(
+        `Claude plugin cache path is not a directory: ${normalized}`,
+      )
+    }
+    return
+  }
+
+  const slashIndex = normalized.lastIndexOf('/')
+  if (slashIndex > 0) {
+    await ensureDirectory(adapter, normalized.slice(0, slashIndex))
+  }
+  try {
+    await adapter.mkdir(normalized)
+  } catch (error) {
+    if (!(await adapter.exists(normalized))) {
+      throw error
+    }
+  }
+}
+
+const ensureParentDirectory = async (
+  adapter: DataAdapter,
+  path: string,
+): Promise<void> => {
+  const slashIndex = path.lastIndexOf('/')
+  if (slashIndex > 0) {
+    await ensureDirectory(adapter, path.slice(0, slashIndex))
+  }
+}
+
+const removeDirectory = async (
+  adapter: DataAdapter,
+  directory: string,
+): Promise<void> => {
+  if (!(await adapter.exists(directory))) return
+  const listing = await adapter.list(directory)
+  for (const file of listing.files) {
+    await adapter.remove(file)
+  }
+  for (const folder of listing.folders) {
+    await removeDirectory(adapter, folder)
+  }
+  await adapter.rmdir(directory, false)
+}
+
+const assertSafeResourcePath = (relativePath: string): string => {
+  if (
+    relativePath.length === 0 ||
+    relativePath.startsWith('/') ||
+    relativePath.startsWith('\\') ||
+    /^[A-Za-z]:/.test(relativePath)
+  ) {
+    throw new Error(`Unsafe Claude skill resource path: ${relativePath}`)
+  }
+
+  const segments = relativePath.split(/[\\/]/)
+  if (
+    segments.some(
+      (segment) =>
+        segment.length === 0 ||
+        segment === '.' ||
+        segment === '..' ||
+        segment.includes('\0'),
+    )
+  ) {
+    throw new Error(`Unsafe Claude skill resource path: ${relativePath}`)
+  }
+
+  return segments.join('/')
+}
+
+const assertNoPathCollisions = (paths: string[]): void => {
+  const normalized = paths.map((path) => path.toLowerCase())
+  const unique = new Set(normalized)
+  if (unique.size !== normalized.length) {
+    throw new Error(`Claude skill resource path collision: ${paths.join(', ')}`)
+  }
+  for (const path of unique) {
+    const segments = path.split('/')
+    for (let end = 1; end < segments.length; end += 1) {
+      if (!unique.has(segments.slice(0, end).join('/'))) continue
+      throw new Error(
+        `Claude skill resource path collision: ${paths.join(', ')}`,
+      )
+    }
+  }
+}
+
+const hashResources = async (
+  resources: MaterializedResource[],
+): Promise<string> => {
+  // eslint-disable-next-line import/no-nodejs-modules -- called only after desktop filesystem capability validation
+  const { createHash } = await import('node:crypto')
+  const hash = createHash('sha256')
+  hash.update(
+    JSON.stringify({
+      version: CACHE_ENTRY_VERSION,
+      resources: resources.map((resource) => ({
+        path: resource.path,
+        byteLength: resource.bytes.byteLength,
+      })),
+    }),
+  )
+  for (const resource of resources) {
+    hash.update(new Uint8Array(resource.bytes))
+  }
+  return hash.digest('hex')
+}
+
+const getManifest = (hash: string): string =>
+  `${JSON.stringify(
+    {
+      name: `yolo-enabled-skills-${hash.slice(0, 12)}`,
+      version: '1.0.0',
+      description: 'Derived YOLO skills enabled for this Assistant.',
+    },
+    null,
+    2,
+  )}\n`
+
+const getMarker = (hash: string): string =>
+  `${JSON.stringify({ version: CACHE_ENTRY_VERSION, contentHash: hash })}\n`
+
+const isOwnedCacheEntry = async (
+  adapter: DataAdapter,
+  directory: string,
+  expectedHash: string,
+): Promise<boolean> => {
+  const markerPath = normalizePath(`${directory}/${CACHE_ENTRY_MARKER}`)
+  if (!(await adapter.exists(markerPath))) return false
+  try {
+    const marker = JSON.parse(await adapter.read(markerPath)) as {
+      version?: unknown
+      contentHash?: unknown
+    }
+    return (
+      marker.version === CACHE_ENTRY_VERSION &&
+      marker.contentHash === expectedHash
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Materializes the Assistant's enabled YOLO skills as one derived local Claude
+ * plugin. Source packages remain the single truth; this cache is content
+ * addressed and rebuilt whenever their exact bytes change.
+ */
+export class ClaudeLocalPluginCache {
+  private readonly app: App
+  private readonly getSettings: ClaudeLocalPluginCacheOptions['getSettings']
+  private readonly getSkillPackageSource: typeof getLiteSkillPackageSource
+  private writeQueue: Promise<void> = Promise.resolve()
+
+  constructor(options: ClaudeLocalPluginCacheOptions) {
+    this.app = options.app
+    this.getSettings = options.getSettings
+    this.getSkillPackageSource =
+      options.getSkillPackageSource ?? getLiteSkillPackageSource
+  }
+
+  readonly resolvePluginPaths: ClaudePluginPathProvider = (input) =>
+    this.serialize(() => this.resolvePluginPathsUnlocked(input))
+
+  private serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.writeQueue.then(operation, operation)
+    this.writeQueue = result.then(
+      () => undefined,
+      () => undefined,
+    )
+    return result
+  }
+
+  private async resolvePluginPathsUnlocked(
+    input: ClaudePluginPathInput,
+  ): Promise<string[]> {
+    if (!Platform.isDesktop) {
+      throw new Error('Claude local plugin cache is only available on desktop')
+    }
+    const adapter = this.app.vault.adapter
+    if (!(adapter instanceof FileSystemAdapter)) {
+      throw new Error(
+        'Claude local plugin cache requires a desktop filesystem vault',
+      )
+    }
+
+    const enabledNames = [...new Set(input.enabledSkillNames)].sort()
+    if (enabledNames.length === 0) return []
+
+    const settings = this.getSettings() ?? undefined
+    const sources: LiteSkillPackageSource[] = []
+    const missingNames: string[] = []
+    for (const name of enabledNames) {
+      if (name !== name.trim() || validateSkillName(name).length > 0) {
+        throw new Error(`Invalid enabled YOLO skill name: ${name}`)
+      }
+      const source = await this.getSkillPackageSource({
+        app: this.app,
+        name,
+        settings,
+      })
+      if (!source) {
+        missingNames.push(name)
+        continue
+      }
+      if (source.entry.name !== name) {
+        throw new Error(
+          `YOLO skill name collision: requested "${name}", resolved "${source.entry.name}"`,
+        )
+      }
+      sources.push(source)
+    }
+    if (missingNames.length > 0) {
+      throw new Error(
+        `Enabled YOLO skills are missing: ${missingNames.join(', ')}`,
+      )
+    }
+
+    const resources: MaterializedResource[] = []
+    for (const source of sources) {
+      for (const resource of source.resources) {
+        const relativePath = assertSafeResourcePath(resource.relativePath)
+        const targetPath = `skills/${source.entry.name}/${relativePath}`
+        resources.push({
+          path: targetPath,
+          bytes:
+            resource.kind === 'builtin'
+              ? encodeUtf8(resource.content)
+              : cloneArrayBuffer(await adapter.readBinary(resource.path)),
+        })
+      }
+    }
+    resources.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+    assertNoPathCollisions(resources.map((resource) => resource.path))
+
+    const hash = await hashResources(resources)
+    const cacheRoot = normalizePath(
+      `${getYoloBaseDir(settings)}/${CACHE_RELATIVE_DIR}`,
+    )
+    const targetDir = normalizePath(`${cacheRoot}/${hash}`)
+    const stagingDir = normalizePath(`${cacheRoot}/.staging-${hash}`)
+
+    await ensureDirectory(adapter, cacheRoot)
+    if (await adapter.exists(targetDir)) {
+      if (!(await isOwnedCacheEntry(adapter, targetDir, hash))) {
+        throw new Error(
+          `Claude plugin cache entry is not owned by YOLO: ${targetDir}`,
+        )
+      }
+    } else {
+      await removeDirectory(adapter, stagingDir)
+      await ensureDirectory(adapter, stagingDir)
+      try {
+        for (const resource of resources) {
+          const targetPath = normalizePath(`${stagingDir}/${resource.path}`)
+          await ensureParentDirectory(adapter, targetPath)
+          await adapter.writeBinary(targetPath, resource.bytes)
+        }
+        const manifestPath = normalizePath(
+          `${stagingDir}/.claude-plugin/plugin.json`,
+        )
+        await ensureParentDirectory(adapter, manifestPath)
+        await adapter.write(manifestPath, getManifest(hash))
+        await adapter.write(
+          normalizePath(`${stagingDir}/${CACHE_ENTRY_MARKER}`),
+          getMarker(hash),
+        )
+        await adapter.rename(stagingDir, targetDir)
+      } finally {
+        await removeDirectory(adapter, stagingDir)
+      }
+    }
+
+    await this.cleanupOldEntries(adapter, cacheRoot, hash)
+    return [await this.toAbsolutePath(adapter, targetDir)]
+  }
+
+  private async cleanupOldEntries(
+    adapter: DataAdapter,
+    cacheRoot: string,
+    currentHash: string,
+  ): Promise<void> {
+    const listing = await adapter.list(cacheRoot)
+    for (const folder of listing.folders) {
+      const name = folder.slice(folder.lastIndexOf('/') + 1)
+      if (name === currentHash) continue
+      if (name.startsWith('.staging-')) {
+        await removeDirectory(adapter, folder)
+        continue
+      }
+      if (
+        HASH_PATTERN.test(name) &&
+        (await isOwnedCacheEntry(adapter, folder, name))
+      ) {
+        await removeDirectory(adapter, folder)
+      }
+    }
+  }
+
+  private async toAbsolutePath(
+    adapter: FileSystemAdapter,
+    vaultRelativePath: string,
+  ): Promise<string> {
+    // eslint-disable-next-line import/no-nodejs-modules -- called only after desktop filesystem capability validation
+    const path = await import('node:path')
+    const vaultRoot = adapter.getBasePath()
+    if (!path.isAbsolute(vaultRoot)) {
+      throw new Error('Desktop vault filesystem path must be absolute')
+    }
+    const absolutePath = path.resolve(vaultRoot, vaultRelativePath)
+    const relative = path.relative(vaultRoot, absolutePath)
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('Claude plugin cache escaped the vault filesystem root')
+    }
+    return absolutePath
+  }
+}


### PR DESCRIPTION
## Summary
- materialize enabled YOLO directory skills into a content-addressed local Claude plugin inside the managed vault root
- preserve nested text/binary resources and emit an Agent SDK-compatible plugin manifest
- serialize atomic staging/rename writes and clean only owned stale cache entries
- protect every plugin path used by active scopes for the process lifetime
- reject missing/colliding/traversal inputs, mobile/non-filesystem hosts, and relative filesystem roots before writes

## Verification
- Claude runtime/cache/process: 3 suites / 26 tests
- `npm run type:check`
- focused ESLint/Prettier/diff-check