### PR TITLE
fix(chat): 压缩状态隐藏运行时选择箭头

### DIFF
--- a/src/components/chat-view/RuntimeSelector.tsx
+++ b/src/components/chat-view/RuntimeSelector.tsx
@@ -82,6 +82,7 @@ export function RuntimeSelector({
 }: RuntimeSelectorProps) {
   const { t } = useLanguage()
   const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const expandedWidthRef = useRef(0)
   const [isCompact, setIsCompact] = useState(false)
   const menuLabelId = useId()
   const cliRuntimeAvailable = isCliRuntimeAvailable()
@@ -115,6 +116,7 @@ export function RuntimeSelector({
         gap * 2 +
         (Number.parseFloat(style.paddingInlineStart) || 0) +
         (Number.parseFloat(style.paddingInlineEnd) || 0)
+      expandedWidthRef.current = requiredWidth
 
       if (trigger.clientWidth < requiredWidth) {
         setIsCompact(true)
@@ -129,19 +131,37 @@ export function RuntimeSelector({
 
   useEffect(() => {
     const trigger = triggerRef.current
+    const header = trigger?.closest('.yolo-chat-header')
     const headerLeft = trigger?.closest('.yolo-chat-header-left')
-    if (!headerLeft || !isCompact || typeof ResizeObserver === 'undefined')
+    const headerRight = header?.querySelector<HTMLElement>(
+      '.yolo-chat-header-right',
+    )
+    if (
+      !header ||
+      !headerLeft ||
+      !isCompact ||
+      typeof ResizeObserver === 'undefined'
+    )
       return
 
-    let receivedInitialSize = false
+    const runtimeTrigger = trigger!
     const resizeObserver = new ResizeObserver(() => {
-      if (!receivedInitialSize) {
-        receivedInitialSize = true
-        return
+      const headerStyle = getComputedStyle(header)
+      const headerGap = Number.parseFloat(headerStyle.gap) || 0
+      const availableLeftWidth =
+        header.clientWidth -
+        (headerRight?.getBoundingClientRect().width ?? 0) -
+        headerGap
+      const requiredLeftWidth =
+        headerLeft.getBoundingClientRect().width -
+        runtimeTrigger.getBoundingClientRect().width +
+        expandedWidthRef.current
+
+      if (requiredLeftWidth <= availableLeftWidth) {
+        setIsCompact(false)
       }
-      setIsCompact(false)
     })
-    resizeObserver.observe(headerLeft)
+    resizeObserver.observe(header)
     return () => resizeObserver.disconnect()
   }, [isCompact])
 

--- a/src/components/chat-view/RuntimeSelector.tsx
+++ b/src/components/chat-view/RuntimeSelector.tsx
@@ -109,16 +109,19 @@ export function RuntimeSelector({
 
       const style = getComputedStyle(trigger)
       const gap = Number.parseFloat(style.gap) || 0
-      const requiredWidth =
+      const requiredContentWidth =
         icon.getBoundingClientRect().width +
         label.scrollWidth +
         chevron.getBoundingClientRect().width +
         gap * 2 +
         (Number.parseFloat(style.paddingInlineStart) || 0) +
         (Number.parseFloat(style.paddingInlineEnd) || 0)
-      expandedWidthRef.current = requiredWidth
+      expandedWidthRef.current =
+        requiredContentWidth +
+        (Number.parseFloat(style.borderInlineStartWidth) || 0) +
+        (Number.parseFloat(style.borderInlineEndWidth) || 0)
 
-      if (trigger.clientWidth < requiredWidth) {
+      if (trigger.clientWidth < requiredContentWidth) {
         setIsCompact(true)
       }
     }

--- a/src/components/chat-view/RuntimeSelector.tsx
+++ b/src/components/chat-view/RuntimeSelector.tsx
@@ -1,6 +1,6 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { Check, ChevronDown } from 'lucide-react'
-import { useId, useRef } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 
 import anthropicLogo from '../../assets/provider-icons/anthropic.svg'
 import openaiLogo from '../../assets/provider-icons/openai.svg'
@@ -82,8 +82,68 @@ export function RuntimeSelector({
 }: RuntimeSelectorProps) {
   const { t } = useLanguage()
   const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const [isCompact, setIsCompact] = useState(false)
   const menuLabelId = useId()
   const cliRuntimeAvailable = isCliRuntimeAvailable()
+
+  useEffect(() => {
+    setIsCompact(false)
+  }, [currentRuntimeId])
+
+  useEffect(() => {
+    const trigger = triggerRef.current
+    if (!trigger || isCompact || typeof ResizeObserver === 'undefined') return
+
+    const updateCompactState = () => {
+      const label = trigger.querySelector<HTMLElement>(
+        '.yolo-runtime-selector__label',
+      )
+      const icon = trigger.querySelector<HTMLElement>(
+        '.yolo-runtime-selector__icon',
+      )
+      const chevron = trigger.querySelector<HTMLElement>(
+        '.yolo-runtime-selector__chevron',
+      )
+      if (!label || !icon || !chevron) return
+
+      const style = getComputedStyle(trigger)
+      const gap = Number.parseFloat(style.gap) || 0
+      const requiredWidth =
+        icon.getBoundingClientRect().width +
+        label.scrollWidth +
+        chevron.getBoundingClientRect().width +
+        gap * 2 +
+        (Number.parseFloat(style.paddingInlineStart) || 0) +
+        (Number.parseFloat(style.paddingInlineEnd) || 0)
+
+      if (trigger.clientWidth < requiredWidth) {
+        setIsCompact(true)
+      }
+    }
+
+    updateCompactState()
+    const resizeObserver = new ResizeObserver(updateCompactState)
+    resizeObserver.observe(trigger)
+    return () => resizeObserver.disconnect()
+  }, [isCompact])
+
+  useEffect(() => {
+    const trigger = triggerRef.current
+    const headerLeft = trigger?.closest('.yolo-chat-header-left')
+    if (!headerLeft || !isCompact || typeof ResizeObserver === 'undefined')
+      return
+
+    let receivedInitialSize = false
+    const resizeObserver = new ResizeObserver(() => {
+      if (!receivedInitialSize) {
+        receivedInitialSize = true
+        return
+      }
+      setIsCompact(false)
+    })
+    resizeObserver.observe(headerLeft)
+    return () => resizeObserver.disconnect()
+  }, [isCompact])
 
   if (!cliRuntimeAvailable) {
     return null
@@ -106,6 +166,7 @@ export function RuntimeSelector({
         disabled={disabled}
         aria-label={accessibleLabel}
         data-runtime-id={currentRuntimeId}
+        data-compact={isCompact || undefined}
       >
         <span className="yolo-runtime-selector__icon" aria-hidden="true">
           <RuntimeIcon runtimeId={currentOption.id} />

--- a/src/styles/chat/input.css
+++ b/src/styles/chat/input.css
@@ -58,6 +58,7 @@
 
 button.yolo-runtime-selector {
   display: inline-flex;
+  position: relative;
   align-items: center;
   gap: 6px;
   min-width: 43px;
@@ -77,6 +78,15 @@ button.yolo-runtime-selector {
   cursor: pointer;
   appearance: none;
   -webkit-appearance: none;
+  container-type: inline-size;
+}
+
+button.yolo-runtime-selector[data-runtime-id='codex'] {
+  contain-intrinsic-inline-size: 74px;
+}
+
+button.yolo-runtime-selector[data-runtime-id='claude-code'] {
+  contain-intrinsic-inline-size: 112px;
 }
 
 button.yolo-runtime-selector:hover,
@@ -144,6 +154,40 @@ body.theme-dark .yolo-runtime-selector__provider-logo[data-provider='openai'] {
 button.yolo-runtime-selector[data-state='open']
   .yolo-runtime-selector__chevron {
   transform: rotate(180deg);
+}
+
+/* Match the Chat / CLI toggle's icon-only form when this selector itself no
+   longer has room for its complete runtime name. The label and caret retain
+   their layout slots while transparent, so the selector can grow back and
+   restore its full affordance as soon as the header has room again. */
+@container (max-width: 73px) {
+  button.yolo-runtime-selector[data-runtime-id='codex']
+    .yolo-runtime-selector__label,
+  button.yolo-runtime-selector[data-runtime-id='codex']
+    .yolo-runtime-selector__chevron {
+    opacity: 0;
+  }
+
+  button.yolo-runtime-selector[data-runtime-id='codex']
+    .yolo-runtime-selector__icon {
+    position: absolute;
+    inset: 0;
+  }
+}
+
+@container (max-width: 111px) {
+  button.yolo-runtime-selector[data-runtime-id='claude-code']
+    .yolo-runtime-selector__label,
+  button.yolo-runtime-selector[data-runtime-id='claude-code']
+    .yolo-runtime-selector__chevron {
+    opacity: 0;
+  }
+
+  button.yolo-runtime-selector[data-runtime-id='claude-code']
+    .yolo-runtime-selector__icon {
+    position: absolute;
+    inset: 0;
+  }
 }
 
 .yolo-runtime-selector__content {

--- a/src/styles/chat/input.css
+++ b/src/styles/chat/input.css
@@ -78,15 +78,6 @@ button.yolo-runtime-selector {
   cursor: pointer;
   appearance: none;
   -webkit-appearance: none;
-  container-type: inline-size;
-}
-
-button.yolo-runtime-selector[data-runtime-id='codex'] {
-  contain-intrinsic-inline-size: 74px;
-}
-
-button.yolo-runtime-selector[data-runtime-id='claude-code'] {
-  contain-intrinsic-inline-size: 112px;
 }
 
 button.yolo-runtime-selector:hover,
@@ -156,38 +147,23 @@ button.yolo-runtime-selector[data-state='open']
   transform: rotate(180deg);
 }
 
-/* Match the Chat / CLI toggle's icon-only form when this selector itself no
-   longer has room for its complete runtime name. The label and caret retain
-   their layout slots while transparent, so the selector can grow back and
-   restore its full affordance as soon as the header has room again. */
-@container (max-width: 73px) {
-  button.yolo-runtime-selector[data-runtime-id='codex']
-    .yolo-runtime-selector__label,
-  button.yolo-runtime-selector[data-runtime-id='codex']
-    .yolo-runtime-selector__chevron {
-    opacity: 0;
-  }
-
-  button.yolo-runtime-selector[data-runtime-id='codex']
-    .yolo-runtime-selector__icon {
-    position: absolute;
-    inset: 0;
-  }
+/* The compact form is a real icon button so it releases space to the header
+   instead of preserving an empty label slot. RuntimeSelector restores the
+   complete trigger when the header grows again. */
+button.yolo-runtime-selector[data-compact='true'] {
+  box-sizing: border-box;
+  width: 30px;
+  min-width: 30px;
+  flex: 0 0 30px;
+  justify-content: center;
+  gap: 0;
+  padding: 4px;
 }
 
-@container (max-width: 111px) {
-  button.yolo-runtime-selector[data-runtime-id='claude-code']
-    .yolo-runtime-selector__label,
-  button.yolo-runtime-selector[data-runtime-id='claude-code']
-    .yolo-runtime-selector__chevron {
-    opacity: 0;
-  }
-
-  button.yolo-runtime-selector[data-runtime-id='claude-code']
-    .yolo-runtime-selector__icon {
-    position: absolute;
-    inset: 0;
-  }
+button.yolo-runtime-selector[data-compact='true'] .yolo-runtime-selector__label,
+button.yolo-runtime-selector[data-compact='true']
+  .yolo-runtime-selector__chevron {
+  display: none;
 }
 
 .yolo-runtime-selector__content {

--- a/src/styles/chat/message.css
+++ b/src/styles/chat/message.css
@@ -1956,7 +1956,8 @@ button.yolo-llm-debug-modal-button:focus-visible {
      label when the button is `--expanded`. We need to overpower that
      rule's specificity (0,3,0) so the caret really disappears in compact
      mode — otherwise the icon-only form still has a hanging chevron. */
-  .yolo-view-toggle-button--roller.yolo-view-toggle-button--expanded
+  .yolo-view-toggle
+    .yolo-view-toggle-button--roller.yolo-view-toggle-button--expanded
     .yolo-roller-select-caret {
     width: 0;
     margin-left: 0;

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
-/* @yolo-version: 1.6.3.1 */
+/* @yolo-version: 1.6.4 */
 
 /* Settings */
 
@@ -9637,6 +9637,7 @@ svg.svg-icon.yolo-orbit {
 
 button.yolo-runtime-selector {
   display: inline-flex;
+  position: relative;
   align-items: center;
   gap: 6px;
   min-width: 43px;
@@ -9656,6 +9657,15 @@ button.yolo-runtime-selector {
   cursor: pointer;
   appearance: none;
   -webkit-appearance: none;
+  container-type: inline-size;
+}
+
+button.yolo-runtime-selector[data-runtime-id='codex'] {
+  contain-intrinsic-inline-size: 74px;
+}
+
+button.yolo-runtime-selector[data-runtime-id='claude-code'] {
+  contain-intrinsic-inline-size: 112px;
 }
 
 button.yolo-runtime-selector:hover,
@@ -9723,6 +9733,41 @@ body.theme-dark .yolo-runtime-selector__provider-logo[data-provider='openai'] {
 button.yolo-runtime-selector[data-state='open']
   .yolo-runtime-selector__chevron {
   transform: rotate(180deg);
+}
+
+/* Match the Chat / CLI toggle's icon-only form when this selector itself no
+   longer has room for its complete runtime name. The label and caret retain
+   their layout slots while transparent, so the selector can grow back and
+   restore its full affordance as soon as the header has room again. */
+
+@container (max-width: 73px) {
+  button.yolo-runtime-selector[data-runtime-id='codex']
+    .yolo-runtime-selector__label,
+  button.yolo-runtime-selector[data-runtime-id='codex']
+    .yolo-runtime-selector__chevron {
+    opacity: 0;
+  }
+
+  button.yolo-runtime-selector[data-runtime-id='codex']
+    .yolo-runtime-selector__icon {
+    position: absolute;
+    inset: 0;
+  }
+}
+
+@container (max-width: 111px) {
+  button.yolo-runtime-selector[data-runtime-id='claude-code']
+    .yolo-runtime-selector__label,
+  button.yolo-runtime-selector[data-runtime-id='claude-code']
+    .yolo-runtime-selector__chevron {
+    opacity: 0;
+  }
+
+  button.yolo-runtime-selector[data-runtime-id='claude-code']
+    .yolo-runtime-selector__icon {
+    position: absolute;
+    inset: 0;
+  }
 }
 
 .yolo-runtime-selector__content {
@@ -16011,7 +16056,8 @@ button.yolo-llm-debug-modal-button:focus-visible {
      label when the button is `--expanded`. We need to overpower that
      rule's specificity (0,3,0) so the caret really disappears in compact
      mode — otherwise the icon-only form still has a hanging chevron. */
-  .yolo-view-toggle-button--roller.yolo-view-toggle-button--expanded
+  .yolo-view-toggle
+    .yolo-view-toggle-button--roller.yolo-view-toggle-button--expanded
     .yolo-roller-select-caret {
     width: 0;
     margin-left: 0;

--- a/styles.css
+++ b/styles.css
@@ -9657,15 +9657,6 @@ button.yolo-runtime-selector {
   cursor: pointer;
   appearance: none;
   -webkit-appearance: none;
-  container-type: inline-size;
-}
-
-button.yolo-runtime-selector[data-runtime-id='codex'] {
-  contain-intrinsic-inline-size: 74px;
-}
-
-button.yolo-runtime-selector[data-runtime-id='claude-code'] {
-  contain-intrinsic-inline-size: 112px;
 }
 
 button.yolo-runtime-selector:hover,
@@ -9735,39 +9726,24 @@ button.yolo-runtime-selector[data-state='open']
   transform: rotate(180deg);
 }
 
-/* Match the Chat / CLI toggle's icon-only form when this selector itself no
-   longer has room for its complete runtime name. The label and caret retain
-   their layout slots while transparent, so the selector can grow back and
-   restore its full affordance as soon as the header has room again. */
+/* The compact form is a real icon button so it releases space to the header
+   instead of preserving an empty label slot. RuntimeSelector restores the
+   complete trigger when the header grows again. */
 
-@container (max-width: 73px) {
-  button.yolo-runtime-selector[data-runtime-id='codex']
-    .yolo-runtime-selector__label,
-  button.yolo-runtime-selector[data-runtime-id='codex']
-    .yolo-runtime-selector__chevron {
-    opacity: 0;
-  }
-
-  button.yolo-runtime-selector[data-runtime-id='codex']
-    .yolo-runtime-selector__icon {
-    position: absolute;
-    inset: 0;
-  }
+button.yolo-runtime-selector[data-compact='true'] {
+  box-sizing: border-box;
+  width: 30px;
+  min-width: 30px;
+  flex: 0 0 30px;
+  justify-content: center;
+  gap: 0;
+  padding: 4px;
 }
 
-@container (max-width: 111px) {
-  button.yolo-runtime-selector[data-runtime-id='claude-code']
-    .yolo-runtime-selector__label,
-  button.yolo-runtime-selector[data-runtime-id='claude-code']
-    .yolo-runtime-selector__chevron {
-    opacity: 0;
-  }
-
-  button.yolo-runtime-selector[data-runtime-id='claude-code']
-    .yolo-runtime-selector__icon {
-    position: absolute;
-    inset: 0;
-  }
+button.yolo-runtime-selector[data-compact='true'] .yolo-runtime-selector__label,
+button.yolo-runtime-selector[data-compact='true']
+  .yolo-runtime-selector__chevron {
+  display: none;
 }
 
 .yolo-runtime-selector__content {


### PR DESCRIPTION
## 摘要
- 运行时选择器在名称无法完整显示时切换为居中图标，隐藏名称与下拉箭头
- 修复 Chat/CLI 紧凑态的箭头隐藏规则被后续样式覆盖的问题
- 重新生成宿主样式产物

## 验证
- `npm run styles:build`
- `npm run type:check`
- 在 obsidiandev Vault 中截图验证正常态与紧凑态