### PR TITLE
fix(learning): run the initial card pass read-only (#494)

### DIFF
--- a/modules/bundled.json
+++ b/modules/bundled.json
@@ -34,7 +34,7 @@
       "manifestUrl": "https://github.com/Lapis0x0/obsidian-yolo/releases/download/module-learning-v0.1.2-dev.0/module.json",
       "manifest": {
         "byteSize": 1910,
-        "sha256": "4f05bac4445aede0d6bdcc4ba6f5cccc5a15125b508a10d9a20e20014a1c4042"
+        "sha256": "f273b8e33312398c722166f56433643b2e83297ebf4955cd9ae64df65a7352af"
       }
     }
   ]

--- a/modules/learning/src/generation/cardGenerator.test.ts
+++ b/modules/learning/src/generation/cardGenerator.test.ts
@@ -289,10 +289,12 @@ describe('generateCardsForChapter streaming', () => {
       if (retryWithExternalEdit) expect(written).toContain('user edit')
       expect(written).not.toMatch(/[\u4e00-\u9fff]/)
       expect(create).toHaveBeenCalledTimes(preexistingRollbackShell ? 0 : 1)
+      // The initial generation pass runs read-only: the prompt forbids fs_edit
+      // there and cards.md does not exist yet.
       expect(stream).toHaveBeenCalledWith(
         expect.objectContaining({
           modelId: 'learning-model',
-          capability: 'edit-vault',
+          capability: 'readonly-vault',
         }),
       )
       if (retryWithExternalEdit) {
@@ -476,6 +478,81 @@ describe('generateCardsForChapter streaming', () => {
       },
     ])
     warn.mockRestore()
+  })
+
+  it('requests read-only capability for the initial pass and write only for the correction pass', async () => {
+    const knowledgePath = 'project/chapter/knowledge.md'
+    const cardsPath = 'project/chapter/cards.md'
+    const capabilities: string[] = []
+    const contents = new Map<string, string>([
+      [knowledgePath, '## KP <!--kp:aaaaaaaa-->\n\nBody'],
+    ])
+    let call = 0
+
+    const host: LearningGenerationHost = {
+      vault: {
+        getEntry: (path: string) =>
+          contents.has(path)
+            ? { kind: 'file', path, name: 'f.md', ctime: 0, mtime: 0 }
+            : null,
+      } as unknown as LearningVaultReadApi,
+      vaultWriter: {
+        readTextSnapshot: async (path: string) => ({
+          path,
+          content: contents.get(path) ?? '',
+          identity: { path },
+        }),
+        createTextIfAbsent: async (path: string, content: string) => {
+          contents.set(path, content)
+          return { path, content, identity: { path } }
+        },
+        replaceTextIfUnchanged: async (
+          snapshot: { path: string },
+          content: string,
+        ) => {
+          contents.set(snapshot.path, content)
+          return {
+            path: snapshot.path,
+            content,
+            identity: { path: snapshot.path },
+          }
+        },
+      } as unknown as LearningVaultWriteApi,
+      agent: {
+        stream: async function* (request: { capability: string }) {
+          capabilities.push(request.capability)
+          call += 1
+          // First pass streams one well-formed card; the follow-up pass exists
+          // only to exercise the capability used for corrections.
+          if (call === 1) {
+            const text = `${cardBlock('A')}${CARD_END_MARKER}\n`
+            yield { type: 'text' as const, text, delta: text }
+          }
+        },
+      } as unknown as LearningGenerationHost['agent'],
+    }
+
+    await generateCardsForChapter({
+      host,
+      chapterIndex: 0,
+      projectTopic: 'Topic',
+      chapterTitle: 'Chapter',
+      chapterContract: 'Contract',
+      knowledgePath,
+      cardsPath,
+      level: 'beginner',
+      usedCardUuids: new Set(),
+      runId: 'run',
+      projectId: 'project',
+      chapterId: 'chapter',
+    }).catch(() => undefined)
+
+    // The initial generation pass must not be handed the vault write tool: the
+    // prompt forbids fs_edit there and cards.md does not exist yet.
+    expect(capabilities[0]).toBe('readonly-vault')
+    for (const capability of capabilities.slice(1)) {
+      expect(capability).toBe('edit-vault')
+    }
   })
 
   it('rejects an explicit abort before writing streamed cards', async () => {

--- a/modules/learning/src/generation/cardGenerator.ts
+++ b/modules/learning/src/generation/cardGenerator.ts
@@ -16,6 +16,7 @@ import {
 import type {
   LearningGenerationActivity,
   LearningGenerationAssistantMessage,
+  LearningGenerationCapability,
   LearningGenerationHost,
   LearningGenerationMessage,
   LearningGenerationUserMessage,
@@ -145,6 +146,13 @@ export async function generateCardsForChapter({
   const runStream = async (
     request: { prompt: string } | { messages: LearningGenerationMessage[] },
     consumeCards = false,
+    // The card prompt states that fs_edit is forbidden on the initial pass and
+    // only allowed once cards.md exists and a correction is requested. Grant
+    // the matching capability so the initial pass cannot spend its turn on a
+    // write tool: at that point cards.md has not been created yet (see
+    // createCardsFile below), so an attempted edit cannot succeed and the
+    // stream can end without ever emitting a card block.
+    capability: LearningGenerationCapability = 'readonly-vault',
   ): Promise<{ text: string; error?: Error; aborted?: true }> => {
     let accumulated = ''
     let completedText = ''
@@ -154,7 +162,7 @@ export async function generateCardsForChapter({
         ...request,
         modelId,
         systemPromptOverride: CARD_GENERATOR_PROMPT,
-        capability: 'edit-vault',
+        capability,
         workspaceScope: cardWorkspaceScope,
         activity,
         abortSignal,
@@ -255,9 +263,13 @@ export async function generateCardsForChapter({
       }
       let retryAborted = false
       try {
-        const retryRun = await runStream({
-          messages: [firstUserMessage, assistant, retry],
-        })
+        const retryRun = await runStream(
+          { messages: [firstUserMessage, assistant, retry] },
+          false,
+          // cards.md exists by now and this pass is explicitly a correction,
+          // which is exactly when the prompt permits fs_edit.
+          'edit-vault',
+        )
         retryAborted = retryRun.aborted === true
         if (retryRun.error) throw retryRun.error
       } catch (error) {


### PR DESCRIPTION
Follow-up on #494. This aligns the card generator's requested capability with what its own prompt says, and I believe it is the zero-card cause.

## The mismatch

`CARD_GENERATOR_PROMPT` states:

> **fs_edit is strictly forbidden during the initial generation pass**. fs_edit is only allowed when a later user message explicitly states that `cards.md` has been written and asks for corrections

But `runStream` hardcodes `capability: 'edit-vault'`, and it is used for **both** passes. So the initial pass is handed the vault write tool on the one pass the prompt forbids using it.

Two details make that worse than a cosmetic inconsistency:

1. `mapRequest` in `src/core/modules/moduleAgent.ts` runs module agents as `mode: 'agent', yolo: true`, and `TOOLS_BY_CAPABILITY['vault-write']` attaches `read`, `list` **and `edit`**. Auto-approved.
2. `createCardsFile` runs *after* the zero-draft check, so **`cards.md` does not exist while the initial pass is streaming** — yet `buildCardPrompt` tells the model exactly where it "will be written".

A model that takes the file path plus an auto-approved edit tool and tries to write the cards directly therefore attempts an edit against a path that does not exist, and can finish the turn without ever streaming a card block. That is precisely the observed failure: `assignedDrafts === 0`, `No card drafts generated`, and no `cards.md` on disk.

It also explains why the other two stages are unaffected: `outlineGenerator` and `knowledgePointGenerator` request `readonly-vault`/`none`, so with no workspace scope they get an **empty** tool list and behave like plain completions.

## The change

Parameterise `runStream`'s capability:

- initial pass → `readonly-vault` (the prompt still permits `fs_read`/`fs_list` for reference material, which this keeps);
- correction pass → `edit-vault`, which is exactly when the prompt allows `fs_edit` and when `cards.md` actually exists.

Tests: a new case asserts the first stream requests `readonly-vault` and any follow-up requests `edit-vault`; the existing streaming test's assertion is updated to the corrected contract. `jest modules/learning` **273 passed**, `module:typecheck` clean, prettier/eslint clean on the changed files.

## Honest scope

I have not captured a runtime trace proving the model attempts the write — the released module predates the `parserRejections` diagnostics, and `moduleAgent` had no debug hook until `ad5ebde6`, so there is nothing on disk to post-mortem (detailed in #494). What I can evidence is: the failure is 100% reproducible at the `no-usable-drafts` boundary, across two unrelated providers, at one-chapter scale, and it is isolated to the only stage that requests write capability.

So I would frame this as: the capability/prompt mismatch is a real defect worth correcting on its own terms, and it is the most plausible mechanism for the reported failure. If you'd rather land it behind the diagnostics instead, the next release carrying `parserRejections` should show `parserRejections.length === 0` on this path and confirm it directly — happy to wait for that or to test a build if you'd prefer confirmation first.
