### PR TITLE
feat(cli): integrate desktop runtime lifecycle

### DIFF
--- a/src/ChatView.cli-runtime.test.tsx
+++ b/src/ChatView.cli-runtime.test.tsx
@@ -1,0 +1,266 @@
+const renderedTrees: unknown[] = []
+const roots: Array<{ render: jest.Mock; unmount: jest.Mock }> = []
+
+jest.mock('react', () => {
+  const actual = jest.requireActual<typeof import('react')>('react')
+  return { __esModule: true, ...actual, default: actual }
+})
+
+jest.mock('react-dom/client', () => ({
+  createRoot: jest.fn(() => {
+    const root = {
+      render: jest.fn((tree: unknown) => renderedTrees.push(tree)),
+      unmount: jest.fn(),
+    }
+    roots.push(root)
+    return root
+  }),
+}))
+
+jest.mock('obsidian', () => {
+  class ItemView {
+    app: unknown
+    containerEl: unknown
+    leaf: unknown
+
+    constructor(leaf: unknown) {
+      this.leaf = leaf
+      this.app = {}
+      this.containerEl = {}
+    }
+  }
+  return {
+    ItemView,
+    TFile: class {},
+    TFolder: class {},
+    WorkspaceLeaf: class {},
+  }
+})
+
+const passthroughProvider = ({ children }: { children: unknown }) => children
+jest.mock('./contexts/app-context', () => ({
+  AppProvider: passthroughProvider,
+}))
+jest.mock('./contexts/chat-view-context', () => ({
+  ChatViewProvider: passthroughProvider,
+}))
+jest.mock('./contexts/dark-mode-context', () => ({
+  DarkModeProvider: passthroughProvider,
+}))
+jest.mock('./contexts/database-context', () => ({
+  DatabaseProvider: passthroughProvider,
+}))
+jest.mock('./contexts/dialog-container-context', () => ({
+  DialogContainerProvider: passthroughProvider,
+}))
+jest.mock('./contexts/language-context', () => ({
+  LanguageProvider: passthroughProvider,
+}))
+jest.mock('./contexts/mcp-context', () => ({
+  McpProvider: passthroughProvider,
+}))
+jest.mock('./contexts/plugin-context', () => ({
+  PluginProvider: passthroughProvider,
+}))
+jest.mock('./contexts/rag-context', () => ({
+  RAGProvider: passthroughProvider,
+}))
+jest.mock('./contexts/settings-context', () => ({
+  SettingsProvider: passthroughProvider,
+}))
+
+const ChatSidebarTabs = jest.fn((_props: unknown) => null)
+const mockChatSidebarTabsComponent = (props: unknown) => ChatSidebarTabs(props)
+jest.mock('./components/chat-view/ChatSidebarTabs', () => ({
+  __esModule: true,
+  default: mockChatSidebarTabsComponent,
+}))
+jest.mock('./hooks/useChatHistory', () => ({
+  getConversationDisplayTitle: (title: string | undefined) => title ?? '',
+}))
+
+import type { ReactElement } from 'react'
+
+import { ChatView } from './ChatView'
+import type { CliRuntimeScope } from './core/cli-runtime/coordinator'
+
+type TestChatView = {
+  app: unknown
+  containerEl: {
+    children: unknown[]
+    win: { cancelAnimationFrame: jest.Mock }
+  }
+  cliRuntimeScope?: CliRuntimeScope
+  cliRuntimeScopeInitialization: Promise<void> | null
+  cliRuntimeScopeDisposal: Promise<void> | null
+  prepareCliRuntimeScopeForOpen(): Promise<void>
+  initializeCliRuntimeScope(): Promise<void>
+  rebuild(): Promise<void>
+  render(): Promise<void>
+  onClose(): Promise<void>
+  isClosed: boolean
+  root: { render: jest.Mock; unmount: jest.Mock } | null
+}
+
+const makeScope = (): {
+  scope: CliRuntimeScope
+  dispose: jest.Mock<Promise<void>, []>
+} => {
+  const dispose = jest.fn(async () => undefined)
+  return {
+    scope: { dispose } as unknown as CliRuntimeScope,
+    dispose,
+  }
+}
+
+const createView = (
+  createCliRuntimeScope: () => Promise<CliRuntimeScope | null>,
+): TestChatView => {
+  const manager = {
+    getLeafPlacement: jest.fn(() => 'sidebar'),
+    unregisterLeaf: jest.fn(),
+  }
+  const host = { ownerDocument: {} }
+  const view = Object.create(ChatView.prototype) as unknown as TestChatView
+  Object.assign(view, {
+    plugin: {
+      app: {},
+      settings: {},
+      createCliRuntimeScope,
+      getChatLeafSessionManager: () => manager,
+      setSettings: jest.fn(),
+      addSettingsChangeListener: jest.fn(),
+      getDbManager: jest.fn(),
+      getRAGEngine: jest.fn(),
+      getMcpManager: jest.fn(),
+    },
+    app: {},
+    leaf: {},
+    containerEl: {
+      children: [{}, host],
+      win: { cancelAnimationFrame: jest.fn() },
+    },
+    root: null,
+    chatRef: { current: null },
+    mountedHost: null,
+    mountedDoc: null,
+    hostObserver: null,
+    windowMigratedDisposer: null,
+    runtimeSnapshot: null,
+    rebuildScheduled: false,
+    rebuildRafId: null,
+    rebuildRafWindow: null,
+    isClosed: false,
+    pendingRestoredConversationId: undefined,
+    restoredConversationLoadPromise: null,
+    cliRuntimeScope: undefined,
+    cliRuntimeScopeInitialization: null,
+    cliRuntimeScopeDisposal: null,
+  })
+  return view
+}
+
+const findElement = (
+  node: unknown,
+  predicate: (element: ReactElement) => boolean,
+): ReactElement | null => {
+  if (!node || typeof node !== 'object') return null
+  const element = node as ReactElement
+  if ('type' in element && predicate(element)) return element
+  const children = (element.props as { children?: unknown } | undefined)
+    ?.children
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const match = findElement(child, predicate)
+      if (match) return match
+    }
+    return null
+  }
+  return findElement(children, predicate)
+}
+
+describe('ChatView CLI runtime scope lifecycle', () => {
+  beforeEach(() => {
+    renderedTrees.length = 0
+    roots.length = 0
+    jest.clearAllMocks()
+  })
+
+  it('creates one scope and passes the same instance through a host rebuild', async () => {
+    const { scope } = makeScope()
+    const createCliRuntimeScope = jest.fn(async () => scope)
+    const view = createView(createCliRuntimeScope)
+    await view.initializeCliRuntimeScope()
+
+    await view.render()
+    const firstTree = renderedTrees.at(-1)
+    const firstTabs = findElement(
+      firstTree,
+      (element) => element.type === mockChatSidebarTabsComponent,
+    )
+
+    const replacementHost = { ownerDocument: {} }
+    view.containerEl.children[1] = replacementHost
+    await view.rebuild()
+    const rebuiltTree = renderedTrees.at(-1)
+    const rebuiltTabs = findElement(
+      rebuiltTree,
+      (element) => element.type === mockChatSidebarTabsComponent,
+    )
+
+    expect(createCliRuntimeScope).toHaveBeenCalledTimes(1)
+    expect(firstTabs?.props.initialChatProps.cliRuntimeScope).toBe(scope)
+    expect(rebuiltTabs?.props.initialChatProps.cliRuntimeScope).toBe(scope)
+  })
+
+  it('disposes its scope once when the view closes', async () => {
+    const { scope, dispose } = makeScope()
+    const view = createView(async () => scope)
+    await view.initializeCliRuntimeScope()
+    await view.render()
+
+    await view.onClose()
+    await view.onClose()
+
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(view.cliRuntimeScope).toBeUndefined()
+  })
+
+  it('disposes a scope that finishes creation after close starts', async () => {
+    let resolveScope!: (scope: CliRuntimeScope) => void
+    const scopePromise = new Promise<CliRuntimeScope>((resolve) => {
+      resolveScope = resolve
+    })
+    const { scope, dispose } = makeScope()
+    const view = createView(() => scopePromise)
+
+    const initialization = view.initializeCliRuntimeScope()
+    const close = view.onClose()
+    resolveScope(scope)
+    await Promise.all([initialization, close])
+
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(view.cliRuntimeScope).toBeUndefined()
+  })
+
+  it('creates a fresh scope when the same ChatView instance reopens', async () => {
+    const first = makeScope()
+    const second = makeScope()
+    const createCliRuntimeScope = jest
+      .fn<Promise<CliRuntimeScope>, []>()
+      .mockResolvedValueOnce(first.scope)
+      .mockResolvedValueOnce(second.scope)
+    const view = createView(createCliRuntimeScope)
+
+    await view.initializeCliRuntimeScope()
+    await view.onClose()
+    await view.prepareCliRuntimeScopeForOpen()
+    view.isClosed = false
+    await view.initializeCliRuntimeScope()
+
+    expect(createCliRuntimeScope).toHaveBeenCalledTimes(2)
+    expect(first.dispose).toHaveBeenCalledTimes(1)
+    expect(second.dispose).not.toHaveBeenCalled()
+    expect(view.cliRuntimeScope).toBe(second.scope)
+  })
+})

