### PR TITLE
refactor(cli-runtime): 复用已水合的原生会话

### DIFF
--- a/src/core/cli-runtime/conversation-controller.test.ts
+++ b/src/core/cli-runtime/conversation-controller.test.ts
@@ -123,7 +123,13 @@ describe('CliConversationController', () => {
     })
     const controller = new CliConversationController(runtime)
 
-    await controller.hydrateSession(ref)
+    await expect(controller.hydrateSession(ref)).resolves.toMatchObject({
+      ref: {
+        runtimeId: 'codex',
+        nativeSessionId: 'existing',
+        sessionPathHint: '/native/session.jsonl',
+      },
+    })
     await controller.ensureReady(assistant)
     expect(controller.getSnapshot()).toMatchObject({
       sessionRef: {

--- a/src/core/cli-runtime/conversation-controller.ts
+++ b/src/core/cli-runtime/conversation-controller.ts
@@ -5,6 +5,7 @@ import type {
   CliRuntime,
   CliRuntimeEvent,
   CliRuntimeRunState,
+  CliSessionHydration,
   CliSessionRef,
   CliTurnInput,
 } from './types'
@@ -114,7 +115,9 @@ export class CliConversationController {
     this.beginSessionTransition(null)
   }
 
-  async hydrateSession(ref: CliSessionRef): Promise<void> {
+  async hydrateSession(
+    ref: CliSessionRef,
+  ): Promise<CliSessionHydration | null> {
     this.assertActive()
     this.assertRuntimeRef(ref)
     this.beginSessionTransition(ref)
@@ -122,7 +125,7 @@ export class CliConversationController {
 
     try {
       const hydration = await operation.runtime.openSession(ref)
-      if (!this.isCurrent(operation)) return
+      if (!this.isCurrent(operation)) return null
       this.assertRuntimeRef(hydration.ref)
       if (!isSameSession(ref, hydration.ref)) {
         throw new Error('CLI runtime hydrated a different session.')
@@ -134,6 +137,7 @@ export class CliConversationController {
         runState: 'idle',
         error: null,
       })
+      return hydration
     } catch (error) {
       if (this.isCurrent(operation)) this.publishError(error)
       throw error

--- a/src/core/cli-runtime/session-service.test.ts
+++ b/src/core/cli-runtime/session-service.test.ts
@@ -150,6 +150,33 @@ describe('CliSessionService', () => {
     })
   })
 
+  it('records an existing hydration without reading the native transcript again', async () => {
+    const index = new MemoryIndex()
+    const ref = {
+      runtimeId: 'claude-code' as const,
+      nativeSessionId: 'claude-1',
+      sessionPathHint: '/native/claude-1.jsonl',
+    }
+    const nativeRuntime = runtime({ runtimeId: 'claude-code' })
+    const openSession = jest.spyOn(nativeRuntime, 'openSession')
+    const service = new CliSessionService({
+      runtimes: [nativeRuntime],
+      indexStore: index,
+    })
+
+    await service.recordOpenedSession(
+      { ref, messages: [] },
+      { assistantId: 'assistant-1', openedAt: 321 },
+    )
+
+    expect(openSession).not.toHaveBeenCalled()
+    await expect(index.get(ref)).resolves.toMatchObject({
+      assistantId: 'assistant-1',
+      lastOpenedAt: 321,
+      sessionPathHint: '/native/claude-1.jsonl',
+    })
+  })
+
   it('changes pin and assistant overlay without touching runtime history', async () => {
     const index = new MemoryIndex()
     const ref = { runtimeId: 'claude-code' as const, nativeSessionId: 'c-1' }

--- a/src/core/cli-runtime/session-service.ts
+++ b/src/core/cli-runtime/session-service.ts
@@ -113,10 +113,17 @@ export class CliSessionService {
     options: OpenCliSessionOptions = {},
   ): Promise<CliSessionHydration> {
     const runtime = this.getRuntime(ref.runtimeId)
-    const [hydration, existing] = await Promise.all([
-      runtime.openSession(ref),
-      this.indexStore.get(ref),
-    ])
+    const hydration = await runtime.openSession(ref)
+    await this.recordOpenedSession(hydration, options)
+    return hydration
+  }
+
+  async recordOpenedSession(
+    hydration: CliSessionHydration,
+    options: OpenCliSessionOptions = {},
+  ): Promise<void> {
+    const ref = hydration.ref
+    const existing = await this.indexStore.get(ref)
     await this.indexStore.upsert(
       createCliSessionIndexEntry({
         runtimeId: ref.runtimeId,
@@ -140,7 +147,6 @@ export class CliSessionService {
           : {}),
       }),
     )
-    return hydration
   }
 
   async setAssistantBinding(


### PR DESCRIPTION
## Summary
- return the accepted provider hydration from CliConversationController
- let CliSessionService record an already-hydrated native session overlay
- avoid reading the provider transcript twice when opening from the combined history list

## Verification
- focused controller/session service: 15 tests
- `npm run type:check`
- focused ESLint/Prettier/diff-check