### PR TITLE
fix(cli): harden native runtime protocols and sessions

### DIFF
--- a/scripts/verify-runtime-component-boundaries.mjs
+++ b/scripts/verify-runtime-component-boundaries.mjs
@@ -1,6 +1,5 @@
-import { stat, readFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 
-const HOST_BUDGET_BYTES = 8 * 1024 * 1024
 const hostMetafile = JSON.parse(await readFile('meta.json', 'utf8'))
 const inputs = Object.keys(hostMetafile.inputs).map((path) =>
   path.replaceAll('\\', '/'),
@@ -20,13 +19,6 @@ for (const dependency of forbidden) {
   if (match) {
     throw new Error(`Host bundle contains runtime dependency: ${match}`)
   }
-}
-
-const size = (await stat('main.js')).size
-if (size > HOST_BUDGET_BYTES) {
-  throw new Error(
-    `main.js is ${size} bytes, exceeding the ${HOST_BUDGET_BYTES}-byte runtime-component budget`,
-  )
 }
 
 const expectedClosures = {
@@ -53,4 +45,4 @@ for (const [componentId, dependencies] of Object.entries(expectedClosures)) {
   }
 }
 
-console.log(`Runtime component boundaries verified; main.js=${size} bytes`)
+console.log('Runtime component boundaries verified')

--- a/src/core/cli-runtime/claude/ClaudeCliRuntime.test.ts
+++ b/src/core/cli-runtime/claude/ClaudeCliRuntime.test.ts
@@ -9,6 +9,7 @@ import type {
 import { Platform } from 'obsidian'
 
 import { ToolCallResponseStatus } from '../../../types/tool-call.types'
+import { CliConversationController } from '../conversation-controller'
 import type { CliRuntimeEvent } from '../types'
 
 import { ClaudeCliRuntime } from './ClaudeCliRuntime'
@@ -80,7 +81,7 @@ const createSdk = () => {
   const queryInputs: QueryInput[] = []
   const listSessions = jest.fn<
     Promise<SDKSessionInfo[]>,
-    [options?: { dir?: string }]
+    [options?: { dir?: string; limit?: number; offset?: number }]
   >(async () => [])
   const getSessionMessages = jest.fn<
     Promise<SessionMessage[]>,
@@ -304,10 +305,8 @@ describe('ClaudeCliRuntime', () => {
       nativeSessionId: 'session-1',
     })
 
-    expect(listSessions).toHaveBeenCalledWith({ dir: '/vault' })
-    expect(getSessionMessages).toHaveBeenCalledWith('session-1', {
-      dir: '/vault',
-    })
+    expect(listSessions).toHaveBeenCalledWith({ limit: 100, offset: 0 })
+    expect(getSessionMessages).toHaveBeenCalledWith('session-1')
     expect(hydration.messages).toHaveLength(5)
     expect(hydration.messages[0]).toMatchObject({
       role: 'user',
@@ -376,6 +375,79 @@ describe('ClaudeCliRuntime', () => {
     })
   })
 
+  it('paginates global discovery and exposes only root or descendant sessions', async () => {
+    const { sdk, listSessions } = createSdk()
+    const outsideSessions = Array.from(
+      { length: 96 },
+      (_, index): SDKSessionInfo => ({
+        sessionId: `outside-${index}`,
+        summary: `Outside ${index}`,
+        lastModified: index,
+        cwd: `/outside/${index}`,
+      }),
+    )
+    listSessions.mockImplementation(async (options) => {
+      if ((options?.offset ?? 0) === 0) {
+        return [
+          {
+            sessionId: 'root',
+            summary: 'Root',
+            lastModified: 4,
+            cwd: '/vault',
+          },
+          {
+            sessionId: 'descendant',
+            summary: 'Descendant',
+            lastModified: 3,
+            cwd: '/vault/projects/one',
+          },
+          {
+            sessionId: 'sibling',
+            summary: 'Sibling',
+            lastModified: 2,
+            cwd: '/other',
+          },
+          {
+            sessionId: 'prefix-spoof',
+            summary: 'Prefix spoof',
+            lastModified: 1,
+            cwd: '/vault-copy',
+          },
+          ...outsideSessions,
+        ]
+      }
+      return [
+        {
+          sessionId: 'second-page-descendant',
+          summary: 'Second page',
+          lastModified: 5,
+          cwd: '/vault/projects/two',
+        },
+      ]
+    })
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk: async () => sdk,
+      resolveProcessSupport: async () => processSupport,
+    })
+
+    await expect(runtime.listSessions()).resolves.toMatchObject([
+      { ref: { nativeSessionId: 'root' }, cwd: '/vault' },
+      {
+        ref: { nativeSessionId: 'descendant' },
+        cwd: '/vault/projects/one',
+      },
+      {
+        ref: { nativeSessionId: 'second-page-descendant' },
+        cwd: '/vault/projects/two',
+      },
+    ])
+    expect(listSessions).toHaveBeenNthCalledWith(2, {
+      limit: 100,
+      offset: 100,
+    })
+  })
+
   it('keeps one streaming query across turns and resumes the native session', async () => {
     const { sdk, query, queryInputs } = createSdk()
     const resolvePluginPaths = jest.fn(async () => [
@@ -437,6 +509,73 @@ describe('ClaudeCliRuntime', () => {
     await expect(iterator.next()).resolves.toMatchObject({
       value: { type: 'user', message: { content: 'Second turn' } },
     })
+  })
+
+  it('binds a generated session after initialization without waiting for an init event', async () => {
+    const { sdk, query, queryInputs, queryInstance } = createSdk()
+    const runtime = new ClaudeCliRuntime({
+      vaultPath: '/vault',
+      loadSdk: async () => sdk,
+      resolveProcessSupport: async () => processSupport,
+    })
+    const events: CliRuntimeEvent[] = []
+    runtime.subscribe((event) => events.push(event))
+    const controller = new CliConversationController(runtime)
+
+    await controller.ensureReady({
+      systemPrompt: '',
+      enabledSkillNames: [],
+    })
+    const ref = controller.getSnapshot().sessionRef
+    expect(ref).toMatchObject({ runtimeId: 'claude-code' })
+    expect(ref?.nativeSessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    )
+    expect(queryInputs[0].options).toMatchObject({
+      sessionId: ref?.nativeSessionId,
+    })
+    expect(queryInputs[0].options?.resume).toBeUndefined()
+    await controller.ensureReady({
+      systemPrompt: '',
+      enabledSkillNames: [],
+    })
+    expect(query).toHaveBeenCalledTimes(1)
+
+    await controller.sendTurn({
+      userMessage: {
+        role: 'user',
+        id: 'user-first',
+        content: null,
+        promptContent: 'First turn',
+        mentionables: [],
+      },
+      content: 'First turn',
+    })
+    const prompt = queryInputs[0].prompt
+    if (typeof prompt === 'string') throw new Error('Expected streaming prompt')
+    await expect(prompt[Symbol.asyncIterator]().next()).resolves.toMatchObject({
+      value: {
+        type: 'user',
+        session_id: ref?.nativeSessionId,
+        message: { content: 'First turn' },
+      },
+    })
+
+    queryInstance.push({
+      type: 'system',
+      subtype: 'init',
+      session_id: ref?.nativeSessionId,
+    } as SDKMessage)
+    queryInstance.push({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'mismatched-session',
+    } as SDKMessage)
+    await flushPromises()
+    expect(controller.getSnapshot().sessionRef).toEqual(ref)
+    expect(events.filter((event) => event.type === 'session_bound')).toEqual([
+      { type: 'session_bound', ref },
+    ])
   })
 
   it('leaves enabled skill names unapplied when no plugin provider exists', async () => {
@@ -865,7 +1004,7 @@ describe('ClaudeCliRuntime', () => {
   })
 
   it('interrupts without discarding the persistent query', async () => {
-    const { sdk, query, queryInstance } = createSdk()
+    const { sdk, query, queryInputs, queryInstance } = createSdk()
     const runtime = new ClaudeCliRuntime({
       vaultPath: '/vault',
       loadSdk: async () => sdk,
@@ -875,10 +1014,16 @@ describe('ClaudeCliRuntime', () => {
       assistant: { systemPrompt: '', enabledSkillNames: [] },
     }
     await runtime.ensureReady(readyInput)
+    const sessionId = queryInputs[0].options?.sessionId
+    if (!sessionId) throw new Error('Expected generated Claude session ID')
+    const sessionRef = {
+      runtimeId: 'claude-code' as const,
+      nativeSessionId: sessionId,
+    }
     await runtime.sendTurn({ content: 'Start' })
     await runtime.cancel()
-    await runtime.ensureReady(readyInput)
-    await runtime.sendTurn({ content: 'Continue' })
+    await runtime.ensureReady({ ...readyInput, sessionRef })
+    await runtime.sendTurn({ sessionRef, content: 'Continue' })
 
     expect(queryInstance.interrupt).toHaveBeenCalledTimes(1)
     expect(query).toHaveBeenCalledTimes(1)

--- a/src/core/cli-runtime/claude/ClaudeCliRuntime.ts
+++ b/src/core/cli-runtime/claude/ClaudeCliRuntime.ts
@@ -16,6 +16,7 @@ import {
   createPartialToolCallArguments,
 } from '../../../types/tool-call.types'
 import { assertCliRuntimeAvailable } from '../desktop'
+import { isSessionPathInVault } from '../session-path'
 import type {
   CliApprovalResponse,
   CliAssistantBinding,
@@ -87,6 +88,8 @@ export type ClaudeCliRuntimeOptions = {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value)
+
+const CLAUDE_SESSION_PAGE_SIZE = 100
 
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
@@ -223,6 +226,7 @@ export class ClaudeCliRuntime implements CliRuntime {
   private consumePromise?: Promise<void>
   private readyKey?: string
   private currentSessionRef?: CliSessionRef
+  private publishedSessionRef?: CliSessionRef
   private activeAssistant?: ChatAssistantMessage
   private activeAssistantKey?: string
   private disposed = false
@@ -245,35 +249,52 @@ export class ClaudeCliRuntime implements CliRuntime {
   async listSessions(): Promise<CliSessionMetadata[]> {
     this.assertUsable()
     const sdk = await this.getSdk()
-    const sessions = await sdk.listSessions({ dir: this.vaultPath })
-    return sessions.map((session) => ({
-      ref: {
-        runtimeId: 'claude-code',
-        nativeSessionId: session.sessionId,
-      },
-      title:
-        session.customTitle ||
-        session.summary ||
-        session.firstPrompt ||
-        session.sessionId,
-      ...(session.firstPrompt && session.firstPrompt !== session.summary
-        ? { preview: session.firstPrompt }
-        : {}),
-      ...(session.createdAt !== undefined
-        ? { createdAt: session.createdAt }
-        : {}),
-      updatedAt: session.lastModified,
-      ...(session.cwd ? { cwd: session.cwd } : {}),
-    }))
+    const sessions: Awaited<ReturnType<ClaudeSdkModule['listSessions']>> = []
+    let offset = 0
+    while (true) {
+      const page = await sdk.listSessions({
+        limit: CLAUDE_SESSION_PAGE_SIZE,
+        offset,
+      })
+      sessions.push(...page)
+      if (page.length < CLAUDE_SESSION_PAGE_SIZE) break
+      offset += page.length
+    }
+    const belongsToVault = await Promise.all(
+      sessions.map((session) =>
+        session.cwd
+          ? isSessionPathInVault(this.vaultPath, session.cwd)
+          : Promise.resolve(false),
+      ),
+    )
+    return sessions
+      .filter((_, index) => belongsToVault[index])
+      .map((session) => ({
+        ref: {
+          runtimeId: 'claude-code',
+          nativeSessionId: session.sessionId,
+        },
+        title:
+          session.customTitle ||
+          session.summary ||
+          session.firstPrompt ||
+          session.sessionId,
+        ...(session.firstPrompt && session.firstPrompt !== session.summary
+          ? { preview: session.firstPrompt }
+          : {}),
+        ...(session.createdAt !== undefined
+          ? { createdAt: session.createdAt }
+          : {}),
+        updatedAt: session.lastModified,
+        ...(session.cwd ? { cwd: session.cwd } : {}),
+      }))
   }
 
   async openSession(ref: CliSessionRef): Promise<CliSessionHydration> {
     this.assertUsable()
     this.assertClaudeRef(ref)
     const sdk = await this.getSdk()
-    const messages = await sdk.getSessionMessages(ref.nativeSessionId, {
-      dir: this.vaultPath,
-    })
+    const messages = await sdk.getSessionMessages(ref.nativeSessionId)
     return { ref, messages: hydrateClaudeSessionMessages(messages) }
   }
 
@@ -286,17 +307,26 @@ export class ClaudeCliRuntime implements CliRuntime {
       this.resolveProcessSupport(),
       this.resolveAssistantPluginPaths(input.assistant),
     ])
-    const readyKey = JSON.stringify({
+    const readyConfiguration = {
       sessionId: input.sessionRef?.nativeSessionId,
       systemPrompt: input.assistant.systemPrompt,
       cliPath: processSupport.cliPath,
       pluginPaths,
-    })
+    }
+    const readyKey = JSON.stringify(readyConfiguration)
     if (this.query && this.readyKey === readyKey) return
 
     await this.resetQuery()
-    this.currentSessionRef = input.sessionRef
-    this.readyKey = readyKey
+    const sessionRef = input.sessionRef ?? {
+      runtimeId: 'claude-code' as const,
+      nativeSessionId: uuidv4(),
+    }
+    this.currentSessionRef = sessionRef
+    this.publishedSessionRef = undefined
+    this.readyKey = JSON.stringify({
+      ...readyConfiguration,
+      sessionId: sessionRef.nativeSessionId,
+    })
     this.inputQueue = new AsyncPushQueue<SDKUserMessage>()
     this.query = sdk.query({
       prompt: this.inputQueue,
@@ -317,7 +347,7 @@ export class ClaudeCliRuntime implements CliRuntime {
         },
         ...(input.sessionRef
           ? { resume: input.sessionRef.nativeSessionId }
-          : {}),
+          : { sessionId: sessionRef.nativeSessionId }),
         ...(pluginPaths.length > 0
           ? {
               plugins: pluginPaths.map((path) => ({
@@ -332,6 +362,7 @@ export class ClaudeCliRuntime implements CliRuntime {
     this.consumePromise = this.consume(query)
     try {
       await query.initializationResult()
+      this.publishSessionBound(sessionRef)
     } catch (error) {
       await this.resetQuery()
       throw error
@@ -628,12 +659,10 @@ export class ClaudeCliRuntime implements CliRuntime {
 
   private handleSdkMessage(message: SDKMessage): void {
     if (message.type === 'system' && message.subtype === 'init') {
-      const ref: CliSessionRef = {
+      this.publishSessionBound({
         runtimeId: 'claude-code',
         nativeSessionId: message.session_id,
-      }
-      this.currentSessionRef = ref
-      this.emit({ type: 'session_bound', ref })
+      })
       return
     }
     if (message.type === 'stream_event') {
@@ -922,6 +951,21 @@ export class ClaudeCliRuntime implements CliRuntime {
     for (const listener of this.listeners) listener(event)
   }
 
+  private publishSessionBound(ref: CliSessionRef): void {
+    if (
+      this.currentSessionRef &&
+      this.currentSessionRef.nativeSessionId !== ref.nativeSessionId
+    ) {
+      return
+    }
+    this.currentSessionRef = ref
+    if (this.publishedSessionRef?.nativeSessionId === ref.nativeSessionId) {
+      return
+    }
+    this.publishedSessionRef = ref
+    this.emit({ type: 'session_bound', ref })
+  }
+
   private emitPendingRunStateOrRunning(): void {
     const pending = Array.from(new Set(this.pendingPermissions.values()))
     const state = pending.some((request) => request.kind === 'question')
@@ -952,6 +996,8 @@ export class ClaudeCliRuntime implements CliRuntime {
     this.inputQueue = undefined
     this.consumePromise = undefined
     this.readyKey = undefined
+    this.currentSessionRef = undefined
+    this.publishedSessionRef = undefined
     this.activeAssistant = undefined
     this.activeAssistantKey = undefined
     this.tools.clear()

--- a/src/core/cli-runtime/claude/types.ts
+++ b/src/core/cli-runtime/claude/types.ts
@@ -19,7 +19,11 @@ export type ClaudeSdkModule = {
     prompt: string | AsyncIterable<SDKUserMessage>
     options?: Options
   }): ClaudeSdkQuery
-  listSessions(options?: { dir?: string }): Promise<SDKSessionInfo[]>
+  listSessions(options?: {
+    dir?: string
+    limit?: number
+    offset?: number
+  }): Promise<SDKSessionInfo[]>
   getSessionMessages(
     sessionId: string,
     options?: { dir?: string },

--- a/src/core/cli-runtime/codex/process.test.ts
+++ b/src/core/cli-runtime/codex/process.test.ts
@@ -1,0 +1,26 @@
+import { CodexAppServerProcess } from './process'
+
+jest.mock('shell-env', () => ({ shellEnvSync: () => ({}) }))
+
+describe('CodexAppServerProcess', () => {
+  it('rejects a missing executable without leaking an uncaught child error', async () => {
+    const command = `missing-codex-${Date.now()}-${Math.random()}`
+    const globals = globalThis as typeof globalThis & {
+      require?: NodeJS.Require
+    }
+    const originalRequire = globals.require
+    globals.require = require
+
+    try {
+      await expect(
+        CodexAppServerProcess.start({ command, cwd: process.cwd() }),
+      ).rejects.toThrow(
+        new RegExp(
+          `Failed to start Codex app-server \\(${command}\\).*(ENOENT|not found)`,
+        ),
+      )
+    } finally {
+      globals.require = originalRequire
+    }
+  })
+})

--- a/src/core/cli-runtime/codex/process.ts
+++ b/src/core/cli-runtime/codex/process.ts
@@ -1,14 +1,14 @@
-import type { ChildProcess } from 'node:child_process'
-
 import { loadDesktopNodeModule } from '../../../utils/platform/desktopNodeModule'
 import { assertCliRuntimeAvailable } from '../desktop'
+
+type ChildProcess = import('node:child_process').ChildProcess
 
 export type CodexProcessExitListener = (
   code: number | null,
   signal: NodeJS.Signals | null,
 ) => void
 
-export interface CodexProcessLike {
+export type CodexProcessLike = {
   write(line: string): void
   onLine(listener: (line: string) => void): () => void
   onExit(listener: CodexProcessExitListener): () => void
@@ -75,14 +75,34 @@ const getProcessEnv = async (
 export class CodexAppServerProcess implements CodexProcessLike {
   private readonly lineListeners = new Set<(line: string) => void>()
   private readonly exitListeners = new Set<CodexProcessExitListener>()
+  private readonly started: Promise<void>
   private stderr = ''
   private stdoutBuffer = ''
+  private termination:
+    | { code: number | null; signal: NodeJS.Signals | null }
+    | undefined
 
   private constructor(
     private readonly child: ChildProcess,
     private readonly spawnSpec: SpawnSpec,
     private readonly spawn: typeof import('node:child_process').spawn,
   ) {
+    this.started = new Promise<void>((resolve, reject) => {
+      let settled = false
+      child.once('spawn', () => {
+        settled = true
+        resolve()
+      })
+      child.on('error', (error) => {
+        const detail = `Failed to start Codex app-server (${spawnSpec.command}): ${error.message}`
+        this.stderr = `${this.stderr}${detail}`.slice(-8192)
+        if (!settled) {
+          settled = true
+          reject(new Error(detail))
+        }
+        this.signalExit(null, null)
+      })
+    })
     child.stdout?.on('data', (chunk: Buffer | string) => {
       this.stdoutBuffer += Buffer.isBuffer(chunk)
         ? chunk.toString('utf8')
@@ -90,19 +110,24 @@ export class CodexAppServerProcess implements CodexProcessLike {
       this.flushLines()
     })
     child.stderr?.on('data', (chunk: Buffer | string) => {
-      const text = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk)
+      const text = Buffer.isBuffer(chunk)
+        ? chunk.toString('utf8')
+        : String(chunk)
       this.stderr = `${this.stderr}${text}`.slice(-8192)
     })
     child.on('close', (code, signal) => {
-      for (const listener of this.exitListeners) listener(code, signal)
+      this.signalExit(code, signal)
     })
   }
 
-  static async start(options: CodexProcessOptions): Promise<CodexAppServerProcess> {
+  static async start(
+    options: CodexProcessOptions,
+  ): Promise<CodexAppServerProcess> {
     assertCliRuntimeAvailable('codex')
-    const { spawn } = await loadDesktopNodeModule<
-      typeof import('node:child_process')
-    >('node:child_process')
+    const { spawn } =
+      await loadDesktopNodeModule<typeof import('node:child_process')>(
+        'node:child_process',
+      )
     const spec = resolveSpawnSpec(options.command?.trim() || 'codex')
     const child = spawn(spec.command, spec.args, {
       cwd: options.cwd,
@@ -111,11 +136,19 @@ export class CodexAppServerProcess implements CodexProcessLike {
       windowsHide: true,
       windowsVerbatimArguments: spec.windowsVerbatimArguments,
     })
-    return new CodexAppServerProcess(child, spec, spawn)
+    const process = new CodexAppServerProcess(child, spec, spawn)
+    await process.started
+    return process
   }
 
   write(line: string): void {
-    if (!this.child.stdin?.writable) throw new Error('Codex app-server stdin is closed.')
+    if (this.termination) {
+      throw new Error(
+        this.getStderrSnapshot() || 'Codex app-server is not running.',
+      )
+    }
+    if (!this.child.stdin?.writable)
+      throw new Error('Codex app-server stdin is closed.')
     this.child.stdin.write(line)
   }
 
@@ -125,6 +158,11 @@ export class CodexAppServerProcess implements CodexProcessLike {
   }
 
   onExit(listener: CodexProcessExitListener): () => void {
+    if (this.termination) {
+      const { code, signal } = this.termination
+      queueMicrotask(() => listener(code, signal))
+      return () => undefined
+    }
     this.exitListeners.add(listener)
     return () => this.exitListeners.delete(listener)
   }
@@ -134,7 +172,8 @@ export class CodexAppServerProcess implements CodexProcessLike {
   }
 
   async shutdown(): Promise<void> {
-    if (this.child.exitCode !== null || this.child.killed) return
+    if (this.termination || this.child.exitCode !== null || this.child.killed)
+      return
     if (
       process.platform === 'win32' &&
       this.spawnSpec.killProcessTree &&
@@ -147,6 +186,12 @@ export class CodexAppServerProcess implements CodexProcessLike {
       return
     }
     this.child.kill('SIGTERM')
+  }
+
+  private signalExit(code: number | null, signal: NodeJS.Signals | null): void {
+    if (this.termination) return
+    this.termination = { code, signal }
+    for (const listener of this.exitListeners) listener(code, signal)
   }
 
   private flushLines(): void {

--- a/src/core/cli-runtime/codex/runtime.test.ts
+++ b/src/core/cli-runtime/codex/runtime.test.ts
@@ -5,8 +5,13 @@ import { CodexCliRuntime } from './runtime'
 
 class RpcFakeProcess implements CodexProcessLike {
   responses: unknown[] = []
+  errors: unknown[] = []
+  requests: Array<{ method: string; params: Record<string, unknown> }> = []
+  threadPages: Array<Array<typeof this.thread>> = []
+  stderr = ''
   private lineListener: ((line: string) => void) | null = null
-  private thread = {
+  private exitListener: CodexProcessExitListener | null = null
+  readonly thread = {
     id: 'thread-1',
     preview: 'First prompt',
     path: '/sessions/thread-1.jsonl',
@@ -22,15 +27,32 @@ class RpcFakeProcess implements CodexProcessLike {
       id?: string | number
       method?: string
       result?: unknown
+      error?: unknown
+      params?: Record<string, unknown>
     }
     if (request.result !== undefined) {
       this.responses.push(request.result)
       return
     }
+    if (request.error !== undefined) {
+      this.errors.push(request.error)
+      return
+    }
     if (request.id === undefined || !request.method) return
+    this.requests.push({ method: request.method, params: request.params ?? {} })
+    const pageIndex =
+      typeof request.params?.cursor === 'string'
+        ? Number(request.params.cursor)
+        : 0
+    const threadPages =
+      this.threadPages.length > 0 ? this.threadPages : [[this.thread]]
     const result =
       request.method === 'thread/list'
-        ? { data: [this.thread], nextCursor: null }
+        ? {
+            data: threadPages[pageIndex] ?? [],
+            nextCursor:
+              pageIndex + 1 < threadPages.length ? String(pageIndex + 1) : null,
+          }
         : request.method === 'thread/read'
           ? { thread: this.thread }
           : request.method === 'thread/start' ||
@@ -54,15 +76,21 @@ class RpcFakeProcess implements CodexProcessLike {
       this.lineListener = null
     }
   }
-  onExit(_listener: CodexProcessExitListener): () => void {
-    return () => undefined
+  onExit(listener: CodexProcessExitListener): () => void {
+    this.exitListener = listener
+    return () => {
+      if (this.exitListener === listener) this.exitListener = null
+    }
   }
   getStderrSnapshot(): string {
-    return ''
+    return this.stderr
   }
   async shutdown(): Promise<void> {}
   emit(message: unknown): void {
     this.lineListener?.(JSON.stringify(message))
+  }
+  emitExit(code: number | null = 1): void {
+    this.exitListener?.(code, null)
   }
 }
 
@@ -90,6 +118,40 @@ describe('CodexCliRuntime', () => {
       },
     })
     expect(events).toContain('session_bound')
+  })
+
+  it('paginates all sessions and exposes only vault root or descendant cwd values', async () => {
+    const process = new RpcFakeProcess()
+    process.threadPages = [
+      [
+        { ...process.thread, id: 'root', cwd: '/vault' },
+        {
+          ...process.thread,
+          id: 'descendant',
+          cwd: '/vault/projects/one',
+        },
+        { ...process.thread, id: 'sibling', cwd: '/other' },
+      ],
+      [{ ...process.thread, id: 'prefix-spoof', cwd: '/vault-copy' }],
+    ]
+    const runtime = new CodexCliRuntime({
+      cwd: '/vault',
+      createProcess: async () => process,
+    })
+
+    await expect(runtime.listSessions()).resolves.toMatchObject([
+      { ref: { nativeSessionId: 'root' }, cwd: '/vault' },
+      {
+        ref: { nativeSessionId: 'descendant' },
+        cwd: '/vault/projects/one',
+      },
+    ])
+    const listRequests = process.requests.filter(
+      (request) => request.method === 'thread/list',
+    )
+    expect(listRequests).toHaveLength(2)
+    expect(listRequests[0].params).not.toHaveProperty('cwd')
+    expect(listRequests[1].params).toMatchObject({ cursor: '1' })
   })
 
   it('surfaces server approvals and routes the UI decision back by tool id', async () => {
@@ -131,6 +193,123 @@ describe('CodexCliRuntime', () => {
         decision: 'reject',
       }),
     ).resolves.toBe(false)
+  })
+
+  it('uses method-specific file and permission approval response schemas', async () => {
+    const process = new RpcFakeProcess()
+    const runtime = new CodexCliRuntime({
+      cwd: '/vault',
+      createProcess: async () => process,
+    })
+    await runtime.ensureReady({
+      assistant: { systemPrompt: '', enabledSkillNames: [] },
+    })
+
+    process.emit({
+      jsonrpc: '2.0',
+      id: 101,
+      method: 'item/fileChange/requestApproval',
+      params: { itemId: 'file-1', reason: 'edit file' },
+    })
+    await expect(
+      runtime.respondApproval({ requestId: 'file-1', decision: 'reject' }),
+    ).resolves.toBe(true)
+    expect(process.responses).toContainEqual({ decision: 'decline' })
+
+    const permissions = {
+      network: { enabled: true },
+      fileSystem: { read: null, write: ['/vault/shared'] },
+    }
+    process.emit({
+      jsonrpc: '2.0',
+      id: 102,
+      method: 'item/permissions/requestApproval',
+      params: { itemId: 'permissions-once', permissions },
+    })
+    await expect(
+      runtime.respondApproval({
+        requestId: 'permissions-once',
+        decision: 'approve_once',
+      }),
+    ).resolves.toBe(true)
+    expect(process.responses).toContainEqual({
+      permissions,
+      scope: 'turn',
+    })
+
+    process.emit({
+      jsonrpc: '2.0',
+      id: 103,
+      method: 'item/permissions/requestApproval',
+      params: { itemId: 'permissions-session', permissions },
+    })
+    await runtime.respondApproval({
+      requestId: 'permissions-session',
+      decision: 'approve_for_session',
+    })
+    expect(process.responses).toContainEqual({
+      permissions,
+      scope: 'session',
+    })
+
+    process.emit({
+      jsonrpc: '2.0',
+      id: 104,
+      method: 'item/permissions/requestApproval',
+      params: { itemId: 'permissions-reject', permissions },
+    })
+    await runtime.respondApproval({
+      requestId: 'permissions-reject',
+      decision: 'reject',
+    })
+    expect(process.errors).toContainEqual({
+      code: -32000,
+      message: 'User denied the requested permissions.',
+      data: null,
+    })
+  })
+
+  it('invalidates a dead transport during a turn and rebuilds it on next readiness', async () => {
+    const first = new RpcFakeProcess()
+    const second = new RpcFakeProcess()
+    const createProcess = jest
+      .fn<Promise<CodexProcessLike>, []>()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second)
+    const runtime = new CodexCliRuntime({ cwd: '/vault', createProcess })
+    const runStates: Array<{ state: string; error?: string }> = []
+    runtime.subscribe((event) => {
+      if (event.type === 'run_state') runStates.push(event)
+    })
+    const assistant = { systemPrompt: '', enabledSkillNames: [] }
+    await runtime.ensureReady({ assistant })
+    await runtime.sendTurn({
+      sessionRef: { runtimeId: 'codex', nativeSessionId: 'thread-1' },
+      content: 'keep working',
+    })
+
+    first.stderr = 'process crashed'
+    first.emitExit()
+    await Promise.resolve()
+    expect(runStates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          state: 'error',
+          error: 'Codex app-server exited: process crashed',
+        }),
+      ]),
+    )
+
+    await runtime.ensureReady({
+      sessionRef: { runtimeId: 'codex', nativeSessionId: 'thread-1' },
+      assistant,
+    })
+    expect(createProcess).toHaveBeenCalledTimes(2)
+    expect(second.requests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ method: 'thread/resume' }),
+      ]),
+    )
   })
 
   it('maps Codex user input requests to the shared Ask User card contract', async () => {

--- a/src/core/cli-runtime/codex/runtime.ts
+++ b/src/core/cli-runtime/codex/runtime.ts
@@ -1,5 +1,6 @@
 import type { ContentPart } from '../../../types/llm/request'
 import { ToolCallResponseStatus } from '../../../types/tool-call.types'
+import { isSessionPathInVault } from '../session-path'
 import type {
   CliApprovalResponse,
   CliQuestionResponse,
@@ -84,6 +85,19 @@ const approvalDecision = (
   return 'decline'
 }
 
+const permissionApprovalResult = (
+  request: CodexServerRequest,
+  decision: Exclude<CliApprovalResponse['decision'], 'reject'>,
+): Record<string, unknown> => ({
+  permissions:
+    request.params.permissions &&
+    typeof request.params.permissions === 'object' &&
+    !Array.isArray(request.params.permissions)
+      ? request.params.permissions
+      : {},
+  scope: decision === 'approve_for_session' ? 'session' : 'turn',
+})
+
 const toCodexQuestionAnswers = (answer: unknown): Record<string, unknown> => {
   if (!answer || typeof answer !== 'object' || Array.isArray(answer)) return {}
   const rawAnswers = (answer as { answers?: unknown }).answers
@@ -121,6 +135,7 @@ export class CodexCliRuntime implements CliRuntime {
   private activeSessionRef: CliSessionRef | null = null
   private activeTurnId: string | null = null
   private assistantKey = ''
+  private disposed = false
 
   constructor(private readonly options: CodexCliRuntimeOptions) {}
 
@@ -135,9 +150,17 @@ export class CodexCliRuntime implements CliRuntime {
           limit: 100,
           sortKey: 'updated_at',
           sortDirection: 'desc',
-          cwd: this.options.cwd,
         })
-      sessions.push(...response.data.map(toSessionMetadata))
+      const belongsToVault = await Promise.all(
+        response.data.map((thread) =>
+          isSessionPathInVault(this.options.cwd, thread.cwd),
+        ),
+      )
+      sessions.push(
+        ...response.data
+          .filter((_, index) => belongsToVault[index])
+          .map(toSessionMetadata),
+      )
       cursor = response.nextCursor
     } while (cursor)
     return sessions
@@ -231,9 +254,26 @@ export class CodexCliRuntime implements CliRuntime {
     const pending = this.pendingRequests.get(response.requestId)
     if (!pending || pending.kind !== 'approval') return false
     this.deletePendingRequest(pending)
-    ;(await this.getTransport()).respond(pending.request.id, {
-      decision: approvalDecision(response.decision),
-    })
+    const transport = await this.getTransport()
+    if (pending.request.method === 'item/permissions/requestApproval') {
+      if (response.decision === 'reject') {
+        transport.respondError(
+          pending.request.id,
+          -32000,
+          'User denied the requested permissions.',
+          null,
+        )
+      } else {
+        transport.respond(
+          pending.request.id,
+          permissionApprovalResult(pending.request, response.decision),
+        )
+      }
+    } else {
+      transport.respond(pending.request.id, {
+        decision: approvalDecision(response.decision),
+      })
+    }
     return true
   }
 
@@ -253,6 +293,8 @@ export class CodexCliRuntime implements CliRuntime {
   }
 
   async dispose(): Promise<void> {
+    if (this.disposed) return
+    this.disposed = true
     if (this.transportPromise) {
       await this.transportPromise.catch(() => undefined)
     }
@@ -269,6 +311,7 @@ export class CodexCliRuntime implements CliRuntime {
   }
 
   private async getTransport(): Promise<CodexRpcTransport> {
+    if (this.disposed) throw new Error('Codex CLI runtime has been disposed.')
     if (this.transport) return this.transport
     if (this.transportPromise) return this.transportPromise
     const promise = this.createTransport()
@@ -284,21 +327,49 @@ export class CodexCliRuntime implements CliRuntime {
     const createProcess =
       this.options.createProcess ??
       ((options: CodexProcessOptions) => CodexAppServerProcess.start(options))
-    this.process = await createProcess(this.options)
-    const transport = new CodexRpcTransport(this.process)
+    const process = await createProcess(this.options)
+    this.process = process
+    const transport = new CodexRpcTransport(process)
+    transport.onFatal((error) =>
+      this.handleTransportFatal(transport, process, error),
+    )
     transport.onNotification((notification) =>
       this.handleNotification(notification.method, notification.params),
     )
     transport.onServerRequest((request) => this.handleServerRequest(request))
     try {
       await initializeCodexTransport(transport)
+      const fatalError = transport.getFatalError()
+      if (fatalError) throw fatalError
       this.transport = transport
       return transport
     } catch (error) {
       transport.dispose()
-      await this.process.shutdown()
-      this.process = null
+      if (this.process === process) {
+        this.process = null
+        await process.shutdown()
+      }
       throw error
+    }
+  }
+
+  private handleTransportFatal(
+    transport: CodexRpcTransport,
+    process: CodexProcessLike,
+    error: Error,
+  ): void {
+    if (this.transport !== transport && this.process !== process) return
+    if (this.transport === transport) this.transport = null
+    if (this.process === process) this.process = null
+    this.activeTurnId = null
+    this.assistantKey = ''
+    this.pendingRequests.clear()
+    this.streamingAssistantText.clear()
+    this.streamingReasoningText.clear()
+    transport.dispose()
+    void process.shutdown().catch(() => undefined)
+    if (!this.disposed) {
+      this.emit({ type: 'run_state', state: 'error', error: error.message })
     }
   }
 

--- a/src/core/cli-runtime/codex/transport.test.ts
+++ b/src/core/cli-runtime/codex/transport.test.ts
@@ -59,9 +59,9 @@ describe('CodexRpcTransport', () => {
     const order: string[] = []
     transport.onNotification(() => order.push('notification'))
 
-    const resultPromise = transport.request('turn/start', {}).then(() =>
-      order.push('response'),
-    )
+    const resultPromise = transport
+      .request('turn/start', {})
+      .then(() => order.push('response'))
     const sent = JSON.parse(process.writes[0]) as { id: number }
     process.emit({ jsonrpc: '2.0', method: 'turn/started', params: {} })
     process.emit({ jsonrpc: '2.0', id: sent.id, result: {} })

--- a/src/core/cli-runtime/codex/transport.ts
+++ b/src/core/cli-runtime/codex/transport.ts
@@ -1,10 +1,10 @@
+import type { CodexProcessLike } from './process'
 import type {
   CodexNotification,
   CodexServerRequest,
   JsonRpcError,
   JsonRpcId,
 } from './protocol'
-import type { CodexProcessLike } from './process'
 
 type PendingRequest = {
   method: string
@@ -16,32 +16,39 @@ type PendingRequest = {
 export type CodexNotificationListener = (
   notification: CodexNotification,
 ) => void
-export type CodexServerRequestListener = (
-  request: CodexServerRequest,
-) => void
+export type CodexServerRequestListener = (request: CodexServerRequest) => void
+export type CodexTransportFatalListener = (error: Error) => void
 
 export class CodexRpcTransport {
   private nextId = 1
   private readonly pending = new Map<number, PendingRequest>()
-  private readonly notificationListeners =
-    new Set<CodexNotificationListener>()
-  private readonly serverRequestListeners = new Set<CodexServerRequestListener>()
+  private readonly notificationListeners = new Set<CodexNotificationListener>()
+  private readonly serverRequestListeners =
+    new Set<CodexServerRequestListener>()
+  private readonly fatalListeners = new Set<CodexTransportFatalListener>()
   private readonly removeLineListener: () => void
   private readonly removeExitListener: () => void
   private disposed = false
+  private fatalError: Error | null = null
 
   constructor(private readonly process: CodexProcessLike) {
     this.removeLineListener = process.onLine((line) => this.handleLine(line))
     this.removeExitListener = process.onExit(() => {
       const stderr = process.getStderrSnapshot()
-      this.rejectAll(
-        new Error(stderr ? `Codex app-server exited: ${stderr}` : 'Codex app-server exited.'),
+      this.fail(
+        new Error(
+          stderr
+            ? `Codex app-server exited: ${stderr}`
+            : 'Codex app-server exited.',
+        ),
       )
     })
   }
 
   request<T>(method: string, params: unknown, timeoutMs = 30_000): Promise<T> {
-    if (this.disposed) return Promise.reject(new Error('Codex transport disposed.'))
+    if (this.fatalError) return Promise.reject(this.fatalError)
+    if (this.disposed)
+      return Promise.reject(new Error('Codex transport disposed.'))
     const id = this.nextId++
     return new Promise<T>((resolve, reject) => {
       const timer = timeoutMs
@@ -61,15 +68,28 @@ export class CodexRpcTransport {
   }
 
   notify(method: string, params?: unknown): void {
-    this.send({ jsonrpc: '2.0', method, ...(params === undefined ? {} : { params }) })
+    this.send({
+      jsonrpc: '2.0',
+      method,
+      ...(params === undefined ? {} : { params }),
+    })
   }
 
   respond(id: JsonRpcId, result: unknown): void {
     this.send({ jsonrpc: '2.0', id, result })
   }
 
-  respondError(id: JsonRpcId, code: number, message: string): void {
-    this.send({ jsonrpc: '2.0', id, error: { code, message } })
+  respondError(
+    id: JsonRpcId,
+    code: number,
+    message: string,
+    data?: unknown,
+  ): void {
+    this.send({
+      jsonrpc: '2.0',
+      id,
+      error: { code, message, ...(data !== undefined ? { data } : {}) },
+    })
   }
 
   onNotification(listener: CodexNotificationListener): () => void {
@@ -82,15 +102,31 @@ export class CodexRpcTransport {
     return () => this.serverRequestListeners.delete(listener)
   }
 
+  onFatal(listener: CodexTransportFatalListener): () => void {
+    if (this.fatalError) {
+      const error = this.fatalError
+      queueMicrotask(() => listener(error))
+      return () => undefined
+    }
+    this.fatalListeners.add(listener)
+    return () => this.fatalListeners.delete(listener)
+  }
+
+  getFatalError(): Error | null {
+    return this.fatalError
+  }
+
   dispose(): void {
     if (this.disposed) return
     this.disposed = true
     this.removeLineListener()
     this.removeExitListener()
     this.rejectAll(new Error('Codex transport disposed.'))
+    this.fatalListeners.clear()
   }
 
   private send(message: unknown): void {
+    if (this.fatalError) throw this.fatalError
     if (this.disposed) throw new Error('Codex transport disposed.')
     this.process.write(`${JSON.stringify(message)}\n`)
   }
@@ -145,6 +181,13 @@ export class CodexRpcTransport {
       pending.reject(error)
     }
     this.pending.clear()
+  }
+
+  private fail(error: Error): void {
+    if (this.fatalError || this.disposed) return
+    this.fatalError = error
+    this.rejectAll(error)
+    for (const listener of this.fatalListeners) listener(error)
   }
 }
 

--- a/src/core/cli-runtime/coordinator.test.ts
+++ b/src/core/cli-runtime/coordinator.test.ts
@@ -28,6 +28,7 @@ const indexStore = (): CliSessionIndexStore => ({
   list: async () => [],
   get: async () => null,
   upsert: async () => undefined,
+  update: async (_ref, mutator) => mutator(null),
   remove: async () => false,
 })
 

--- a/src/core/cli-runtime/coordinator.ts
+++ b/src/core/cli-runtime/coordinator.ts
@@ -11,6 +11,7 @@ import type { CodexCliRuntimeOptions } from './codex'
 import { CliConversationController } from './conversation-controller'
 import type {
   CliSessionIndexEntry,
+  CliSessionIndexMutator,
   CliSessionIndexStore,
 } from './session-index'
 import { CliSessionService } from './session-service'
@@ -96,6 +97,13 @@ class SettingsAwareSessionIndexStore implements CliSessionIndexStore {
 
   upsert(entry: CliSessionIndexEntry): Promise<void> {
     return this.enqueueWrite(() => this.currentStore().upsert(entry))
+  }
+
+  update(
+    ref: CliSessionRef,
+    mutator: CliSessionIndexMutator,
+  ): Promise<CliSessionIndexEntry> {
+    return this.enqueueWrite(() => this.currentStore().update(ref, mutator))
   }
 
   remove(ref: CliSessionRef): Promise<boolean> {

--- a/src/core/cli-runtime/session-index.ts
+++ b/src/core/cli-runtime/session-index.ts
@@ -29,7 +29,8 @@ export const cliSessionIndexDocumentSchema = z
         context.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['sessions', key],
-          message: 'Session index key does not match its runtime/native identity.',
+          message:
+            'Session index key does not match its runtime/native identity.',
         })
       }
     }
@@ -55,9 +56,7 @@ export const toCliSessionRef = (
 ): CliSessionRef => ({
   runtimeId: entry.runtimeId,
   nativeSessionId: entry.nativeSessionId,
-  ...(entry.sessionPathHint
-    ? { sessionPathHint: entry.sessionPathHint }
-    : {}),
+  ...(entry.sessionPathHint ? { sessionPathHint: entry.sessionPathHint } : {}),
 })
 
 export const createCliSessionIndexEntry = ({
@@ -74,9 +73,17 @@ export const createCliSessionIndexEntry = ({
     ...overlay,
   })
 
-export interface CliSessionIndexStore {
+export type CliSessionIndexMutator = (
+  current: CliSessionIndexEntry | null,
+) => CliSessionIndexEntry
+
+export type CliSessionIndexStore = {
   list(): Promise<CliSessionIndexEntry[]>
   get(ref: CliSessionRef): Promise<CliSessionIndexEntry | null>
   upsert(entry: CliSessionIndexEntry): Promise<void>
+  update(
+    ref: CliSessionRef,
+    mutator: CliSessionIndexMutator,
+  ): Promise<CliSessionIndexEntry>
   remove(ref: CliSessionRef): Promise<boolean>
 }

--- a/src/core/cli-runtime/session-path.test.ts
+++ b/src/core/cli-runtime/session-path.test.ts
@@ -1,0 +1,61 @@
+import { isSessionPathInVault } from './session-path'
+
+const unavailableRealpath = async (): Promise<string> => {
+  throw new Error('path no longer exists')
+}
+
+describe('native CLI session path ownership', () => {
+  it.each([
+    ['/vault', true],
+    ['/vault/project', true],
+    ['/vault-sibling', false],
+    ['/vault/../outside', false],
+    ['/outside', false],
+  ])('classifies POSIX path %s', async (candidate, expected) => {
+    await expect(
+      isSessionPathInVault('/vault', candidate, {
+        platform: 'linux',
+        realpath: unavailableRealpath,
+      }),
+    ).resolves.toBe(expected)
+  })
+
+  it('uses real paths when available to reject a symlink escape', async () => {
+    const realPaths: Record<string, string> = {
+      '/vault': '/real/vault',
+      '/vault/link': '/outside/project',
+    }
+    await expect(
+      isSessionPathInVault('/vault', '/vault/link', {
+        platform: 'linux',
+        realpath: async (path) => realPaths[path],
+      }),
+    ).resolves.toBe(false)
+  })
+
+  it('falls back to lexical ownership when stale paths cannot be resolved', async () => {
+    await expect(
+      isSessionPathInVault('/vault', '/vault/deleted-project', {
+        platform: 'linux',
+        realpath: unavailableRealpath,
+      }),
+    ).resolves.toBe(true)
+  })
+
+  it.each([
+    ['C:\\Vault', 'c:\\vault\\project', true],
+    ['C:\\Vault', 'C:\\VaultSibling', false],
+    ['C:\\Vault', 'C:\\Vault\\..\\outside', false],
+    ['C:\\Vault', 'D:\\Vault\\project', false],
+  ])(
+    'uses Windows lexical semantics for %s and %s',
+    async (root, candidate, expected) => {
+      await expect(
+        isSessionPathInVault(root, candidate, {
+          platform: 'win32',
+          realpath: unavailableRealpath,
+        }),
+      ).resolves.toBe(expected)
+    },
+  )
+})

--- a/src/core/cli-runtime/session-path.ts
+++ b/src/core/cli-runtime/session-path.ts
@@ -1,0 +1,57 @@
+type SessionPathOptions = {
+  platform?: NodeJS.Platform
+  realpath?: (path: string) => Promise<string>
+}
+
+const isSameOrDescendant = (
+  path: typeof import('node:path').posix,
+  root: string,
+  candidate: string,
+): boolean => {
+  const relative = path.relative(root, candidate)
+  return (
+    relative === '' ||
+    (relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  )
+}
+
+/**
+ * Checks whether a provider-native session cwd belongs to the current vault.
+ * Existing paths use their real locations so symlinks cannot escape the vault;
+ * stale transcript paths fall back to platform-correct lexical comparison.
+ */
+export const isSessionPathInVault = async (
+  vaultRoot: string,
+  candidate: string,
+  options: SessionPathOptions = {},
+): Promise<boolean> => {
+  // eslint-disable-next-line import/no-nodejs-modules -- CLI runtimes call this only behind the desktop capability gate
+  const pathModule = await import('node:path')
+  const platform = options.platform ?? process.platform
+  const path = platform === 'win32' ? pathModule.win32 : pathModule.posix
+  if (!path.isAbsolute(vaultRoot) || !path.isAbsolute(candidate)) return false
+
+  const lexicalRoot = path.resolve(vaultRoot)
+  const lexicalCandidate = path.resolve(candidate)
+  const lexicalResult = isSameOrDescendant(path, lexicalRoot, lexicalCandidate)
+
+  try {
+    const realpath =
+      options.realpath ??
+      // eslint-disable-next-line import/no-nodejs-modules -- CLI runtimes call this only behind the desktop capability gate
+      (await import('node:fs/promises')).realpath
+    const [realRoot, realCandidate] = await Promise.all([
+      realpath(lexicalRoot),
+      realpath(lexicalCandidate),
+    ])
+    return isSameOrDescendant(
+      path,
+      path.resolve(realRoot),
+      path.resolve(realCandidate),
+    )
+  } catch {
+    return lexicalResult
+  }
+}

--- a/src/core/cli-runtime/session-service.test.ts
+++ b/src/core/cli-runtime/session-service.test.ts
@@ -12,6 +12,7 @@ import type {
 
 class MemoryIndex implements CliSessionIndexStore {
   entries = new Map<string, CliSessionIndexEntry>()
+  private writeTail: Promise<void> = Promise.resolve()
   async list(): Promise<CliSessionIndexEntry[]> {
     return [...this.entries.values()]
   }
@@ -20,6 +21,23 @@ class MemoryIndex implements CliSessionIndexStore {
   }
   async upsert(entry: CliSessionIndexEntry): Promise<void> {
     this.entries.set(getCliSessionIndexKey(entry), entry)
+  }
+  update(
+    ref: Parameters<CliSessionIndexStore['update']>[0],
+    mutator: Parameters<CliSessionIndexStore['update']>[1],
+  ): Promise<CliSessionIndexEntry> {
+    const operation = this.writeTail.then(async () => {
+      const key = getCliSessionIndexKey(ref)
+      await Promise.resolve()
+      const next = mutator(this.entries.get(key) ?? null)
+      this.entries.set(key, next)
+      return next
+    })
+    this.writeTail = operation.then(
+      () => undefined,
+      () => undefined,
+    )
+    return operation
   }
   async remove(ref: Parameters<CliSessionIndexStore['remove']>[0]) {
     return this.entries.delete(getCliSessionIndexKey(ref))
@@ -193,5 +211,34 @@ describe('CliSessionService', () => {
       pinnedAt: 456,
     })
     await expect(service.removeOverlay(ref)).resolves.toBe(true)
+  })
+
+  it('preserves independently updated overlay fields under concurrency', async () => {
+    const index = new MemoryIndex()
+    const ref = {
+      runtimeId: 'codex' as const,
+      nativeSessionId: 'thread-concurrent',
+      sessionPathHint: '/vault/thread-concurrent.jsonl',
+    }
+    const service = new CliSessionService({
+      runtimes: [runtime({ runtimeId: 'codex' })],
+      indexStore: index,
+    })
+
+    await Promise.all([
+      service.recordOpenedSession({ ref, messages: [] }, { openedAt: 100 }),
+      service.setAssistantBinding(ref, 'assistant-concurrent'),
+      service.setPinned(ref, true, 200),
+    ])
+
+    await expect(index.get(ref)).resolves.toEqual({
+      runtimeId: 'codex',
+      nativeSessionId: 'thread-concurrent',
+      sessionPathHint: '/vault/thread-concurrent.jsonl',
+      assistantId: 'assistant-concurrent',
+      lastOpenedAt: 100,
+      isPinned: true,
+      pinnedAt: 200,
+    })
   })
 })

--- a/src/core/cli-runtime/session-service.ts
+++ b/src/core/cli-runtime/session-service.ts
@@ -123,8 +123,7 @@ export class CliSessionService {
     options: OpenCliSessionOptions = {},
   ): Promise<void> {
     const ref = hydration.ref
-    const existing = await this.indexStore.get(ref)
-    await this.indexStore.upsert(
+    await this.indexStore.update(ref, (existing) =>
       createCliSessionIndexEntry({
         runtimeId: ref.runtimeId,
         nativeSessionId: ref.nativeSessionId,
@@ -153,8 +152,7 @@ export class CliSessionService {
     ref: CliSessionRef,
     assistantId: string | undefined,
   ): Promise<void> {
-    const existing = await this.indexStore.get(ref)
-    await this.indexStore.upsert(
+    await this.indexStore.update(ref, (existing) =>
       createCliSessionIndexEntry({
         runtimeId: ref.runtimeId,
         nativeSessionId: ref.nativeSessionId,
@@ -182,8 +180,7 @@ export class CliSessionService {
     pinned: boolean,
     pinnedAt = Date.now(),
   ): Promise<void> {
-    const existing = await this.indexStore.get(ref)
-    await this.indexStore.upsert(
+    await this.indexStore.update(ref, (existing) =>
       createCliSessionIndexEntry({
         runtimeId: ref.runtimeId,
         nativeSessionId: ref.nativeSessionId,

--- a/src/core/cli-runtime/vault-session-index-store.test.ts
+++ b/src/core/cli-runtime/vault-session-index-store.test.ts
@@ -7,8 +7,8 @@ const createMemoryApp = () => {
   const files = new Map<string, string>()
   const directories = new Set<string>()
   const adapter = {
-    exists: jest.fn(async (path: string) =>
-      files.has(path) || directories.has(path),
+    exists: jest.fn(
+      async (path: string) => files.has(path) || directories.has(path),
     ),
     mkdir: jest.fn(async (path: string) => {
       directories.add(path)
@@ -78,6 +78,46 @@ describe('VaultCliSessionIndexStore', () => {
     ])
 
     await expect(store.list()).resolves.toHaveLength(2)
+  })
+
+  it('serializes read-modify-write updates for one native identity', async () => {
+    const { app } = createMemoryApp()
+    const store = new VaultCliSessionIndexStore(app)
+    const ref = { runtimeId: 'codex' as const, nativeSessionId: 'thread-1' }
+
+    await Promise.all([
+      store.update(ref, (current) =>
+        createCliSessionIndexEntry({
+          ...ref,
+          ...current,
+          assistantId: 'assistant-1',
+        }),
+      ),
+      store.update(ref, (current) =>
+        createCliSessionIndexEntry({
+          ...ref,
+          ...current,
+          isPinned: true,
+          pinnedAt: 20,
+        }),
+      ),
+      store.update(ref, (current) =>
+        createCliSessionIndexEntry({
+          ...ref,
+          ...current,
+          lastOpenedAt: 30,
+        }),
+      ),
+    ])
+
+    await expect(store.get(ref)).resolves.toEqual({
+      runtimeId: 'codex',
+      nativeSessionId: 'thread-1',
+      assistantId: 'assistant-1',
+      isPinned: true,
+      pinnedAt: 20,
+      lastOpenedAt: 30,
+    })
   })
 
   it('removes only the overlay and never touches a native transcript', async () => {

--- a/src/core/cli-runtime/vault-session-index-store.ts
+++ b/src/core/cli-runtime/vault-session-index-store.ts
@@ -6,8 +6,10 @@ import {
   CLI_SESSION_INDEX_SCHEMA_VERSION,
   type CliSessionIndexDocument,
   type CliSessionIndexEntry,
+  type CliSessionIndexMutator,
   type CliSessionIndexStore,
   cliSessionIndexDocumentSchema,
+  cliSessionIndexEntrySchema,
   getCliSessionIndexKey,
 } from './session-index'
 import type { CliSessionRef } from './types'
@@ -55,12 +57,31 @@ export class VaultCliSessionIndexStore implements CliSessionIndexStore {
     })
   }
 
+  async update(
+    ref: CliSessionRef,
+    mutator: CliSessionIndexMutator,
+  ): Promise<CliSessionIndexEntry> {
+    return this.enqueueWrite(async () => {
+      const document = await this.readDocument()
+      const key = getCliSessionIndexKey(ref)
+      const next = cliSessionIndexEntrySchema.parse(
+        mutator(document.sessions[key] ?? null),
+      )
+      if (getCliSessionIndexKey(next) !== key) {
+        throw new Error('Session index update cannot change native identity.')
+      }
+      document.sessions[key] = next
+      await this.writeDocument(document)
+      return next
+    })
+  }
+
   async remove(ref: CliSessionRef): Promise<boolean> {
     return this.enqueueWrite(async () => {
       const document = await this.readDocument()
       const key = getCliSessionIndexKey(ref)
       if (!document.sessions[key]) return false
-      delete document.sessions[key]
+      Reflect.deleteProperty(document.sessions, key)
       await this.writeDocument(document)
       return true
     })
@@ -92,7 +113,9 @@ export class VaultCliSessionIndexStore implements CliSessionIndexStore {
       parsed = JSON.parse(content)
     } catch (error) {
       const detail = error instanceof Error ? ` ${error.message}` : ''
-      throw new Error(`Failed to parse ${CLI_SESSION_INDEX_FILE_NAME}.${detail}`)
+      throw new Error(
+        `Failed to parse ${CLI_SESSION_INDEX_FILE_NAME}.${detail}`,
+      )
     }
     return cliSessionIndexDocumentSchema.parse(parsed)
   }


### PR DESCRIPTION
Fixes Claude first-session readiness, vault-descendant session discovery for both providers, Codex spawn/fatal lifecycle and permissions approval wire format, and atomic session-overlay updates. Removes the obsolete absolute main.js size limit while retaining runtime dependency-boundary checks.\n\nVerification: focused runtime suites; npm run type:check; npm run build.