### PR TITLE
feat(cli-runtime): 固定会话级 Assistant 绑定

### DIFF
--- a/src/core/cli-runtime/assistant-binding.test.ts
+++ b/src/core/cli-runtime/assistant-binding.test.ts
@@ -1,0 +1,83 @@
+import type { App } from 'obsidian'
+
+import type { YoloSettings } from '../../settings/schema/setting.types'
+import type { LiteSkillEntry } from '../skills/liteSkills'
+
+import { resolveCliAssistantBinding } from './assistant-binding'
+
+const settings = {
+  assistants: [
+    {
+      id: 'assistant-1',
+      name: 'Reviewer',
+      systemPrompt: 'Review carefully.',
+      skillPreferences: {
+        disabled: { enabled: false },
+      },
+    },
+  ],
+  skills: { disabledSkillIds: ['global-off'] },
+} as unknown as YoloSettings
+
+const skills: LiteSkillEntry[] = [
+  {
+    name: 'zeta',
+    description: 'Z',
+    mode: 'lazy',
+    path: 'skills/zeta/SKILL.md',
+  },
+  {
+    name: 'global-off',
+    description: 'Global',
+    mode: 'lazy',
+    path: 'skills/global-off/SKILL.md',
+  },
+  {
+    name: 'disabled',
+    description: 'Disabled',
+    mode: 'always',
+    path: 'skills/disabled/SKILL.md',
+  },
+  {
+    name: 'alpha',
+    description: 'A',
+    mode: 'always',
+    path: 'skills/alpha/SKILL.md',
+  },
+]
+
+describe('resolveCliAssistantBinding', () => {
+  it('freezes the selected persona and deterministically enabled skill names', async () => {
+    const listSkillEntries = jest.fn(async () => skills)
+
+    await expect(
+      resolveCliAssistantBinding({
+        app: {} as App,
+        settings,
+        assistantId: 'assistant-1',
+        listSkillEntries,
+      }),
+    ).resolves.toEqual({
+      assistantId: 'assistant-1',
+      systemPrompt: 'Review carefully.',
+      enabledSkillNames: ['alpha', 'zeta'],
+    })
+    expect(listSkillEntries).toHaveBeenCalledWith(expect.anything(), {
+      settings,
+    })
+  })
+
+  it('rejects a missing Assistant instead of silently changing persona', async () => {
+    const listSkillEntries = jest.fn(async () => skills)
+
+    await expect(
+      resolveCliAssistantBinding({
+        app: {} as App,
+        settings,
+        assistantId: 'missing',
+        listSkillEntries,
+      }),
+    ).rejects.toThrow('Assistant is unavailable: missing')
+    expect(listSkillEntries).not.toHaveBeenCalled()
+  })
+})

--- a/src/core/cli-runtime/assistant-binding.ts
+++ b/src/core/cli-runtime/assistant-binding.ts
@@ -1,0 +1,53 @@
+import type { App } from 'obsidian'
+
+import type { YoloSettings } from '../../settings/schema/setting.types'
+import { type LiteSkillEntry, listLiteSkillEntries } from '../skills/liteSkills'
+import { isSkillEnabledForAssistant } from '../skills/skillPolicy'
+
+import type { CliAssistantBinding } from './types'
+
+type ListSkillEntries = (
+  app: App,
+  options: { settings: YoloSettings },
+) => Promise<LiteSkillEntry[]>
+
+export type ResolveCliAssistantBindingInput = {
+  app: App
+  settings: YoloSettings
+  assistantId: string
+  listSkillEntries?: ListSkillEntries
+}
+
+/** Resolve the exact session-level persona and skill set used by CLI agents. */
+export const resolveCliAssistantBinding = async ({
+  app,
+  settings,
+  assistantId,
+  listSkillEntries = listLiteSkillEntries,
+}: ResolveCliAssistantBindingInput): Promise<CliAssistantBinding> => {
+  const assistant = settings.assistants.find(
+    (candidate) => candidate.id === assistantId,
+  )
+  if (!assistant) {
+    throw new Error(`Assistant is unavailable: ${assistantId}`)
+  }
+
+  const disabledSkillNames = settings.skills?.disabledSkillIds ?? []
+  const enabledSkillNames = (await listSkillEntries(app, { settings }))
+    .filter((skill) =>
+      isSkillEnabledForAssistant({
+        assistant,
+        skillName: skill.name,
+        disabledSkillNames,
+        defaultLoadMode: skill.mode,
+      }),
+    )
+    .map((skill) => skill.name)
+    .sort((left, right) => left.localeCompare(right))
+
+  return {
+    assistantId: assistant.id,
+    systemPrompt: assistant.systemPrompt,
+    enabledSkillNames,
+  }
+}

--- a/src/core/cli-runtime/index.ts
+++ b/src/core/cli-runtime/index.ts
@@ -1,4 +1,5 @@
 export * from './actions'
+export * from './assistant-binding'
 export * from './claude'
 export * from './cli-actions'
 export * from './codex'


### PR DESCRIPTION
## Summary
- resolve the exact Assistant persona and enabled skill names for a CLI native session
- reuse the existing global/Assistant skill policy and deterministic canonical ordering
- fail explicitly when the requested Assistant no longer exists

## Verification
- focused Jest: 2 tests
- `npm run type:check`
- focused ESLint/Prettier/diff-check