--- a/src/ChatView.tsx
+++ b/src/ChatView.tsx
@@ -21,9 +21,10 @@ import { McpProvider } from './contexts/mcp-context'
 import { PluginProvider } from './contexts/plugin-context'
 import { RAGProvider } from './contexts/rag-context'
 import { SettingsProvider } from './contexts/settings-context'
+import type { CliRuntimeScope } from './core/cli-runtime/coordinator'
 import type { PendingChatOpenPayload } from './features/chat/chatLeafSessionManager'
 import { getConversationDisplayTitle } from './hooks/useChatHistory'
-import YoloPlugin from './main'
+import type YoloPlugin from './main'
 import { ConversationOverrideSettings } from './types/conversation-settings.types'
 import {
   MentionableBlockData,
@@ -57,6 +58,9 @@ export class ChatView extends ItemView {
   private isApplyingPersistedViewState = false
   private pendingRestoredConversationId?: string
   private restoredConversationLoadPromise: Promise<void> | null = null
+  private cliRuntimeScope: CliRuntimeScope | undefined
+  private cliRuntimeScopeInitialization: Promise<void> | null = null
+  private cliRuntimeScopeDisposal: Promise<void> | null = null
 
   constructor(
     leaf: WorkspaceLeaf,
@@ -123,8 +127,12 @@ export class ChatView extends ItemView {
   }
 
   async onOpen(): Promise<void> {
+    await this.prepareCliRuntimeScopeForOpen()
     this.isClosed = false
-    await this.plugin.warmupAgentService()
+    await Promise.all([
+      this.plugin.warmupAgentService(),
+      this.initializeCliRuntimeScope(),
+    ])
     const manager = this.plugin.getChatLeafSessionManager()
     const pendingPayload = manager.consumePendingPayload(this.leaf)
     const placement =
@@ -171,7 +179,7 @@ export class ChatView extends ItemView {
     this.plugin.refreshInstallationIncompleteBanner()
   }
 
-  onClose(): Promise<void> {
+  async onClose(): Promise<void> {
     this.isClosed = true
     this.runtimeSnapshot =
       this.chatRef.current?.getRuntimeSnapshot() ?? this.runtimeSnapshot
@@ -194,7 +202,43 @@ export class ChatView extends ItemView {
     this.root = null
     this.mountedHost = null
     this.mountedDoc = null
-    return Promise.resolve()
+    await this.disposeCliRuntimeScope()
+  }
+
+  private async prepareCliRuntimeScopeForOpen(): Promise<void> {
+    if (!this.cliRuntimeScopeDisposal) return
+    await this.cliRuntimeScopeDisposal
+    this.cliRuntimeScopeInitialization = null
+    this.cliRuntimeScopeDisposal = null
+  }
+
+  private initializeCliRuntimeScope(): Promise<void> {
+    this.cliRuntimeScopeInitialization ??= (async () => {
+      try {
+        const scope = await this.plugin.createCliRuntimeScope()
+        if (!scope) return
+        if (this.isClosed) {
+          await scope.dispose()
+          return
+        }
+        this.cliRuntimeScope = scope
+      } catch (error) {
+        console.error('[YOLO] Failed to initialize ChatView CLI scope', error)
+      }
+    })()
+    return this.cliRuntimeScopeInitialization
+  }
+
+  private disposeCliRuntimeScope(): Promise<void> {
+    this.cliRuntimeScopeDisposal ??= (async () => {
+      await this.cliRuntimeScopeInitialization
+      const scope = this.cliRuntimeScope
+      this.cliRuntimeScope = undefined
+      await scope?.dispose()
+    })().catch((error: unknown) => {
+      console.error('[YOLO] Failed to dispose ChatView CLI scope', error)
+    })
+    return this.cliRuntimeScopeDisposal
   }
 
   private scheduleRebuildCheck(): void {
@@ -295,6 +339,7 @@ export class ChatView extends ItemView {
                                 placement={placement}
                                 initialChatProps={{
                                   ...(this.initialChatProps ?? {}),
+                                  cliRuntimeScope: this.cliRuntimeScope,
                                   seededRuntimeSnapshot,
                                 }}
                                 onConversationContextChange={(context) => {

--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -37,6 +37,7 @@ import { getLatestAssistantContextUsage } from '../../core/agent/compaction'
 import { DEFAULT_ASSISTANT_ID } from '../../core/agent/default-assistant'
 import type { AgentConversationRunSummary } from '../../core/agent/service'
 import {
+  type CliRuntimeScope,
   type YoloConversationRef,
   createYoloChatRuntimeActions,
 } from '../../core/cli-runtime'
@@ -884,6 +885,7 @@ export type ChatRuntimeSnapshot = {
 }
 
 export type ChatProps = {
+  cliRuntimeScope?: CliRuntimeScope
   selectedBlock?: MentionableBlockData
   activeView?: 'chat' | 'composer'
   onChangeView?: (view: 'chat' | 'composer') => void

--- a/src/main.cli-runtime.test.ts
+++ b/src/main.cli-runtime.test.ts
@@ -1,0 +1,201 @@
+const createDesktopCliRuntimeCoordinator = jest.fn()
+const cacheInstances: Array<{
+  options: {
+    getSettings: () => unknown
+  }
+  resolvePluginPaths: jest.Mock
+}> = []
+
+jest.mock('react', () => {
+  const actual = jest.requireActual<typeof import('react')>('react')
+  return { __esModule: true, ...actual, default: actual }
+})
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: () => null,
+  defaultUrlTransform: (url: string) => url,
+}))
+jest.mock('remark-gfm', () => ({ __esModule: true, default: jest.fn() }))
+jest.mock('remark-math', () => ({ __esModule: true, default: jest.fn() }))
+
+jest.mock('obsidian', () => {
+  class ObsidianBase {}
+  const Platform = { isDesktop: true, isMobile: false }
+  return new Proxy(
+    {
+      Platform,
+      Plugin: ObsidianBase,
+      normalizePath: (path: string) => path,
+      getLanguage: () => 'en',
+    },
+    {
+      get(target, property: string) {
+        if (property in target) {
+          return target[property as keyof typeof target]
+        }
+        return ObsidianBase
+      },
+    },
+  )
+})
+
+jest.mock('./ChatView', () => ({ ChatView: jest.fn() }))
+jest.mock('./constants/bakedVersion', () => ({ BAKED_PLUGIN_VERSION: 'test' }))
+jest.mock(
+  './core/runtime-components',
+  () =>
+    new Proxy(
+      { BAKED_RUNTIME_COMPONENT_REGISTRY: {} },
+      {
+        get: (target, property: string) =>
+          (target as Record<string, unknown>)[property] ?? jest.fn(),
+      },
+    ),
+)
+jest.mock('./core/cli-runtime/coordinator', () => ({
+  createDesktopCliRuntimeCoordinator: (...args: unknown[]) =>
+    createDesktopCliRuntimeCoordinator(...args),
+}))
+jest.mock('./core/cli-runtime/claude/plugin-cache', () => ({
+  ClaudeLocalPluginCache: class {
+    readonly resolvePluginPaths = jest.fn()
+
+    constructor(readonly options: { getSettings: () => unknown }) {
+      cacheInstances.push(this)
+    }
+  },
+}))
+
+import { Platform } from 'obsidian'
+
+import type {
+  CliRuntimeCoordinator,
+  CliRuntimeScope,
+} from './core/cli-runtime/coordinator'
+import YoloPlugin from './main'
+
+type TestPlugin = {
+  app: unknown
+  settings: YoloPlugin['settings']
+  isUnloaded: boolean
+  getCliRuntimeCoordinator: YoloPlugin['getCliRuntimeCoordinator']
+  createCliRuntimeScope: YoloPlugin['createCliRuntimeScope']
+  disposeCliRuntimeCoordinator(): void
+}
+
+const createScope = (name: string): CliRuntimeScope =>
+  ({ name, dispose: jest.fn() }) as unknown as CliRuntimeScope
+
+const createPlugin = (): TestPlugin => {
+  const plugin = Object.create(YoloPlugin.prototype) as unknown as TestPlugin
+  Object.assign(plugin, {
+    app: { vault: { adapter: {} } },
+    settings: { yolo: { baseDir: 'first' } },
+    isUnloaded: false,
+  })
+  return plugin
+}
+
+const flushPromises = async (): Promise<void> => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('YoloPlugin CLI runtime lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    cacheInstances.length = 0
+    Platform.isDesktop = true
+    Platform.isMobile = false
+  })
+
+  it('does not import or construct the desktop coordinator/cache on mobile', async () => {
+    Platform.isDesktop = false
+    Platform.isMobile = true
+    const plugin = createPlugin()
+
+    await expect(plugin.getCliRuntimeCoordinator()).resolves.toBeNull()
+    await expect(plugin.createCliRuntimeScope()).resolves.toBeNull()
+
+    expect(createDesktopCliRuntimeCoordinator).not.toHaveBeenCalled()
+    expect(cacheInstances).toHaveLength(0)
+  })
+
+  it('shares one coordinator promise and creates distinct ChatView scopes', async () => {
+    const firstScope = createScope('first')
+    const secondScope = createScope('second')
+    const coordinator: CliRuntimeCoordinator = {
+      createScope: jest
+        .fn<
+          ReturnType<CliRuntimeCoordinator['createScope']>,
+          Parameters<CliRuntimeCoordinator['createScope']>
+        >()
+        .mockReturnValueOnce(firstScope)
+        .mockReturnValueOnce(secondScope),
+      dispose: jest.fn(async () => undefined),
+    }
+    createDesktopCliRuntimeCoordinator.mockResolvedValue(coordinator)
+    const plugin = createPlugin()
+
+    const firstAccess = plugin.getCliRuntimeCoordinator()
+    const secondAccess = plugin.getCliRuntimeCoordinator()
+    expect(secondAccess).toBe(firstAccess)
+    await expect(firstAccess).resolves.toBe(coordinator)
+    await expect(plugin.createCliRuntimeScope()).resolves.toBe(firstScope)
+    await expect(plugin.createCliRuntimeScope()).resolves.toBe(secondScope)
+
+    expect(createDesktopCliRuntimeCoordinator).toHaveBeenCalledTimes(1)
+    expect(cacheInstances).toHaveLength(1)
+    expect(firstScope).not.toBe(secondScope)
+
+    const cacheSettings = cacheInstances[0].options.getSettings
+    const coordinatorOptions = createDesktopCliRuntimeCoordinator.mock
+      .calls[0][0] as { getSettings: () => unknown }
+    plugin.settings = { yolo: { baseDir: 'second' } } as typeof plugin.settings
+    expect(cacheSettings()).toBe(plugin.settings)
+    expect(coordinatorOptions.getSettings()).toBe(plugin.settings)
+  })
+
+  it('disposes a coordinator that finishes creation during unload', async () => {
+    let resolveCoordinator!: (coordinator: CliRuntimeCoordinator) => void
+    const pendingCoordinator = new Promise<CliRuntimeCoordinator>((resolve) => {
+      resolveCoordinator = resolve
+    })
+    createDesktopCliRuntimeCoordinator.mockReturnValue(pendingCoordinator)
+    const disposeCoordinator = jest.fn(async () => undefined)
+    const coordinator: CliRuntimeCoordinator = {
+      createScope: jest.fn(),
+      dispose: disposeCoordinator,
+    }
+    const plugin = createPlugin()
+
+    const access = plugin.getCliRuntimeCoordinator()
+    await flushPromises()
+    plugin.isUnloaded = true
+    plugin.disposeCliRuntimeCoordinator()
+    resolveCoordinator(coordinator)
+
+    await expect(access).resolves.toBeNull()
+    await flushPromises()
+    expect(disposeCoordinator).toHaveBeenCalledTimes(1)
+    expect(plugin.getCliRuntimeCoordinator()).resolves.toBeNull()
+  })
+
+  it('starts coordinator disposal from the plugin unload hook', () => {
+    const plugin = createPlugin()
+    const stopAfterCoordinatorCleanup = new Error('stop after CLI cleanup')
+    const disposeCliRuntimeCoordinator = jest.fn(() => {
+      throw stopAfterCoordinatorCleanup
+    })
+    plugin.disposeCliRuntimeCoordinator = disposeCliRuntimeCoordinator
+
+    expect(() =>
+      YoloPlugin.prototype.onunload.call(
+        plugin as unknown as InstanceType<typeof YoloPlugin>,
+      ),
+    ).toThrow(stopAfterCoordinatorCleanup)
+
+    expect(plugin.isUnloaded).toBe(true)
+    expect(disposeCliRuntimeCoordinator).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,11 @@ import { backgroundExecutionController } from './core/background/backgroundExecu
 import { buildBackgroundStatusModel } from './core/background/backgroundStatusModel'
 import { noteWebviewLeafFocus } from './core/browser/activeWebviewProbe'
 import { WebviewSelectionBridge } from './core/browser/webviewSelectionBridge'
+import type { ClaudeLocalPluginCache } from './core/cli-runtime/claude/plugin-cache'
+import type {
+  CliRuntimeCoordinator,
+  CliRuntimeScope,
+} from './core/cli-runtime/coordinator'
 import { DistributionFeedClient } from './core/distribution/distributionFeedClient'
 import { localeStore } from './core/i18n/localeStore'
 import {
@@ -316,6 +321,10 @@ export default class YoloPlugin extends Plugin {
     new Map()
   // Quick Ask state
   private quickAskController: QuickAskController | null = null
+  private cliRuntimeCoordinatorPromise: Promise<CliRuntimeCoordinator | null> | null =
+    null
+  private claudeLocalPluginCache: ClaudeLocalPluginCache | null = null
+  private cliRuntimeCapabilityError: unknown = null
   private agentService: AgentService | null = null
   private agentServiceReady: Promise<AgentService> | null = null
   private agentApiService: YoloAgentApiService | null = null
@@ -394,6 +403,86 @@ export default class YoloPlugin extends Plugin {
       this.chatLeafSessionManager = new ChatLeafSessionManager(this.app)
     }
     return this.chatLeafSessionManager
+  }
+
+  /**
+   * Lazily enters the desktop-only CLI boundary. Keeping the promise here
+   * gives every ChatView one shared coordinator without loading provider
+   * runtime paths on mobile.
+   */
+  getCliRuntimeCoordinator(): Promise<CliRuntimeCoordinator | null> {
+    if (!Platform.isDesktop || this.isUnloaded) {
+      return Promise.resolve(null)
+    }
+    this.cliRuntimeCoordinatorPromise ??= this.initializeCliRuntimeCoordinator()
+    return this.cliRuntimeCoordinatorPromise
+  }
+
+  async createCliRuntimeScope(): Promise<CliRuntimeScope | null> {
+    const coordinator = await this.getCliRuntimeCoordinator()
+    if (!coordinator || this.isUnloaded) return null
+    try {
+      return coordinator.createScope()
+    } catch (error) {
+      this.reportCliRuntimeCapabilityError(error)
+      return null
+    }
+  }
+
+  getCliRuntimeCapabilityError(): unknown {
+    return this.cliRuntimeCapabilityError
+  }
+
+  private async initializeCliRuntimeCoordinator(): Promise<CliRuntimeCoordinator | null> {
+    try {
+      const [
+        { createDesktopCliRuntimeCoordinator },
+        { ClaudeLocalPluginCache },
+      ] = await Promise.all([
+        import('./core/cli-runtime/coordinator'),
+        import('./core/cli-runtime/claude/plugin-cache'),
+      ])
+      if (this.isUnloaded) return null
+
+      const cache = new ClaudeLocalPluginCache({
+        app: this.app,
+        getSettings: () => this.settings,
+      })
+      const coordinator = await createDesktopCliRuntimeCoordinator({
+        app: this.app,
+        getSettings: () => this.settings,
+        resolveClaudePluginPaths: cache.resolvePluginPaths,
+      })
+      if (this.isUnloaded) {
+        await coordinator.dispose()
+        return null
+      }
+
+      this.claudeLocalPluginCache = cache
+      return coordinator
+    } catch (error) {
+      if (!this.isUnloaded) {
+        this.reportCliRuntimeCapabilityError(error)
+      }
+      return null
+    }
+  }
+
+  private reportCliRuntimeCapabilityError(error: unknown): void {
+    this.cliRuntimeCapabilityError = error
+    console.error('[YOLO] CLI runtime capability is unavailable', error)
+  }
+
+  private disposeCliRuntimeCoordinator(): void {
+    const coordinatorPromise = this.cliRuntimeCoordinatorPromise
+    this.cliRuntimeCoordinatorPromise = null
+    this.claudeLocalPluginCache = null
+    if (!coordinatorPromise) return
+    void coordinatorPromise
+      .then((coordinator) => coordinator?.dispose())
+      .catch((error: unknown) => {
+        console.error('[YOLO] CLI runtime coordinator cleanup failed', error)
+      })
   }
 
   getMarkdownInsertionTarget(): MarkdownView | null {
@@ -1988,6 +2077,7 @@ export default class YoloPlugin extends Plugin {
 
   async onload() {
     this.isUnloaded = false
+    this.cliRuntimeCapabilityError = null
     this.actionToastController = mountActionToast()
     this.initializeModuleSystem()
     this.initializeRuntimeComponentSystem()
@@ -2488,6 +2578,7 @@ export default class YoloPlugin extends Plugin {
 
   onunload() {
     this.isUnloaded = true
+    this.disposeCliRuntimeCoordinator()
     this.moduleUpdateController?.dispose()
     this.moduleUpdateController = null
     this.moduleService?.dispose()


### PR DESCRIPTION
Adds the desktop-only plugin coordinator lifecycle and one isolated CLI runtime scope per ChatView, preserved across host rebuilds and disposed safely across close/reopen and unload races.\n\nTests: 31 focused tests; npm run type:check; production host esbuild.