### PR TITLE
[auto-triage] Align Quick Ask assistant runtime context (#529)

### DIFF
--- a/src/components/panels/quick-ask/QuickAskPanel.tsx
+++ b/src/components/panels/quick-ask/QuickAskPanel.tsx
@@ -593,17 +593,11 @@ export function QuickAskPanel({
   // runtime's `contextualInjections` channel — see editorSnapshotInjection
   // built below in the submit path.
   const requestContextBuilder = useMemo(() => {
-    const globalSystemPrompt = settings.systemPrompt || ''
-    const assistantPrompt = selectedAssistant?.systemPrompt || ''
-    const combinedSystemPrompt =
-      `${globalSystemPrompt}\n\n${assistantPrompt}`.trim()
-
     return new RequestContextBuilder(
       app,
       {
         ...settings,
         currentAssistantId: selectedAssistant?.id,
-        systemPrompt: combinedSystemPrompt,
       },
       {
         includeSkills: executionMode === 'agent' || executionMode === 'ask',
@@ -1116,6 +1110,7 @@ export function QuickAskPanel({
             enableToolDisclosure: settings.mcp.enableToolDisclosure,
             toolPreferences: chatModeRuntime.toolPreferences,
             toolServerPreferences: chatModeRuntime.toolServerPreferences,
+            workspaceScope: selectedAssistant?.workspaceScope,
             allowedSkillPaths,
             toolCapabilityMode: chatModeRuntime.toolCapabilityMode,
             contextualInjections: editorSnapshotInjection

--- a/src/features/editor/selection-rewrite/selectionRewriteController.ts
+++ b/src/features/editor/selection-rewrite/selectionRewriteController.ts
@@ -412,9 +412,10 @@ function getLengthHandleHorizontalAnchor(
     direction === Direction.RTL
       ? Math.min(...lastLine.map((rect) => rect.left))
       : Math.max(...lastLine.map((rect) => rect.left + rect.width))
-  const edgeAnchor = direction === Direction.RTL
-    ? Math.max(selectionEdge, contentCenter)
-    : Math.min(selectionEdge, contentCenter)
+  const edgeAnchor =
+    direction === Direction.RTL
+      ? Math.max(selectionEdge, contentCenter)
+      : Math.min(selectionEdge, contentCenter)
   return (
     edgeAnchor +
     (direction === Direction.RTL


### PR DESCRIPTION
## Summary
- Let the shared request-context builder add the selected Assistant instructions exactly once.
- Pass the selected Assistant workspace scope into the shared Agent runtime so Quick Ask tool calls observe the same path boundary as Chat.

## Analysis
Quick Ask already invokes `AgentService.run` and shares `resolveChatModeRuntime`, MCP/Skill resolution, streaming, cancellation, and the native Agent runtime. Its local context setup still concatenated the global and Assistant prompts before `RequestContextBuilder` appended the Assistant prompt a second time. It also omitted `workspaceScope`, so local tools could bypass an Assistant scope that Chat passes to the same runtime.

The existing Quick Ask model picker remains a separate, explicit override backed by `continuationModelId`. Changing its precedence relative to `Assistant.modelId` needs a product decision about the intended override scope, so this PR deliberately does not change that visible behavior.

## Validation
- `npm run type:check`
- `npx jest src/utils/chat/requestContextBuilder.test.ts src/core/agent/tool-gateway.test.ts --runInBand` (2 suites, 83 tests)

Related to #529.