### PR TITLE
[auto-triage] Show requesting state before response preparation (#524)

### DIFF
--- a/src/core/agent/llm-turn-executor.test.ts
+++ b/src/core/agent/llm-turn-executor.test.ts
@@ -146,6 +146,52 @@ describe('AgentLlmTurnExecutor', () => {
     )
   })
 
+  it('publishes the streaming placeholder before preparing the request', async () => {
+    const provider = new MockProvider()
+    const observedAssistantMessages: ChatAssistantMessage[] = []
+    const requestContextBuilder = {
+      generateRequestMessages: jest.fn(async () => {
+        expect(observedAssistantMessages).toHaveLength(1)
+        expect(
+          observedAssistantMessages[0].metadata?.generationState,
+        ).toBe('streaming')
+        return [{ role: 'user' as const, content: 'hello' }]
+      }),
+    } as unknown as RequestContextBuilder
+    const mcpManager = createMockMcpManager()
+    mockExecuteSingleTurn.mockResolvedValue({
+      content: 'done',
+      reasoning: undefined,
+      annotations: undefined,
+      usage: undefined,
+      providerMetadata: undefined,
+      toolCalls: [],
+    })
+
+    const executor = new AgentLlmTurnExecutor({
+      providerClient: provider,
+      model: TEST_MODEL,
+      requestContextBuilder,
+      mcpManager,
+      conversationId: 'conv-1',
+      messages: [],
+      enableTools: false,
+      includeBuiltinTools: false,
+      onAssistantMessage: (message) => {
+        observedAssistantMessages.push({
+          ...message,
+          metadata: message.metadata ? { ...message.metadata } : undefined,
+        })
+      },
+    })
+
+    await executor.run()
+
+    expect(observedAssistantMessages.at(-1)?.metadata?.generationState).toBe(
+      'completed',
+    )
+  })
+
   it('keeps streaming arguments for local write tool previews', async () => {
     const provider = new MockProvider()
     mockExecuteSingleTurn.mockImplementation(async ({ onStreamDelta }) => {

--- a/src/core/agent/llm-turn-executor.ts
+++ b/src/core/agent/llm-turn-executor.ts
@@ -109,56 +109,6 @@ export class AgentLlmTurnExecutor {
   constructor(private readonly input: AgentLlmTurnExecutorInput) {}
 
   async run(): Promise<AgentLlmTurnExecutorOutput> {
-    const availableTools = this.input.enableTools
-      ? await this.input.mcpManager.listAvailableTools({
-          includeBuiltinTools: this.input.includeBuiltinTools,
-          // Pass the active model's modalities so built-in tool schemas
-          // (notably fs_read's modality enum) are tailored — PDF-capable
-          // models see ['text','pdf'], vision-capable see ['text','image'],
-          // text-only see no modality field at all.
-          chatModelModalities: this.input.model.modalities,
-        })
-      : []
-    const {
-      filteredTools,
-      hasTools,
-      hasMemoryTools,
-      hasOnDemandTools,
-      requestTools: tools,
-    } = await selectAllowedTools({
-      availableTools,
-      allowedToolNames: this.input.allowedToolNames,
-      toolPreferences: this.input.toolPreferences,
-      apiType: this.input.apiType,
-      enableToolDisclosure: this.input.enableToolDisclosure,
-      jsSandboxSettings: this.input.mcpManager.getJsSandboxSettings(),
-      settings: this.input.mcpManager.getSettingsSnapshot(),
-    })
-    const runtimeModePrompt = buildToolCapabilityPrompt({
-      mode: this.input.toolCapabilityMode ?? 'agent',
-      toolNames: filteredTools.map((tool) => tool.name),
-    })
-    const baseRequestMessages =
-      await this.input.requestContextBuilder.generateRequestMessages({
-        messages: this.input.messages,
-        hasTools,
-        hasMemoryTools,
-        hasOnDemandTools,
-        model: this.input.model,
-        conversationId: this.input.conversationId,
-        compaction: this.input.compaction,
-        contextualInjections: this.input.contextualInjections,
-        runtimeModePrompt,
-        systemPromptOverride: this.input.systemPromptOverride,
-        // Real LLM request: freeze (or reuse) the per-conversation system prompt.
-        systemPromptSnapshotMode: 'create',
-      })
-    const requestMessages =
-      this.input.transientRequestMessages &&
-      this.input.transientRequestMessages.length > 0
-        ? [...baseRequestMessages, ...this.input.transientRequestMessages]
-        : baseRequestMessages
-
     const responseStart = Date.now()
     const model = this.input.model
     const deliveryMode = this.input.requestParams?.deliveryMode ?? 'incremental'
@@ -217,7 +167,59 @@ export class AgentLlmTurnExecutor {
 
     let turnResult: Awaited<ReturnType<typeof executeSingleTurn>>
     let requestReasoning: ReasoningLevel | undefined
+    let requestMessages: RequestMessage[]
+    let tools: RequestTool[] | undefined
     try {
+      const availableTools = this.input.enableTools
+        ? await this.input.mcpManager.listAvailableTools({
+            includeBuiltinTools: this.input.includeBuiltinTools,
+            // Pass the active model's modalities so built-in tool schemas
+            // (notably fs_read's modality enum) are tailored — PDF-capable
+            // models see ['text','pdf'], vision-capable see ['text','image'],
+            // text-only see no modality field at all.
+            chatModelModalities: this.input.model.modalities,
+          })
+        : []
+      const {
+        filteredTools,
+        hasTools,
+        hasMemoryTools,
+        hasOnDemandTools,
+        requestTools,
+      } = await selectAllowedTools({
+        availableTools,
+        allowedToolNames: this.input.allowedToolNames,
+        toolPreferences: this.input.toolPreferences,
+        apiType: this.input.apiType,
+        enableToolDisclosure: this.input.enableToolDisclosure,
+        jsSandboxSettings: this.input.mcpManager.getJsSandboxSettings(),
+        settings: this.input.mcpManager.getSettingsSnapshot(),
+      })
+      tools = requestTools
+      const runtimeModePrompt = buildToolCapabilityPrompt({
+        mode: this.input.toolCapabilityMode ?? 'agent',
+        toolNames: filteredTools.map((tool) => tool.name),
+      })
+      const baseRequestMessages =
+        await this.input.requestContextBuilder.generateRequestMessages({
+          messages: this.input.messages,
+          hasTools,
+          hasMemoryTools,
+          hasOnDemandTools,
+          model: this.input.model,
+          conversationId: this.input.conversationId,
+          compaction: this.input.compaction,
+          contextualInjections: this.input.contextualInjections,
+          runtimeModePrompt,
+          systemPromptOverride: this.input.systemPromptOverride,
+          // Real LLM request: freeze (or reuse) the per-conversation system prompt.
+          systemPromptSnapshotMode: 'create',
+        })
+      requestMessages =
+        this.input.transientRequestMessages &&
+        this.input.transientRequestMessages.length > 0
+          ? [...baseRequestMessages, ...this.input.transientRequestMessages]
+          : baseRequestMessages
       requestReasoning = resolveRequestReasoningLevel(
         this.input.model,
         this.input.reasoningLevel,


### PR DESCRIPTION
## Summary
- Publish the existing streaming assistant placeholder before tool discovery and request-context preparation.
- Mark failures during that preparation on the same assistant message.
- Add a regression test for publishing the placeholder before request preparation.

## Analysis
Both Chat and Agent use AgentLlmTurnExecutor. Before this change, its visible streaming assistant message was created only after asynchronous tool selection and context construction, leaving no assistant-side feedback during that shared work.

## Validation
- git diff --check: passed
- npm run type:check: blocked by the available TypeScript compiler with TS5102 (the baseUrl compiler option has been removed). The repository declares TypeScript ^5.6.2, but project dependencies are not installed.
- npx jest src/core/agent/llm-turn-executor.test.ts --runInBand: blocked because project jest and ts-jest dependencies are absent; temporary Jest 30 cannot load this repository's ts-jest transform.

#524.
