### PR TITLE
[auto-triage] Keep desktop CLI runtime out of mobile load path (#538)

### DIFF
--- a/src/core/cli-runtime/index.test.ts
+++ b/src/core/cli-runtime/index.test.ts
@@ -1,4 +1,6 @@
+/* eslint-disable import/no-nodejs-modules -- test inspects the source boundary without loading desktop runtime modules */
 import { readFileSync } from 'node:fs'
+/* eslint-enable import/no-nodejs-modules */
 
 describe('CLI runtime entry point', () => {
   it('does not statically re-export desktop-only runtime implementations', () => {

--- a/src/core/cli-runtime/index.test.ts
+++ b/src/core/cli-runtime/index.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+
+describe('CLI runtime entry point', () => {
+  it('does not statically re-export desktop-only runtime implementations', () => {
+    const source = readFileSync('src/core/cli-runtime/index.ts', 'utf8')
+
+    expect(source).not.toMatch(
+      /export \* from '\.\/(claude|codex|conversation-controller|coordinator|model-catalog|session-index|session-service|vault-session-index-store)'/u,
+    )
+  })
+})

--- a/src/core/cli-runtime/index.ts
+++ b/src/core/cli-runtime/index.ts
@@ -1,16 +1,16 @@
 export * from './actions'
-export * from './claude'
 export * from './cli-actions'
-export * from './codex'
 export * from './context-usage'
-export * from './conversation-controller'
-export * from './coordinator'
 export * from './desktop'
-export * from './model-catalog'
 export * from './permission-profile'
-export * from './session-index'
-export * from './session-service'
 export * from './turn-input'
 export * from './types'
-export * from './vault-session-index-store'
 export * from './yolo-actions'
+
+// This entry point is imported by the host chat surface, including mobile.
+// Keep desktop runtime implementations out of its static module graph.
+export type {
+  CliConversationController,
+  CliConversationSnapshot,
+} from './conversation-controller'
+export type { CliRuntimeScope } from './coordinator'


### PR DESCRIPTION
## 摘要

- 将 CLI 公共入口限制为移动端可安全加载的共享 API。
- 桌面 CLI 实现仅保留类型导出；其运行时代码继续只由桌面守卫后的动态导入进入。
- 添加回归测试，防止公共入口重新静态导出桌面实现。

## 分析依据

1.6.4.1 的发布产物包含 `node:fs/promises`、`node:os`、`node:child_process` 等依赖。聊天界面会静态导入 CLI 公共入口，而该入口此前重导出了协调器和 Codex 启动代码；后者在模块求值时导入 `node:*`。Android 没有 Node 运行时，因此插件会在启用阶段失败，早于现有的 `Platform.isDesktop` 初始化守卫。

## 校验

- `npm run type:check`
- `npx jest src/core/cli-runtime/index.test.ts src/components/chat-view/cliChatIntegration.test.ts src/components/chat-view/CliChatSurface.test.tsx --runInBand`（3 suites / 40 tests）
- `npm run build`

关联 Issue：#538