### PR TITLE
[auto-triage] Avoid Smart Space slash abbreviation trigger (#541)

### DIFF
--- a/src/features/editor/smart-space/smartSpaceController.test.ts
+++ b/src/features/editor/smart-space/smartSpaceController.test.ts
@@ -1,0 +1,17 @@
+import { isStandaloneSmartSpaceSlash } from './smartSpaceTrigger'
+
+describe('isStandaloneSmartSpaceSlash', () => {
+  it.each(['', ' ', '\n', '\t'])(
+    'accepts a slash at a line start or after whitespace %p',
+    (precedingCharacter) => {
+      expect(isStandaloneSmartSpaceSlash(precedingCharacter)).toBe(true)
+    },
+  )
+
+  it.each(['w', '0', ')', '_'])(
+    'does not treat a slash after non-whitespace %p as a Smart Space trigger',
+    (precedingCharacter) => {
+      expect(isStandaloneSmartSpaceSlash(precedingCharacter)).toBe(false)
+    },
+  )
+})

--- a/src/features/editor/smart-space/smartSpaceController.ts
+++ b/src/features/editor/smart-space/smartSpaceController.ts
@@ -9,6 +9,8 @@ import type YoloPlugin from '../../../main'
 import type { YoloSettings } from '../../../settings/schema/setting.types'
 import type { SerializedMentionable } from '../../../types/mentionable'
 
+import { isStandaloneSmartSpaceSlash } from './smartSpaceTrigger'
+
 export type SmartSpaceDraftState = {
   instructionText?: string
   mentionables?: SerializedMentionable[]
@@ -203,6 +205,15 @@ export class SmartSpaceController {
           }
 
           if (isSlash) {
+            const precedingCharacter = view.state.doc.sliceString(
+              Math.max(0, selection.head - 1),
+              selection.head,
+            )
+            if (!isStandaloneSmartSpaceSlash(precedingCharacter)) {
+              this.lastSmartSpaceSlash = null
+              this.lastSmartSpaceSpace = null
+              return false
+            }
             this.lastSmartSpaceSlash = {
               view,
               pos: selection.head,

--- a/src/features/editor/smart-space/smartSpaceTrigger.ts
+++ b/src/features/editor/smart-space/smartSpaceTrigger.ts
@@ -1,0 +1,5 @@
+export function isStandaloneSmartSpaceSlash(
+  precedingCharacter: string,
+): boolean {
+  return precedingCharacter.length === 0 || /\s/.test(precedingCharacter)
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1546,7 +1546,7 @@ export const en: TranslationKeys = {
       continuationModelDesc:
         'Select the model used for continuation in Sparkle.',
       smartSpaceDescription:
-        'Smart space offers a lightweight floating composer while you write; by default it appears when you press the space key on an empty line or type “/” followed by space anywhere. You can switch below to double-space on empty lines or disable space-triggering. Press enter twice to submit and press escape to close.',
+        'Smart space offers a lightweight floating composer while you write; by default it appears when you press the space key on an empty line or type “/” followed by space at the start of a line or after whitespace. You can switch below to double-space on empty lines or disable space-triggering. Press enter twice to submit and press escape to close.',
       smartSpaceToggle: 'Enable smart space',
       smartSpaceToggleDesc:
         'When disabled, the space bar or "/"+space will no longer summon the smart space floating composer.',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1399,7 +1399,7 @@ export const it: DeepPartial<TranslationKeys> = {
       continuationModelDesc:
         'Seleziona il modello usato per la continuazione in Sparkle.',
       smartSpaceDescription:
-        'Smart Space ti aiuta a continuare a scrivere con azioni rapide personalizzabili. Di default si apre con spazio su riga vuota o "/" + spazio; qui sotto puoi passare al doppio spazio o disattivare il trigger con spazio.',
+        'Smart Space ti aiuta a continuare a scrivere con azioni rapide personalizzabili. Di default si apre con spazio su riga vuota o con "/" + spazio a inizio riga o dopo uno spazio; qui sotto puoi passare al doppio spazio o disattivare il trigger con spazio.',
       smartSpaceToggle: 'Abilita smart space',
       smartSpaceToggleDesc:
         'Mostra il menu smart space quando il cursore è su una riga vuota.',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -1437,7 +1437,7 @@ export const zh: TranslationKeys = {
       continuationModel: '续写模型',
       continuationModelDesc: '指定在灵光写作中用于续写的模型。',
       smartSpaceDescription:
-        'Smart Space 会在写作时提供一个轻量的悬浮输入框。默认在空白行按下空格，或任意位置输入 “/” 后紧接空格即可唤出；支持在下方调整为空行双空格触发或关闭空格触发。输入后连续按两次 Enter 提交，Esc 关闭。',
+        'Smart Space 会在写作时提供一个轻量的悬浮输入框。默认在空白行按下空格，或在行首或空白符后输入 “/” 后紧接空格即可唤出；支持在下方调整为空行双空格触发或关闭空格触发。输入后连续按两次 Enter 提交，Esc 关闭。',
       smartSpaceToggle: '启用 Smart Space',
       smartSpaceToggleDesc:
         '当关闭时，空格或 "/"+空格 将不再唤出 Smart Space 悬浮输入框。',


### PR DESCRIPTION
## Summary

- Require the `/ + space` Smart Space shortcut to begin at a line start or after whitespace.
- Preserve normal Smart Space shortcut behavior while allowing abbreviations such as `w/ ` to remain plain text.
- Add regression coverage and align the English, Chinese, and Italian setting descriptions.

## Analysis

The trigger recorded every `/` and opened Smart Space when a space followed within 600ms, regardless of the slash context. That caused normal in-word abbreviations such as `w/ ` to open the composer and remove the slash. Limiting the shortcut to a standalone slash resolves the conflict without adding a new setting or changing the empty-line trigger.

## Validation

- `npx jest src/features/editor/smart-space/smartSpaceController.test.ts --runInBand`
- `npm run type:check`
- `npm run lint:check`

Closes #541