### PR TITLE
feat(cli): add native conversation surface

### DIFF
--- a/src/components/chat-view/CliChatSurface.test.tsx
+++ b/src/components/chat-view/CliChatSurface.test.tsx
@@ -1,0 +1,329 @@
+import React, { type ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import type {
+  ChatRuntimeActions,
+  CliConversationController,
+  CliConversationSnapshot,
+} from '../../core/cli-runtime'
+import type {
+  AssistantToolMessageGroup,
+  ChatAssistantMessage,
+  ChatToolMessage,
+  ChatUserMessage,
+} from '../../types/chat'
+import type { ChatTimelineItem } from '../../types/chat-timeline'
+
+let latestExternalSnapshot: CliConversationSnapshot | undefined
+let externalStoreNotificationCount = 0
+let capturedRuntimeConversation: unknown
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react')
+  return {
+    ...actual,
+    useLayoutEffect: actual.useEffect,
+    useSyncExternalStore: (
+      subscribe: (listener: () => void) => () => void,
+      getSnapshot: () => CliConversationSnapshot,
+    ) => {
+      latestExternalSnapshot = getSnapshot()
+      subscribe(() => {
+        externalStoreNotificationCount += 1
+        latestExternalSnapshot = getSnapshot()
+      })
+      return getSnapshot()
+    },
+  }
+})
+
+jest.mock('../../contexts/language-context', () => ({
+  useLanguage: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? '',
+  }),
+}))
+
+jest.mock('./UserMessageCard', () => ({
+  __esModule: true,
+  default: ({
+    snapshot,
+    className,
+  }: {
+    snapshot: { text: string }
+    className?: string
+  }) => <div className={className}>{snapshot.text}</div>,
+}))
+
+const mockedAssistantGroup = jest.fn(
+  (props: {
+    messages: AssistantToolMessageGroup
+    conversationId: string
+    showRetryAction?: boolean
+    showCopyAction?: boolean
+    showEditAction?: boolean
+    showDeleteAction?: boolean
+  }) => {
+    const { useChatRuntimeActions } = jest.requireActual(
+      './chat-runtime-actions-context',
+    )
+    capturedRuntimeConversation = useChatRuntimeActions(
+      props.conversationId,
+    ).conversation
+    return (
+      <div data-testid="assistant-group">
+        {props.messages.map((message) => message.role).join(',')}
+        {props.showCopyAction ? <button>Copy message</button> : null}
+        {props.showRetryAction ? <button>Regenerate</button> : null}
+        {props.showEditAction ? <button>Edit</button> : null}
+        {props.showDeleteAction ? <button>Delete</button> : null}
+      </div>
+    )
+  },
+)
+
+jest.mock('./AssistantToolMessageGroupItem', () => ({
+  __esModule: true,
+  default: (props: Parameters<typeof mockedAssistantGroup>[0]) =>
+    mockedAssistantGroup(props),
+}))
+
+jest.mock('./ChatConversationPane', () => ({
+  ChatConversationPane: ({
+    showEmptyState,
+    emptyStateAgentTitle,
+    emptyStateAgentDescription,
+    chatTimelineItems,
+    renderChatTimelineItem,
+    footerContent,
+  }: {
+    showEmptyState: boolean
+    emptyStateAgentTitle: string
+    emptyStateAgentDescription: string
+    chatTimelineItems: ChatTimelineItem[]
+    renderChatTimelineItem: (item: ChatTimelineItem) => ReactNode
+    footerContent: ReactNode
+  }) => (
+    <div data-testid="conversation-pane">
+      {showEmptyState ? (
+        <div data-testid="empty-state">
+          {emptyStateAgentTitle} {emptyStateAgentDescription}
+        </div>
+      ) : null}
+      {chatTimelineItems.map((item) => (
+        <div key={item.renderKey}>{renderChatTimelineItem(item)}</div>
+      ))}
+      {footerContent}
+    </div>
+  ),
+}))
+
+jest.mock('./useAutoScroll', () => ({
+  useAutoScroll: () => ({
+    autoScrollToBottom: jest.fn(),
+    forceScrollToBottom: jest.fn(),
+    isAutoFollowEnabled: true,
+  }),
+}))
+
+import { CliChatSurface } from './CliChatSurface'
+
+const actions: ChatRuntimeActions = {
+  cancelRun: async () => {},
+  approveTool: async () => ({ kind: 'handled' }),
+  rejectTool: async () => ({ kind: 'handled' }),
+  abortTool: async () => ({ kind: 'handled' }),
+  answerQuestion: async () => ({ kind: 'handled' }),
+  cancelQuestion: async () => ({ kind: 'handled' }),
+}
+
+const sessionRef = {
+  runtimeId: 'codex',
+  nativeSessionId: 'native/session-1',
+} as const
+
+const makeUser = (
+  id: string,
+  promptContent: ChatUserMessage['promptContent'],
+): ChatUserMessage => ({
+  role: 'user',
+  id,
+  content: null,
+  promptContent,
+  mentionables: [],
+})
+
+const assistant: ChatAssistantMessage = {
+  role: 'assistant',
+  id: 'assistant-1',
+  content: 'Assistant response',
+  metadata: { generationState: 'completed' },
+}
+
+const tool: ChatToolMessage = {
+  role: 'tool',
+  id: 'tool-1',
+  toolCalls: [],
+}
+
+const makeSnapshot = (
+  overrides: Partial<CliConversationSnapshot> = {},
+): CliConversationSnapshot => ({
+  runtimeId: 'codex',
+  messages: [],
+  sessionRef,
+  runState: 'idle',
+  error: null,
+  ...overrides,
+})
+
+const createController = (initial: CliConversationSnapshot) => {
+  let snapshot = initial
+  const listeners = new Set<() => void>()
+  const controller = {
+    getSnapshot: () => snapshot,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  } as unknown as CliConversationController
+  return {
+    controller,
+    publish(next: CliConversationSnapshot) {
+      snapshot = next
+      listeners.forEach((listener) => listener())
+    },
+  }
+}
+
+const renderSurface = (controller: CliConversationController): string =>
+  renderToStaticMarkup(
+    <CliChatSurface
+      controller={controller}
+      actions={actions}
+      footerContent={<div>Composer footer</div>}
+    />,
+  )
+
+describe('CliChatSurface', () => {
+  beforeEach(() => {
+    mockedAssistantGroup.mockClear()
+    capturedRuntimeConversation = undefined
+    latestExternalSnapshot = undefined
+    externalStoreNotificationCount = 0
+  })
+
+  it('renders provider-hydrated promptContent, including flattened text parts', () => {
+    const store = createController(
+      makeSnapshot({
+        messages: [
+          makeUser('user-1', [
+            { type: 'text', text: 'First prompt paragraph' },
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/png;base64,ignored' },
+            },
+            { type: 'text', text: 'Second prompt paragraph' },
+          ]),
+        ],
+      }),
+    )
+
+    const html = renderSurface(store.controller)
+
+    expect(html).toContain('First prompt paragraph')
+    expect(html).toContain('Second prompt paragraph')
+    expect(html).not.toContain('base64,ignored')
+  })
+
+  it('groups assistant and tool messages and exposes only the copy action', () => {
+    const store = createController(
+      makeSnapshot({
+        messages: [makeUser('user-1', 'Prompt'), assistant, tool],
+      }),
+    )
+
+    const html = renderSurface(store.controller)
+
+    expect(mockedAssistantGroup).toHaveBeenCalledTimes(1)
+    expect(mockedAssistantGroup.mock.calls[0]?.[0].messages).toEqual([
+      assistant,
+      tool,
+    ])
+    expect(html).toContain('assistant,tool')
+    expect(html).toContain('Copy message')
+    expect(html).not.toContain('Regenerate')
+    expect(html).not.toContain('Edit')
+    expect(html).not.toContain('Delete')
+  })
+
+  it('keeps even empty native user messages read-only', () => {
+    const store = createController(
+      makeSnapshot({ messages: [makeUser('user-empty', null)] }),
+    )
+
+    const html = renderSurface(store.controller)
+
+    expect(html).toContain('空消息')
+    expect(html).not.toContain('Click to edit')
+  })
+
+  it('provides pending runtime actions with the actual provider session ref', () => {
+    const store = createController(
+      makeSnapshot({ messages: [assistant, tool] }),
+    )
+
+    renderSurface(store.controller)
+
+    expect(capturedRuntimeConversation).toBe(sessionRef)
+  })
+
+  it('fails fast when an assistant/tool group has no bound provider session', () => {
+    const store = createController(
+      makeSnapshot({ messages: [assistant, tool], sessionRef: null }),
+    )
+
+    expect(() => renderSurface(store.controller)).toThrow(
+      'CLI assistant/tool groups require a bound provider session.',
+    )
+  })
+
+  it('subscribes to controller events and reads the published snapshot', () => {
+    const store = createController(makeSnapshot({ sessionRef: null }))
+    expect(renderSurface(store.controller)).toContain('开始一个 CLI 会话')
+
+    store.publish(
+      makeSnapshot({ messages: [makeUser('user-event', 'Event message')] }),
+    )
+
+    expect(externalStoreNotificationCount).toBeGreaterThan(0)
+    expect(latestExternalSnapshot?.messages[0]?.id).toBe('user-event')
+    expect(renderSurface(store.controller)).toContain('Event message')
+  })
+
+  it('renders localized empty, error, and streaming states', () => {
+    const empty = createController(makeSnapshot({ sessionRef: null }))
+    const failed = createController(
+      makeSnapshot({
+        sessionRef: null,
+        runState: 'error',
+        error: 'Provider process exited',
+      }),
+    )
+    const streaming = createController(
+      makeSnapshot({
+        messages: [makeUser('user-streaming', 'Current turn')],
+        runState: 'running',
+      }),
+    )
+
+    expect(renderSurface(empty.controller)).toContain('开始一个 CLI 会话')
+    expect(renderSurface(failed.controller)).toContain(
+      'CLI 会话出错：Provider process exited',
+    )
+    expect(renderSurface(failed.controller)).toContain('CLI 运行出错')
+    expect(renderSurface(streaming.controller)).toContain('CLI 正在回复…')
+    expect(renderSurface(streaming.controller)).toContain(
+      'data-run-state="running"',
+    )
+  })
+})

--- a/src/components/chat-view/CliChatSurface.test.tsx
+++ b/src/components/chat-view/CliChatSurface.test.tsx
@@ -48,10 +48,16 @@ jest.mock('./UserMessageCard', () => ({
   default: ({
     snapshot,
     className,
+    interactive,
   }: {
     snapshot: { text: string }
     className?: string
-  }) => <div className={className}>{snapshot.text}</div>,
+    interactive?: boolean
+  }) => (
+    <div className={className} data-interactive={String(interactive)}>
+      {snapshot.text}
+    </div>
+  ),
 }))
 
 const mockedAssistantGroup = jest.fn(
@@ -232,6 +238,7 @@ describe('CliChatSurface', () => {
 
     expect(html).toContain('First prompt paragraph')
     expect(html).toContain('Second prompt paragraph')
+    expect(html).toContain('data-interactive="false"')
     expect(html).not.toContain('base64,ignored')
   })
 

--- a/src/components/chat-view/CliChatSurface.tsx
+++ b/src/components/chat-view/CliChatSurface.tsx
@@ -1,0 +1,446 @@
+import {
+  type ReactNode,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
+
+import { useLanguage } from '../../contexts/language-context'
+import type { AgentConversationRunSummary } from '../../core/agent/service'
+import type {
+  ChatRuntimeActions,
+  CliConversationController,
+  CliConversationSnapshot,
+  CliRuntimeRunState,
+  CliSessionRef,
+} from '../../core/cli-runtime'
+import type {
+  AssistantToolMessageGroup,
+  ChatMessage,
+  ChatToolMessage,
+  ChatUserMessage,
+} from '../../types/chat'
+import type { ChatTimelineItem } from '../../types/chat-timeline'
+import type { GroupEditSummary } from '../../utils/chat/editSummary'
+import { buildMessageTimelineItems } from '../../utils/chat/timeline'
+
+import AssistantToolMessageGroupItem from './AssistantToolMessageGroupItem'
+import { editorStateToPlainText } from './chat-input/utils/editor-state-to-plain-text'
+import { ChatRuntimeActionsProvider } from './chat-runtime-actions-context'
+import { ChatConversationPane } from './ChatConversationPane'
+import { useAutoScroll } from './useAutoScroll'
+import {
+  useChatTimelineReadModel,
+  useStableChatTimelineItems,
+} from './useChatTimelineReadModel'
+import UserMessageCard from './UserMessageCard'
+
+const ACTIVE_RUN_STATES: ReadonlySet<CliRuntimeRunState> = new Set([
+  'running',
+  'waiting_for_approval',
+  'waiting_for_user',
+])
+
+const noop = (): void => undefined
+const noopToolMessageUpdate = (_message: ChatToolMessage): void => undefined
+const noopOpenEditSummaryFile = (
+  _file: GroupEditSummary['files'][number],
+): void => undefined
+
+export type CliChatSurfaceProps = {
+  controller: CliConversationController
+  actions: ChatRuntimeActions
+  footerContent: ReactNode
+}
+
+export function useCliConversationSnapshot(
+  controller: CliConversationController,
+): CliConversationSnapshot {
+  return useSyncExternalStore(
+    controller.subscribe,
+    controller.getSnapshot,
+    controller.getSnapshot,
+  )
+}
+
+const getPromptContentText = (
+  promptContent: ChatUserMessage['promptContent'],
+): string => {
+  if (!promptContent) return ''
+  if (typeof promptContent === 'string') return promptContent
+  return promptContent
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text)
+    .join('\n\n')
+}
+
+const getUserMessageText = (message: ChatUserMessage): string => {
+  const editorText = message.content
+    ? editorStateToPlainText(message.content)
+    : ''
+  return editorText || getPromptContentText(message.promptContent)
+}
+
+const getConversationId = (sessionRef: CliSessionRef): string =>
+  `${sessionRef.runtimeId}:${sessionRef.nativeSessionId}`
+
+const getLatestUserMessageId = (
+  messages: readonly ChatMessage[],
+): string | undefined => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message?.role === 'user') return message.id
+  }
+  return undefined
+}
+
+const getLatestAssistantGroupId = (
+  groupedChatMessages: (ChatUserMessage | AssistantToolMessageGroup)[],
+): string | null => {
+  for (let index = groupedChatMessages.length - 1; index >= 0; index -= 1) {
+    const messageOrGroup = groupedChatMessages[index]
+    if (Array.isArray(messageOrGroup)) {
+      return messageOrGroup[0]?.id ?? null
+    }
+  }
+  return null
+}
+
+const getActiveStreamingMessageId = (
+  messages: readonly ChatMessage[],
+  runState: CliRuntimeRunState,
+): string | null => {
+  if (!ACTIVE_RUN_STATES.has(runState)) return null
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message?.role !== 'user') return message.id
+  }
+  return null
+}
+
+const toAgentRunStatus = (
+  runState: CliRuntimeRunState,
+): AgentConversationRunSummary['status'] => {
+  if (
+    runState === 'running' ||
+    runState === 'waiting_for_approval' ||
+    runState === 'waiting_for_user'
+  ) {
+    return 'running'
+  }
+  return runState
+}
+
+const buildRunSummary = ({
+  conversationId,
+  messages,
+  runState,
+}: {
+  conversationId: string
+  messages: readonly ChatMessage[]
+  runState: CliRuntimeRunState
+}): AgentConversationRunSummary => {
+  const isActive = ACTIVE_RUN_STATES.has(runState)
+  return {
+    conversationId,
+    anchorMessageId: getLatestUserMessageId(messages),
+    status: toAgentRunStatus(runState),
+    isRunning: runState === 'running',
+    isActive,
+    isAbortable: isActive,
+    isQueueable: false,
+    isWaitingApproval:
+      runState === 'waiting_for_approval' || runState === 'waiting_for_user',
+    isWaitingUserInput: runState === 'waiting_for_user',
+  }
+}
+
+function CliUserMessage({ message }: { message: ChatUserMessage }) {
+  const { t } = useLanguage()
+  const text =
+    getUserMessageText(message) ||
+    t('chat.cliSurface.emptyUserMessage', '空消息')
+  return (
+    <div
+      className="yolo-chat-messages-user yolo-cli-chat-surface__user-message"
+      data-user-message-id={message.id}
+    >
+      <UserMessageCard
+        className="yolo-cli-chat-surface__user-card"
+        snapshot={{
+          content: message.content,
+          text,
+          mentionables: message.mentionables,
+          selectedSkills: message.selectedSkills ?? [],
+          reasoningLevel: message.reasoningLevel,
+        }}
+        onClick={noop}
+      />
+    </div>
+  )
+}
+
+function CliSurfaceFooter({
+  error,
+  runState,
+  footerContent,
+}: {
+  error: string | null
+  runState: CliRuntimeRunState
+  footerContent: ReactNode
+}) {
+  const { t } = useLanguage()
+  const stateLabels: Record<CliRuntimeRunState, string> = {
+    idle: t('chat.cliSurface.state.idle', '空闲'),
+    running: t('chat.cliSurface.state.running', 'CLI 正在回复…'),
+    waiting_for_approval: t(
+      'chat.cliSurface.state.waitingForApproval',
+      '等待工具审批',
+    ),
+    waiting_for_user: t('chat.cliSurface.state.waitingForUser', '等待你的回答'),
+    completed: t('chat.cliSurface.state.completed', '回复完成'),
+    aborted: t('chat.cliSurface.state.aborted', '回复已停止'),
+    error: t('chat.cliSurface.state.error', 'CLI 运行出错'),
+  }
+  const showRunState = runState !== 'idle'
+
+  return (
+    <div className="yolo-cli-chat-surface__footer">
+      {error ? (
+        <div className="yolo-cli-chat-surface__error" role="alert">
+          {t('chat.cliSurface.error', 'CLI 会话出错：{message}').replace(
+            '{message}',
+            error,
+          )}
+        </div>
+      ) : null}
+      {showRunState ? (
+        <div
+          className="yolo-cli-chat-surface__run-state"
+          data-run-state={runState}
+          role="status"
+        >
+          {stateLabels[runState]}
+        </div>
+      ) : null}
+      {footerContent}
+    </div>
+  )
+}
+
+export function CliChatSurface({
+  controller,
+  actions,
+  footerContent,
+}: CliChatSurfaceProps) {
+  const { t } = useLanguage()
+  const snapshot = useCliConversationSnapshot(controller)
+  const messages = useMemo(() => [...snapshot.messages], [snapshot.messages])
+  const readModel = useChatTimelineReadModel({ messages })
+  const activeStreamingMessageId = getActiveStreamingMessageId(
+    snapshot.messages,
+    snapshot.runState,
+  )
+  const timelineItems = useMemo(
+    () =>
+      buildMessageTimelineItems({
+        groupedChatMessages: readModel.groupedChatMessages,
+        revisionsById: readModel.revisionsById,
+        activeEditableMessageId: null,
+        activeStreamingMessageId,
+        includeBottomAnchor: true,
+      }),
+    [activeStreamingMessageId, readModel],
+  )
+  const stableTimelineItems = useStableChatTimelineItems(timelineItems)
+  const latestAssistantGroupId = getLatestAssistantGroupId(
+    readModel.groupedChatMessages,
+  )
+  const conversationId = snapshot.sessionRef
+    ? getConversationId(snapshot.sessionRef)
+    : `cli:${snapshot.runtimeId}:unbound`
+  const runSummary = useMemo(
+    () =>
+      buildRunSummary({
+        conversationId,
+        messages: snapshot.messages,
+        runState: snapshot.runState,
+      }),
+    [conversationId, snapshot.messages, snapshot.runState],
+  )
+
+  const chatMessagesRef = useRef<HTMLDivElement>(null)
+  const [chatMessagesElement, setChatMessagesElement] =
+    useState<HTMLElement | null>(null)
+  const [bottomSentinelElement, setBottomSentinelElement] =
+    useState<HTMLElement | null>(null)
+  const { autoScrollToBottom, forceScrollToBottom, isAutoFollowEnabled } =
+    useAutoScroll({
+      scrollContainerRef: chatMessagesRef,
+      scrollContainerElement: chatMessagesElement,
+      bottomSentinelElement,
+      followKey: conversationId,
+    })
+  useLayoutEffect(() => {
+    autoScrollToBottom()
+  }, [autoScrollToBottom, snapshot.messages])
+
+  const renderTimelineItem = useCallback(
+    (timelineItem: ChatTimelineItem): ReactNode => {
+      if (timelineItem.kind === 'bottom-anchor') {
+        return <div className="yolo-cli-chat-surface__bottom-anchor" />
+      }
+
+      if (timelineItem.kind === 'user-message') {
+        const message = readModel.messagesById.get(timelineItem.messageId)
+        return message?.role === 'user' ? (
+          <CliUserMessage message={message} />
+        ) : null
+      }
+
+      if (timelineItem.kind !== 'assistant-group') return null
+
+      const messageGroup = timelineItem.messageIds
+        .map((messageId) => readModel.messagesById.get(messageId))
+        .filter(
+          (message): message is AssistantToolMessageGroup[number] =>
+            message !== undefined && message.role !== 'user',
+        )
+      if (messageGroup.length === 0) return null
+      if (!snapshot.sessionRef) {
+        throw new Error(
+          'CLI assistant/tool groups require a bound provider session.',
+        )
+      }
+
+      const sessionConversationId = getConversationId(snapshot.sessionRef)
+      return (
+        <ChatRuntimeActionsProvider
+          actions={actions}
+          conversation={snapshot.sessionRef}
+        >
+          <AssistantToolMessageGroupItem
+            messages={messageGroup}
+            conversationId={sessionConversationId}
+            conversationRunSummary={
+              timelineItem.groupId === latestAssistantGroupId
+                ? runSummary
+                : undefined
+            }
+            showInlineInfo={false}
+            showRetryAction={false}
+            showInsertAction={false}
+            showCopyAction
+            showBranchAction={false}
+            showEditAction={false}
+            showDeleteAction={false}
+            showQuoteAction={false}
+            isApplying={false}
+            activeApplyRequestKey={null}
+            onApply={noop}
+            onToolMessageUpdate={noopToolMessageUpdate}
+            onRecoverAnswerUserQuestion={noop}
+            onEditStart={noop}
+            onEditCancel={noop}
+            onEditSave={noop}
+            onDeleteGroup={noop}
+            onRetryGroup={noop}
+            onBranchGroup={noop}
+            onQuoteAssistantSelection={noop}
+            onOpenEditSummaryFile={noopOpenEditSummaryFile}
+          />
+        </ChatRuntimeActionsProvider>
+      )
+    },
+    [
+      actions,
+      latestAssistantGroupId,
+      readModel.messagesById,
+      runSummary,
+      snapshot.sessionRef,
+    ],
+  )
+
+  const renderVersion = useCallback(
+    (timelineItem: ChatTimelineItem): string =>
+      `${timelineItem.renderKey}:${
+        timelineItem.kind === 'assistant-group' ||
+        timelineItem.kind === 'user-message'
+          ? timelineItem.revision
+          : 0
+      }:${snapshot.runState}`,
+    [snapshot.runState],
+  )
+
+  const showEmptyState =
+    readModel.groupedChatMessages.length === 0 &&
+    !ACTIVE_RUN_STATES.has(snapshot.runState)
+
+  return (
+    <div
+      className={`yolo-cli-chat-surface${
+        showEmptyState ? ' yolo-cli-chat-surface--empty' : ''
+      }`}
+      data-runtime-id={snapshot.runtimeId}
+    >
+      <ChatConversationPane
+        chatMode="agent"
+        yoloEnabled={false}
+        showEmptyState={showEmptyState}
+        groupedChatMessagesLength={readModel.groupedChatMessages.length}
+        isAutoFollowEnabled={isAutoFollowEnabled}
+        currentConversationId={conversationId}
+        chatTimelineItems={stableTimelineItems}
+        timelineRenderVersion={renderVersion}
+        chatMessagesRef={chatMessagesRef}
+        onScrollContainerChange={setChatMessagesElement}
+        onBottomSentinelChange={setBottomSentinelElement}
+        renderChatTimelineItem={renderTimelineItem}
+        editingAssistantMessageId={null}
+        onForceScrollToBottom={forceScrollToBottom}
+        hasStreamingMessages={ACTIVE_RUN_STATES.has(snapshot.runState)}
+        scrollToBottomLabel={t('chat.scrollToBottom', '回到底部')}
+        scrollToBottomWhileStreamingLabel={t(
+          'chat.scrollToBottomWhileStreaming',
+          '回到底部继续跟随',
+        )}
+        emptyStateAskTitle={t(
+          'chat.cliSurface.emptyTitle',
+          '开始一个 CLI 会话',
+        )}
+        emptyStateAgentTitle={t(
+          'chat.cliSurface.emptyTitle',
+          '开始一个 CLI 会话',
+        )}
+        emptyStateAgentFullTitle={t(
+          'chat.cliSurface.emptyTitle',
+          '开始一个 CLI 会话',
+        )}
+        emptyStateAskDescription={t(
+          'chat.cliSurface.emptyDescription',
+          '发送消息后，原生 CLI 对话会显示在这里。',
+        )}
+        emptyStateAgentDescription={t(
+          'chat.cliSurface.emptyDescription',
+          '发送消息后，原生 CLI 对话会显示在这里。',
+        )}
+        emptyStateAgentFullDescription={t(
+          'chat.cliSurface.emptyDescription',
+          '发送消息后，原生 CLI 对话会显示在这里。',
+        )}
+        footerContent={
+          <CliSurfaceFooter
+            error={snapshot.error}
+            runState={snapshot.runState}
+            footerContent={footerContent}
+          />
+        }
+      />
+    </div>
+  )
+}
+
+export default CliChatSurface

--- a/src/components/chat-view/CliChatSurface.tsx
+++ b/src/components/chat-view/CliChatSurface.tsx
@@ -170,6 +170,7 @@ function CliUserMessage({ message }: { message: ChatUserMessage }) {
     >
       <UserMessageCard
         className="yolo-cli-chat-surface__user-card"
+        interactive={false}
         snapshot={{
           content: message.content,
           text,

--- a/src/components/chat-view/UserMessageCard.test.tsx
+++ b/src/components/chat-view/UserMessageCard.test.tsx
@@ -1,0 +1,48 @@
+jest.mock('../../contexts/settings-context', () => ({
+  useSettings: () => ({
+    settings: { chatOptions: { mentionDisplayMode: 'inline' } },
+  }),
+}))
+
+jest.mock('./ReadOnlyUserMessageContent', () => ({
+  __esModule: true,
+  default: ({ fallbackText }: { fallbackText: string }) => fallbackText,
+}))
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import type { UserMessageDisplaySnapshot } from '../../types/chat-timeline'
+
+import UserMessageCard from './UserMessageCard'
+
+const snapshot: UserMessageDisplaySnapshot = {
+  content: null,
+  text: 'Read-only history',
+  mentionables: [],
+  selectedSkills: [],
+}
+
+describe('UserMessageCard interaction semantics', () => {
+  it('preserves interactive semantics by default', () => {
+    const html = renderToStaticMarkup(
+      <UserMessageCard snapshot={snapshot} onClick={jest.fn()} />,
+    )
+
+    expect(html).toContain('role="button"')
+    expect(html).toContain('tabindex="0"')
+  })
+
+  it('removes button and keyboard semantics when rendered read-only', () => {
+    const html = renderToStaticMarkup(
+      <UserMessageCard
+        snapshot={snapshot}
+        interactive={false}
+        onClick={jest.fn()}
+      />,
+    )
+
+    expect(html).not.toContain('role="button"')
+    expect(html).not.toContain('tabindex=')
+  })
+})

--- a/src/components/chat-view/UserMessageCard.tsx
+++ b/src/components/chat-view/UserMessageCard.tsx
@@ -18,6 +18,7 @@ type UserMessageCardProps = {
   snapshot: UserMessageDisplaySnapshot
   onClick: () => void
   className?: string
+  interactive?: boolean
 }
 
 const ReadOnlyBadge = memo(function ReadOnlyBadge({
@@ -53,6 +54,7 @@ function UserMessageCard({
   snapshot,
   onClick,
   className,
+  interactive = true,
 }: UserMessageCardProps) {
   const { settings } = useSettings()
   const mentionDisplayMode = settings.chatOptions.mentionDisplayMode ?? 'inline'
@@ -76,11 +78,11 @@ function UserMessageCard({
 
   return (
     <div
-      role="button"
-      tabIndex={0}
+      role={interactive ? 'button' : undefined}
+      tabIndex={interactive ? 0 : undefined}
       className={`yolo-user-message-card yolo-chat-user-input-wrapper yolo-chat-user-input-wrapper--compact${className ? ` ${className}` : ''}`}
-      onClick={onClick}
-      onKeyDown={handleKeyDown}
+      onClick={interactive ? onClick : undefined}
+      onKeyDown={interactive ? handleKeyDown : undefined}
     >
       {mentionDisplayMode === 'badge' &&
         (snapshot.mentionables.length > 0 ||

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1944,6 +1944,22 @@ export const en: TranslationKeys = {
       agentFullDescription:
         'Auto-approve tool calls for search, read/write operations, and multi-step tasks.',
     },
+    cliSurface: {
+      emptyTitle: 'Start a CLI session',
+      emptyDescription:
+        'Native CLI conversation messages will appear here after you send a message.',
+      emptyUserMessage: 'Empty message',
+      error: 'CLI session error: {message}',
+      state: {
+        idle: 'Idle',
+        running: 'CLI is responding…',
+        waitingForApproval: 'Waiting for tool approval',
+        waitingForUser: 'Waiting for your answer',
+        completed: 'Response complete',
+        aborted: 'Response stopped',
+        error: 'CLI run failed',
+      },
+    },
     quickAccess: {
       manage: 'Manage quick access',
       searchPlaceholder: 'Search skills or snippets',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1790,6 +1790,22 @@ export const it: DeepPartial<TranslationKeys> = {
       agentFullDescription:
         'Approva automaticamente gli strumenti per ricerca, lettura/scrittura e task multi-step.',
     },
+    cliSurface: {
+      emptyTitle: 'Avvia una sessione CLI',
+      emptyDescription:
+        'I messaggi della conversazione CLI nativa appariranno qui dopo il primo invio.',
+      emptyUserMessage: 'Messaggio vuoto',
+      error: 'Errore della sessione CLI: {message}',
+      state: {
+        idle: 'Inattivo',
+        running: 'La CLI sta rispondendo…',
+        waitingForApproval: 'In attesa di approvazione dello strumento',
+        waitingForUser: 'In attesa della tua risposta',
+        completed: 'Risposta completata',
+        aborted: 'Risposta interrotta',
+        error: 'Esecuzione CLI non riuscita',
+      },
+    },
     quickAccess: {
       manage: 'Gestisci accessi rapidi',
       searchPlaceholder: 'Cerca skill o comandi rapidi',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -1830,6 +1830,21 @@ export const zh: TranslationKeys = {
       agentFullTitle: '让 AI 自主执行 · YOLO 模式',
       agentFullDescription: '自动放行工具调用，处理搜索、读写与多步骤任务',
     },
+    cliSurface: {
+      emptyTitle: '开始一个 CLI 会话',
+      emptyDescription: '发送消息后，原生 CLI 对话会显示在这里。',
+      emptyUserMessage: '空消息',
+      error: 'CLI 会话出错：{message}',
+      state: {
+        idle: '空闲',
+        running: 'CLI 正在回复…',
+        waitingForApproval: '等待工具审批',
+        waitingForUser: '等待你的回答',
+        completed: '回复完成',
+        aborted: '回复已停止',
+        error: 'CLI 运行出错',
+      },
+    },
     quickAccess: {
       manage: '管理常用入口',
       searchPlaceholder: '搜索 Skills 或快捷指令',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1662,6 +1662,21 @@ export type TranslationKeys = {
       agentFullTitle?: string
       agentFullDescription?: string
     }
+    cliSurface?: {
+      emptyTitle?: string
+      emptyDescription?: string
+      emptyUserMessage?: string
+      error?: string
+      state?: {
+        idle?: string
+        running?: string
+        waitingForApproval?: string
+        waitingForUser?: string
+        completed?: string
+        aborted?: string
+        error?: string
+      }
+    }
     quickAccess?: {
       manage?: string
       searchPlaceholder?: string

--- a/src/styles/chat/cli-chat-surface.css
+++ b/src/styles/chat/cli-chat-surface.css
@@ -1,0 +1,32 @@
+.yolo-cli-chat-surface {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.yolo-cli-chat-surface__user-card {
+  cursor: text;
+  user-select: text;
+}
+
+.yolo-cli-chat-surface__footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-2-2);
+}
+
+.yolo-cli-chat-surface__run-state,
+.yolo-cli-chat-surface__error {
+  padding: 0 var(--size-4-2);
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+}
+
+.yolo-cli-chat-surface__error {
+  color: var(--text-error);
+}
+
+.yolo-cli-chat-surface__bottom-anchor {
+  height: 1px;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -26,6 +26,7 @@
 @import './chat/ask-user-question-panel.css';
 @import './chat/new-tab-action.css';
 @import './chat/cli-session-list.css';
+@import './chat/cli-chat-surface.css';
 
 @import './panels/smart-space.css';
 @import './panels/quick-ask.css';

--- a/styles.css
+++ b/styles.css
@@ -20629,6 +20629,39 @@ button.yolo-cli-session-list__forget:is(:hover, :focus-visible) {
   }
 }
 
+.yolo-cli-chat-surface {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.yolo-cli-chat-surface__user-card {
+  cursor: text;
+  user-select: text;
+}
+
+.yolo-cli-chat-surface__footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-2-2);
+}
+
+.yolo-cli-chat-surface__run-state,
+.yolo-cli-chat-surface__error {
+  padding: 0 var(--size-4-2);
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+}
+
+.yolo-cli-chat-surface__error {
+  color: var(--text-error);
+}
+
+.yolo-cli-chat-surface__bottom-anchor {
+  height: 1px;
+}
+
 /* Custom continue inline panel */
 
 .yolo-smart-space-overlay-host {


### PR DESCRIPTION
Adds a separate provider-native CLI timeline using existing message/tool renderers without writing into YOLO chat state. User history is read-only, pending actions use the native session ref, and promptContent hydration is rendered correctly.\n\nTests: 9 focused tests; npm run type:check; npm run styles:build.