### PR TITLE
[auto-triage] Preserve user-named skill files (#543)

### DIFF
--- a/src/components/settings/modals/AgentSkillsModal.tsx
+++ b/src/components/settings/modals/AgentSkillsModal.tsx
@@ -142,12 +142,18 @@ function AgentSkillsModalContent({
   const deleteSkillPath = async (path: string) => {
     const packageDir = getSkillPackageDirPath(path)
     if (!packageDir) {
-      throw new Error(
-        t(
-          'settings.agent.deleteSkillInvalidPackage',
-          'Invalid skill package path',
-        ),
-      )
+      const file = app.vault.getFileByPath(path)
+      if (file) {
+        await app.fileManager.trashFile(file)
+        return
+      }
+      if (!(await app.vault.adapter.exists(path))) {
+        throw new Error(
+          t('settings.agent.deleteSkillNotFound', 'Skill not found'),
+        )
+      }
+      await app.vault.adapter.remove(path)
+      return
     }
 
     const folder = app.vault.getAbstractFileByPath(packageDir)
@@ -174,7 +180,7 @@ function AgentSkillsModalContent({
       title: t('settings.agent.deleteSkillTitle', 'Delete skill'),
       message: t(
         'settings.agent.deleteSkillBatchMessage',
-        'Are you sure you want to delete {count} skill package(s), including all resources? This cannot be undone.',
+        'Are you sure you want to delete {count} skill(s), including package resources? This cannot be undone.',
       ).replace('{count}', String(names.length)),
       ctaText: t('settings.agent.deleteSkillConfirm', 'Delete'),
       onConfirm: async () => {
@@ -218,7 +224,7 @@ function AgentSkillsModalContent({
       <div className="yolo-settings-desc yolo-settings-callout">
         {t(
           'settings.agent.skillsGlobalDesc',
-          'Skills are discovered from built-in skills and {path}/<name>/SKILL.md packages. Disable a skill here to block it for all agents.',
+          'Skills are discovered from built-in skills, {path}/*.md files, and {path}/<name>/SKILL.md packages. Disable a skill here to block it for all agents.',
         ).replace('{path}', skillsDir)}
       </div>
 

--- a/src/components/settings/modals/AgentSkillsModal.tsx
+++ b/src/components/settings/modals/AgentSkillsModal.tsx
@@ -224,7 +224,7 @@ function AgentSkillsModalContent({
       <div className="yolo-settings-desc yolo-settings-callout">
         {t(
           'settings.agent.skillsGlobalDesc',
-          'Skills are discovered from built-in skills, {path}/*.md files, and {path}/<name>/SKILL.md packages. Disable a skill here to block it for all agents.',
+          'Skills are discovered from built-in skills, {path}/*.md files, and {path}/<folder>/SKILL.md packages. Disable a skill here to block it for all agents.',
         ).replace('{path}', skillsDir)}
       </div>
 
@@ -349,7 +349,7 @@ function AgentSkillsModalContent({
           <div className="yolo-agent-tools-empty">
             {t(
               'settings.agent.skillsEmptyHint',
-              'No skills found. Create a {path}/<name>/SKILL.md package.',
+              'No skills found. Create a Markdown file or a folder containing SKILL.md under {path}.',
             ).replace('{path}', skillsDir)}
           </div>
         )}

--- a/src/components/settings/modals/ImportSkillModal.tsx
+++ b/src/components/settings/modals/ImportSkillModal.tsx
@@ -25,7 +25,7 @@ import {
   type ValidationError,
   parseFrontmatter,
   validateDirectoryPackage,
-  wrapMarkdownAsSkillPackage,
+  validateSingleFileSkill,
 } from '../../../core/skills/skillValidation'
 import YoloPlugin from '../../../main'
 import { ReactModal } from '../../common/ReactModal'
@@ -79,17 +79,18 @@ function ImportSkillModalWrapper({
 // ---------------------------------------------------------------------------
 
 /**
- * 一个准备导入的 skill 包(已经识别出根目录 / 单文件)。
+ * 一个准备导入的 skill(已经识别出目录包 / 单文件)。
  */
 type SkillPackage = {
   /** 用作错误信息显示的源名称(原文件夹名 / 文件名) */
   sourceName: string
-  /** 目标目录名，始终取自 frontmatter.name */
+  /** 保留来源形态的目标文件名或目录名 */
   targetName: string
   /** 用于列表显示 */
   displayName: string
   description: string
   files: FileEntry[]
+  isDirectory: boolean
 }
 
 const SKILL_MD = 'SKILL.md'
@@ -122,51 +123,6 @@ function formatValidationErrors(
         return t(
           'settings.agent.importSkillErrNoName',
           'missing "name" field in metadata',
-        )
-      case 'name:exceeds 64 characters':
-        return t(
-          'settings.agent.importSkillErrNameTooLong',
-          '"name" is too long (max 64 characters)',
-        )
-      case 'name:uppercase not allowed':
-        return t(
-          'settings.agent.importSkillErrNameUppercase',
-          '"name" must be all lowercase',
-        )
-      case 'name:cannot start or end with hyphen':
-        return t(
-          'settings.agent.importSkillErrNameHyphenEdge',
-          '"name" cannot start or end with a hyphen',
-        )
-      case 'name:consecutive hyphens not allowed':
-        return t(
-          'settings.agent.importSkillErrNameDoubleHyphen',
-          '"name" cannot contain consecutive hyphens (--)',
-        )
-      case 'name:only lowercase letters, numbers, and hyphens allowed':
-        return t(
-          'settings.agent.importSkillErrNameInvalidChars',
-          '"name" can only contain lowercase letters, numbers, and hyphens',
-        )
-      case 'name:must match folder name':
-        return t(
-          'settings.agent.importSkillErrNameMismatch',
-          '"name" must match the folder name',
-        )
-      case 'description:missing':
-        return t(
-          'settings.agent.importSkillErrNoDescription',
-          'missing "description" field in metadata',
-        )
-      case 'description:exceeds 1024 characters':
-        return t(
-          'settings.agent.importSkillErrDescTooLong',
-          '"description" is too long (max 1024 characters)',
-        )
-      case 'compatibility:exceeds 500 characters':
-        return t(
-          'settings.agent.importSkillErrCompatTooLong',
-          '"compatibility" is too long (max 500 characters)',
         )
       default:
         return `${err.field}: ${err.message}`
@@ -491,7 +447,7 @@ function ImportSkillModalContent({
           errors.push(
             t(
               'settings.agent.importSkillDuplicateInBatch',
-              'Duplicate skill name in this batch: "{name}" (from "{source}"). Only the first occurrence is kept.',
+              'Duplicate import destination in this batch: "{name}" (from "{source}"). Only the first occurrence is kept.',
             )
               .replace('{name}', pkg.targetName)
               .replace('{source}', pkg.sourceName),
@@ -503,6 +459,17 @@ function ImportSkillModalContent({
       }
 
       for (const candidate of candidates) {
+        if (!isSafeRelativePath(candidate.rootName)) {
+          errors.push(
+            t(
+              'settings.agent.importSkillUnsafePath',
+              'Refused unsafe path in "{name}": {path}',
+            )
+              .replace('{name}', candidate.rootName)
+              .replace('{path}', candidate.rootName),
+          )
+          continue
+        }
         // 路径安全校验(整批候选,提前拦截 — 任意一个文件不安全就丢弃整包)
         const unsafe = candidate.files.find(
           (f) => !isSafeRelativePath(f.relativePath),
@@ -521,19 +488,25 @@ function ImportSkillModalContent({
 
         if (candidate.isSingleFile) {
           const content = candidate.files[0]?.content ?? ''
-          const wrapped = wrapMarkdownAsSkillPackage(content)
-          if (!wrapped.package) {
+          const validationErrors = validateSingleFileSkill(content)
+          if (validationErrors.length > 0) {
             errors.push(
-              formatValidationErrors(wrapped.errors, candidate.rootName, t),
+              formatValidationErrors(validationErrors, candidate.rootName, t),
             )
             continue
           }
+          const fm = parseFrontmatter(content)
+          const fmName =
+            typeof fm?.name === 'string' ? fm.name.trim() : candidate.rootName
+          const description =
+            typeof fm?.description === 'string' ? fm.description.trim() : ''
           pushValid({
             sourceName: candidate.rootName,
-            targetName: wrapped.package.name,
-            displayName: wrapped.package.name,
-            description: wrapped.package.description,
-            files: wrapped.package.files,
+            targetName: candidate.rootName,
+            displayName: fmName,
+            description,
+            files: candidate.files,
+            isDirectory: false,
           })
           continue
         }
@@ -561,10 +534,11 @@ function ImportSkillModalContent({
             (typeof fm?.description === 'string' && fm.description.trim()) || ''
           pushValid({
             sourceName: skill.sourceName,
-            targetName: fmName,
+            targetName: skill.sourceName,
             displayName: fmName,
             description,
             files: skill.files,
+            isDirectory: true,
           })
         }
       }
@@ -719,7 +693,7 @@ function ImportSkillModalContent({
     try {
       const results = await fetchGitHubSkill(trimmed)
       if (!isMountedRef.current) return
-      // 把 GitHub 抓取结果适配成 RawCandidate;rootName 对齐 targetName 以通过目录校验
+      // GitHub 结果保留远端文件名或目录名，不按 frontmatter name 改写路径。
       const candidates: RawCandidate[] = results.map((result) => ({
         rootName: result.targetName,
         files: result.files,
@@ -792,34 +766,40 @@ function ImportSkillModalContent({
 
       for (const pkg of skillPackages) {
         try {
-          const pkgDir = normalizePath(`${skillsDir}/${pkg.targetName}`)
-          // 覆盖时:无论已存在的是文件还是目录,先 trash 再写新,避免遗留旧资源 / 类型冲突
-          const existing = app.vault.getAbstractFileByPath(pkgDir)
+          const targetRoot = normalizePath(`${skillsDir}/${pkg.targetName}`)
+          // 覆盖时先 trash，避免目录遗留旧资源或文件/目录类型冲突。
+          const existing = app.vault.getAbstractFileByPath(targetRoot)
           if (existing) {
             await app.fileManager.trashFile(existing)
           }
-          await app.vault.createFolder(pkgDir)
 
-          for (const file of pkg.files) {
-            if (!isSafeRelativePath(file.relativePath)) {
-              throw new Error(`unsafe path: ${file.relativePath}`)
+          if (pkg.isDirectory) {
+            await app.vault.createFolder(targetRoot)
+            for (const file of pkg.files) {
+              if (!isSafeRelativePath(file.relativePath)) {
+                throw new Error(`unsafe path: ${file.relativePath}`)
+              }
+              const targetPath = normalizePath(
+                `${targetRoot}/${file.relativePath}`,
+              )
+              if (!targetPath.startsWith(`${targetRoot}/`)) {
+                throw new Error(`path escaped target: ${file.relativePath}`)
+              }
+              const parentDir = targetPath.substring(
+                0,
+                targetPath.lastIndexOf('/'),
+              )
+              if (parentDir) {
+                await ensureFolder(parentDir)
+              }
+              if (file.data) {
+                await app.vault.createBinary(targetPath, file.data)
+              } else {
+                await app.vault.create(targetPath, file.content ?? '')
+              }
             }
-            const targetPath = normalizePath(`${pkgDir}/${file.relativePath}`)
-            if (!targetPath.startsWith(`${pkgDir}/`)) {
-              throw new Error(`path escaped target: ${file.relativePath}`)
-            }
-            const parentDir = targetPath.substring(
-              0,
-              targetPath.lastIndexOf('/'),
-            )
-            if (parentDir) {
-              await ensureFolder(parentDir)
-            }
-            if (file.data) {
-              await app.vault.createBinary(targetPath, file.data)
-            } else {
-              await app.vault.create(targetPath, file.content ?? '')
-            }
+          } else {
+            await app.vault.create(targetRoot, pkg.files[0]?.content ?? '')
           }
           successCount++
         } catch (err) {
@@ -883,7 +863,7 @@ function ImportSkillModalContent({
       <div className="yolo-settings-desc yolo-settings-callout">
         {t(
           'settings.agent.importSkillDesc',
-          'Import skill packages into {path}. Single Markdown files are wrapped as <name>/SKILL.md; folders keep SKILL.md and all package resources.',
+          'Import skills into {path}. Markdown files keep their filenames; folders keep their names, SKILL.md, and all package resources.',
         ).replace('{path}', skillsDir)}
       </div>
 

--- a/src/components/settings/sections/AgentsSectionContent.tsx
+++ b/src/components/settings/sections/AgentsSectionContent.tsx
@@ -2084,7 +2084,7 @@ export function AgentsSectionContent({
                   <div className="yolo-agent-tools-empty">
                     {t(
                       'settings.agent.skillsEmptyHint',
-                      'No skills found. Create a {path}/<name>/SKILL.md package.',
+                      'No skills found. Create a Markdown file or a folder containing SKILL.md under {path}.',
                     ).replace('{path}', skillsDir)}
                   </div>
                 )}

--- a/src/core/skills/builtinSkills.test.ts
+++ b/src/core/skills/builtinSkills.test.ts
@@ -13,11 +13,12 @@ describe('builtin skills', () => {
     expect(builtin).not.toBeNull()
     expect(builtin?.content).toContain('99-Assets/YOLO/skills')
     expect(builtin?.content).toContain(
-      '99-Assets/YOLO/skills/<skill-name>/SKILL.md',
+      '99-Assets/YOLO/skills/<readable-name>.md',
     )
-    expect(builtin?.content).not.toContain(
-      'fs_write { path: "YOLO/skills/<skill-name>.md"',
+    expect(builtin?.content).toContain(
+      '99-Assets/YOLO/skills/<folder>/SKILL.md',
     )
+    expect(builtin?.content).not.toContain('fs_write { path: "YOLO/skills/')
   })
 
   it('keeps other builtin skills unchanged when injecting a skills directory', () => {

--- a/src/core/skills/githubSkillImporter.test.ts
+++ b/src/core/skills/githubSkillImporter.test.ts
@@ -206,7 +206,7 @@ describe('fetchGitHubSkill package resources', () => {
   it('keeps non-entry package resources as exact bytes', async () => {
     const skillContent = [
       '---',
-      'name: binary-assets',
+      'name: different-frontmatter-name',
       'description: Keeps binary assets unchanged.',
       '---',
     ].join('\n')
@@ -254,5 +254,20 @@ describe('fetchGitHubSkill package resources', () => {
     expect(new Uint8Array(asset?.data ?? new ArrayBuffer(0))).toEqual(
       new Uint8Array([0, 255, 1, 2]),
     )
+  })
+
+  it('preserves a blob filename instead of replacing it with frontmatter name', async () => {
+    const content = ['---', 'name: different-name', '---'].join('\n')
+    mockedRequestUrl.mockResolvedValueOnce(makeResponse({ text: content }))
+
+    const [result] = await fetchGitHubSkill(
+      'https://github.com/user/repo/blob/main/readable-file.md',
+    )
+
+    expect(result).toMatchObject({
+      sourceName: 'readable-file.md',
+      targetName: 'readable-file.md',
+      isDirectory: false,
+    })
   })
 })

--- a/src/core/skills/githubSkillImporter.ts
+++ b/src/core/skills/githubSkillImporter.ts
@@ -1,6 +1,6 @@
 import { requestUrl } from 'obsidian'
 
-import { type FileEntry, parseFrontmatter } from './skillValidation'
+import { type FileEntry } from './skillValidation'
 
 // ---------------------------------------------------------------------------
 // 唯一保留的边界:单文件大小。其它(深度 / 文件数 / 目录数)由 GitHub 自身的
@@ -335,7 +335,7 @@ export type GitHubFetchResult = {
   files: FileEntry[]
   /** 显示用源名 */
   sourceName: string
-  /** 标准包目录名：优先 frontmatter.name，仅在无法解析时使用源名供校验报错 */
+  /** 保留远端来源的文件名或目录名 */
   targetName: string
   isDirectory: boolean
 }
@@ -388,32 +388,24 @@ async function buildSkillPackage(
   )
 
   const files: FileEntry[] = []
-  let skillMdContent = ''
   for (const { blob, data } of downloaded) {
     const relativePath = skillDir
       ? blob.path.slice(subtreePrefix.length)
       : blob.path
     if (blob.path === skillMdPath) {
-      skillMdContent = new TextDecoder().decode(data)
-      files.push({ relativePath, content: skillMdContent })
+      files.push({ relativePath, content: new TextDecoder().decode(data) })
     } else {
       files.push({ relativePath, data })
     }
   }
 
-  const fm = parseFrontmatter(skillMdContent)
-  const fmName =
-    typeof fm?.name === 'string' && fm.name.trim().length > 0
-      ? fm.name.trim()
-      : null
   const dirLastSeg = skillDir ? (skillDir.split('/').pop() ?? skillDir) : ''
   const fallbackName = dirLastSeg || fallbackRepoName
-  const targetName = fmName ?? fallbackName
 
   return {
     files,
     sourceName: dirLastSeg || fallbackRepoName,
-    targetName,
+    targetName: fallbackName,
     isDirectory: true,
   }
 }
@@ -438,16 +430,11 @@ export async function fetchGitHubSkill(
     const filePath = info.path!
     const content = await fetchRawText(buildRawUrl(info, filePath))
     const fileName = filePath.split('/').pop() ?? filePath
-    const frontmatter = parseFrontmatter(content)
-    const targetName =
-      typeof frontmatter?.name === 'string' && frontmatter.name.trim()
-        ? frontmatter.name.trim()
-        : fileName
     return [
       {
         files: [{ relativePath: fileName, content }],
         sourceName: fileName,
-        targetName,
+        targetName: fileName,
         isDirectory: false,
       },
     ]

--- a/src/core/skills/liteSkills.test.ts
+++ b/src/core/skills/liteSkills.test.ts
@@ -682,7 +682,7 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
     expect(after.map((entry) => entry.name)).not.toContain('old-base')
   })
 
-  it('lists directory packages and legacy root Markdown skills in default and hidden roots', async () => {
+  it('lists directory packages and root Markdown skills in default and hidden roots', async () => {
     const app = makeAdapterApp({
       listings: {
         'YOLO/skills': {
@@ -694,7 +694,7 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
           folders: [],
         },
         [`${OBSIDIAN_CONFIG_DIR}/skills`]: {
-          files: [`${OBSIDIAN_CONFIG_DIR}/skills/legacy-hidden.md`],
+          files: [`${OBSIDIAN_CONFIG_DIR}/skills/legacy-hidden.markdown`],
           folders: [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-skill`],
         },
         [`${OBSIDIAN_CONFIG_DIR}/skills/hidden-skill`]: {
@@ -723,7 +723,7 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
           'description: from default root',
           '---',
         ].join('\n'),
-        [`${OBSIDIAN_CONFIG_DIR}/skills/legacy-hidden.md`]: [
+        [`${OBSIDIAN_CONFIG_DIR}/skills/legacy-hidden.markdown`]: [
           '---',
           'name: legacy-hidden',
           'description: from hidden root',
@@ -942,7 +942,7 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
     expect(document?.content).toBe(content)
   })
 
-  it('ignores nested and folder-name-mismatched packages', async () => {
+  it('ignores nested packages but accepts a folder-name mismatch', async () => {
     const app = makeAdapterApp({
       listings: {
         'YOLO/skills': {
@@ -971,8 +971,7 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
         ].join('\n'),
         'YOLO/skills/wrong-folder/SKILL.md': [
           '---',
-          'name: other-name',
-          'description: folder mismatch',
+          'name: Other Name',
           '---',
         ].join('\n'),
       },
@@ -982,7 +981,7 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
       (entry) => entry.name,
     )
     expect(names).not.toContain('nested-skill')
-    expect(names).not.toContain('other-name')
+    expect(names).toContain('Other Name')
   })
 
   it('exposes every package resource without flattening its paths', async () => {

--- a/src/core/skills/liteSkills.test.ts
+++ b/src/core/skills/liteSkills.test.ts
@@ -9,11 +9,9 @@ import {
   humanizeSkillName,
   initializeLiteSkillRegistryService,
   listLiteSkillEntries,
-  migrateLegacySkillFilesToPackages,
   migrateVaultSkillFrontmatter,
   rewriteSkillFrontmatterIdToName,
 } from './liteSkills'
-import { resolveAssistantSkillPolicy } from './skillPolicy'
 
 const OBSIDIAN_CONFIG_DIR = ['.', 'obsidian'].join('')
 
@@ -684,7 +682,7 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
     expect(after.map((entry) => entry.name)).not.toContain('old-base')
   })
 
-  it('lists only standard directory packages in default and hidden roots', async () => {
+  it('lists directory packages and legacy root Markdown skills in default and hidden roots', async () => {
     const app = makeAdapterApp({
       listings: {
         'YOLO/skills': {
@@ -722,13 +720,13 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
         'YOLO/skills/legacy-root.md': [
           '---',
           'name: legacy-root',
-          'description: must not be scanned',
+          'description: from default root',
           '---',
         ].join('\n'),
         [`${OBSIDIAN_CONFIG_DIR}/skills/legacy-hidden.md`]: [
           '---',
           'name: legacy-hidden',
-          'description: must not be scanned',
+          'description: from hidden root',
           '---',
         ].join('\n'),
       },
@@ -739,8 +737,49 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
 
     expect(names).toContain('default-skill')
     expect(names).toContain('hidden-skill')
-    expect(names).not.toContain('legacy-root')
-    expect(names).not.toContain('legacy-hidden')
+    expect(names).toContain('legacy-root')
+    expect(names).toContain('legacy-hidden')
+    expect(entries.find((entry) => entry.name === 'legacy-root')?.path).toBe(
+      'YOLO/skills/legacy-root.md',
+    )
+  })
+
+  it('prefers a directory package over a same-named root Markdown skill', async () => {
+    const app = makeAdapterApp({
+      listings: {
+        'YOLO/skills': {
+          files: ['YOLO/skills/readable-filename.md'],
+          folders: ['YOLO/skills/standard-name'],
+        },
+        'YOLO/skills/standard-name': {
+          files: ['YOLO/skills/standard-name/SKILL.md'],
+          folders: [],
+        },
+      },
+      fileContents: {
+        'YOLO/skills/readable-filename.md': [
+          '---',
+          'name: standard-name',
+          'description: legacy file',
+          '---',
+        ].join('\n'),
+        'YOLO/skills/standard-name/SKILL.md': [
+          '---',
+          'name: standard-name',
+          'description: package file',
+          '---',
+        ].join('\n'),
+      },
+    })
+
+    const entries = await listLiteSkillEntries(app, { settings })
+
+    expect(
+      entries.find((entry) => entry.name === 'standard-name'),
+    ).toMatchObject({
+      path: 'YOLO/skills/standard-name/SKILL.md',
+      description: 'package file',
+    })
   })
 
   it('discovers Claude-style SKILL.md under hidden directories', async () => {
@@ -1010,6 +1049,42 @@ describe('listLiteSkillEntries and getLiteSkillDocument', () => {
     )
   })
 
+  it('materializes a root Markdown skill as a SKILL.md resource', async () => {
+    const app = makeAdapterApp({
+      listings: {
+        'YOLO/skills': {
+          files: ['YOLO/skills/readable-filename.md'],
+          folders: [],
+        },
+      },
+      fileContents: {
+        'YOLO/skills/readable-filename.md': [
+          '---',
+          'name: readable-skill',
+          'description: A single file.',
+          '---',
+        ].join('\n'),
+      },
+    })
+
+    await expect(
+      getLiteSkillPackageSource({
+        app,
+        name: 'readable-skill',
+        settings,
+      }),
+    ).resolves.toMatchObject({
+      entry: { path: 'YOLO/skills/readable-filename.md' },
+      resources: [
+        {
+          kind: 'vault',
+          path: 'YOLO/skills/readable-filename.md',
+          relativePath: 'SKILL.md',
+        },
+      ],
+    })
+  })
+
   it('resolves builtin skill documents by canonical path', async () => {
     const app = makeAdapterApp({
       listings: {
@@ -1065,182 +1140,6 @@ describe('migrateVaultSkillFrontmatter hidden dirs', () => {
 
     expect(migrated).toContain('name: legacy-hidden')
     expect(migrated).not.toMatch(/^id:/m)
-  })
-})
-
-describe('migrateLegacySkillFilesToPackages', () => {
-  const settings = { yolo: { baseDir: 'YOLO' } }
-
-  it('moves a valid root Markdown skill without changing content and is idempotent', async () => {
-    const sourcePath = 'YOLO/skills/old-filename.md'
-    const targetPath = 'YOLO/skills/stable-name/SKILL.md'
-    const content = [
-      '---',
-      'name: stable-name',
-      'description: Keeps assistant preference identity.',
-      '---',
-      '# Body',
-    ].join('\n')
-    const app = makeAdapterApp({
-      listings: {
-        'YOLO/skills': { files: [sourcePath], folders: [] },
-      },
-      fileContents: { [sourcePath]: content },
-    })
-
-    const first = await migrateLegacySkillFilesToPackages(app, settings)
-
-    expect(first).toEqual({
-      migrated: [{ name: 'stable-name', sourcePath, targetPath }],
-      issues: [],
-    })
-    await expect(app.vault.adapter.exists(sourcePath)).resolves.toBe(false)
-    await expect(app.vault.adapter.read(targetPath)).resolves.toBe(content)
-    expect(
-      (await listLiteSkillEntries(app, { settings })).find(
-        (entry) => entry.name === 'stable-name',
-      )?.path,
-    ).toBe(targetPath)
-    expect(
-      resolveAssistantSkillPolicy({
-        assistant: {
-          id: 'assistant-1',
-          name: 'Assistant',
-          systemPrompt: '',
-          skillPreferences: {
-            'stable-name': { enabled: false, loadMode: 'always' },
-          },
-        },
-        skillName: 'stable-name',
-      }),
-    ).toEqual({ enabled: false, loadMode: 'always' })
-
-    await expect(
-      migrateLegacySkillFilesToPackages(app, settings),
-    ).resolves.toEqual({ migrated: [], issues: [] })
-  })
-
-  it('keeps invalid sources and reports why each was skipped', async () => {
-    const noFrontmatter = 'YOLO/skills/no-frontmatter.md'
-    const invalidName = 'YOLO/skills/invalid-name.md'
-    const app = makeAdapterApp({
-      listings: {
-        'YOLO/skills': {
-          files: [noFrontmatter, invalidName],
-          folders: [],
-        },
-      },
-      fileContents: {
-        [noFrontmatter]: '# Body only',
-        [invalidName]: [
-          '---',
-          'name: Invalid Name',
-          'description: Invalid standard name.',
-          '---',
-        ].join('\n'),
-      },
-    })
-
-    const report = await migrateLegacySkillFilesToPackages(app, settings)
-
-    expect(report.migrated).toEqual([])
-    expect(report.issues).toEqual([
-      { sourcePath: invalidName, reason: 'invalid_name' },
-      { sourcePath: noFrontmatter, reason: 'invalid_frontmatter' },
-    ])
-    await expect(app.vault.adapter.exists(noFrontmatter)).resolves.toBe(true)
-    await expect(app.vault.adapter.exists(invalidName)).resolves.toBe(true)
-  })
-
-  it('never overwrites an existing package or removes the conflicting source', async () => {
-    const sourcePath = 'YOLO/skills/conflicting-source.md'
-    const existingPath = 'YOLO/skills/conflict/SKILL.md'
-    const existingResource = 'YOLO/skills/conflict/assets/keep.txt'
-    const app = makeAdapterApp({
-      listings: {
-        'YOLO/skills': {
-          files: [sourcePath],
-          folders: ['YOLO/skills/conflict'],
-        },
-        'YOLO/skills/conflict': {
-          files: [existingPath],
-          folders: ['YOLO/skills/conflict/assets'],
-        },
-        'YOLO/skills/conflict/assets': {
-          files: [existingResource],
-          folders: [],
-        },
-      },
-      fileContents: {
-        [sourcePath]: [
-          '---',
-          'name: conflict',
-          'description: Must remain at source.',
-          '---',
-        ].join('\n'),
-        [existingPath]: 'existing skill',
-        [existingResource]: 'existing resource',
-      },
-    })
-
-    const report = await migrateLegacySkillFilesToPackages(app, settings)
-
-    expect(report).toEqual({
-      migrated: [],
-      issues: [
-        {
-          sourcePath,
-          targetPath: existingPath,
-          reason: 'target_exists',
-        },
-      ],
-    })
-    await expect(app.vault.adapter.read(sourcePath)).resolves.toContain(
-      'Must remain at source.',
-    )
-    await expect(app.vault.adapter.read(existingPath)).resolves.toBe(
-      'existing skill',
-    )
-    await expect(app.vault.adapter.read(existingResource)).resolves.toBe(
-      'existing resource',
-    )
-  })
-
-  it('keeps the source and removes its empty target if moving fails', async () => {
-    const sourcePath = 'YOLO/skills/cannot-move.md'
-    const app = makeAdapterApp({
-      listings: {
-        'YOLO/skills': { files: [sourcePath], folders: [] },
-      },
-      fileContents: {
-        [sourcePath]: [
-          '---',
-          'name: cannot-move',
-          'description: Simulate an adapter failure.',
-          '---',
-        ].join('\n'),
-      },
-    })
-    ;(
-      app.vault.adapter as unknown as {
-        rename: (source: string, target: string) => Promise<void>
-      }
-    ).rename = () => Promise.reject(new Error('move failed'))
-
-    const report = await migrateLegacySkillFilesToPackages(app, settings)
-
-    expect(report.issues).toEqual([
-      {
-        sourcePath,
-        targetPath: 'YOLO/skills/cannot-move/SKILL.md',
-        reason: 'migration_failed',
-        error: 'move failed',
-      },
-    ])
-    await expect(app.vault.adapter.exists(sourcePath)).resolves.toBe(true)
-    await expect(
-      app.vault.adapter.exists('YOLO/skills/cannot-move'),
-    ).resolves.toBe(false)
   })
 })
 

--- a/src/core/skills/liteSkills.ts
+++ b/src/core/skills/liteSkills.ts
@@ -185,28 +185,21 @@ const listSkillPathsInDir = async (
       paths.push(skillPath)
     }
   }
-  return paths.sort((a, b) => a.localeCompare(b))
-}
-
-const listLegacyRootSkillPaths = async (
-  adapter: App['vault']['adapter'],
-  skillsDir: string,
-): Promise<string[]> => {
-  const normalizedDir = normalizePath(skillsDir)
-  if (!(await adapter.exists(normalizedDir))) {
-    return []
-  }
-
-  const listing = await adapter.list(normalizedDir)
-  return listing.files
-    .map((path) => normalizePath(path))
-    .filter((path) => {
-      const fileName = path.slice(path.lastIndexOf('/') + 1)
-      return (
-        fileName !== YOLO_SKILLS_INDEX_FILE_NAME && fileName.endsWith('.md')
-      )
-    })
-    .sort((a, b) => a.localeCompare(b))
+  // Directory packages take precedence over legacy single-file skills with
+  // the same frontmatter name. This preserves package resources when both
+  // formats are present without moving or renaming either user file.
+  return [
+    ...paths.sort((a, b) => a.localeCompare(b)),
+    ...listing.files
+      .map((path) => normalizePath(path))
+      .filter((path) => {
+        const fileName = path.slice(path.lastIndexOf('/') + 1)
+        return (
+          fileName !== YOLO_SKILLS_INDEX_FILE_NAME && fileName.endsWith('.md')
+        )
+      })
+      .sort((a, b) => a.localeCompare(b)),
+  ]
 }
 
 const getSkillPackageDirName = (skillPath: string): string | null => {
@@ -329,10 +322,11 @@ const buildSkillRegistry = async ({
         frontmatter,
         isReadOnly: !managedSkillDirs.has(skillsDir),
       })
+      const packageDirName = getSkillPackageDirName(path)
       if (
         !entry ||
         validateSkillName(entry.name).length > 0 ||
-        getSkillPackageDirName(path) !== entry.name
+        (packageDirName !== null && packageDirName !== entry.name)
       ) {
         continue
       }
@@ -676,7 +670,16 @@ export async function getLiteSkillPackageSource({
 
   const packageDir = getSkillPackageDirPath(document.entry.path)
   if (!packageDir) {
-    return null
+    return {
+      entry: document.entry,
+      resources: [
+        {
+          kind: 'vault',
+          path: document.entry.path,
+          relativePath: SKILL_PACKAGE_ENTRY_FILE_NAME,
+        },
+      ],
+    }
   }
   const prefix = `${packageDir}/`
   const resources = (
@@ -831,12 +834,7 @@ export async function migrateVaultSkillFrontmatter(
     settings,
     configDir: app.vault.configDir,
   })) {
-    const paths = [
-      ...new Set([
-        ...(await listLegacyRootSkillPaths(app.vault.adapter, skillsDir)),
-        ...(await listSkillPathsInDir(app.vault.adapter, skillsDir)),
-      ]),
-    ].sort((a, b) => a.localeCompare(b))
+    const paths = await listSkillPathsInDir(app.vault.adapter, skillsDir)
     for (const path of paths) {
       try {
         const file = app.vault.getFileByPath(path)
@@ -876,149 +874,4 @@ export async function migrateVaultSkillFrontmatter(
       }
     }
   }
-}
-
-export type LegacySkillPackageMigrationIssueReason =
-  | 'invalid_frontmatter'
-  | 'invalid_name'
-  | 'target_exists'
-  | 'migration_failed'
-
-export type LegacySkillPackageMigrationIssue = {
-  sourcePath: string
-  targetPath?: string
-  reason: LegacySkillPackageMigrationIssueReason
-  error?: string
-}
-
-export type LegacySkillPackageMigrationReport = {
-  migrated: Array<{
-    name: string
-    sourcePath: string
-    targetPath: string
-  }>
-  issues: LegacySkillPackageMigrationIssue[]
-}
-
-const removeEmptyDirIfPresent = async (
-  adapter: App['vault']['adapter'],
-  path: string,
-): Promise<void> => {
-  if (!(await adapter.exists(path))) {
-    return
-  }
-  const listing = await adapter.list(path)
-  if (listing.files.length === 0 && listing.folders.length === 0) {
-    await adapter.rmdir(path, false)
-  }
-}
-
-/**
- * Move root-level legacy Markdown skills into standard directory packages.
- *
- * The migration is intentionally conservative and idempotent: identity comes
- * only from a standards-valid frontmatter `name`; an existing target path is
- * always treated as a conflict; and failed/invalid sources are never removed.
- */
-export async function migrateLegacySkillFilesToPackages(
-  app: App,
-  settings?: SkillSettings,
-): Promise<LegacySkillPackageMigrationReport> {
-  const report: LegacySkillPackageMigrationReport = {
-    migrated: [],
-    issues: [],
-  }
-
-  for (const skillsDir of getManagedSkillScanDirs({
-    settings,
-    configDir: app.vault.configDir,
-  })) {
-    const sourcePaths = await listLegacyRootSkillPaths(
-      app.vault.adapter,
-      skillsDir,
-    )
-    for (const sourcePath of sourcePaths) {
-      let targetDir: string | null = null
-      let createdTargetDir = false
-      try {
-        const content = await app.vault.adapter.read(sourcePath)
-        const frontmatter = parseFrontmatterFromContent(content)
-        if (!frontmatter) {
-          report.issues.push({
-            sourcePath,
-            reason: 'invalid_frontmatter',
-          })
-          continue
-        }
-
-        const nameErrors = validateSkillName(frontmatter.name)
-        if (nameErrors.length > 0 || typeof frontmatter.name !== 'string') {
-          report.issues.push({ sourcePath, reason: 'invalid_name' })
-          continue
-        }
-
-        const name = frontmatter.name.trim()
-        targetDir = normalizePath(`${skillsDir}/${name}`)
-        const targetPath = normalizePath(
-          `${targetDir}/${SKILL_PACKAGE_ENTRY_FILE_NAME}`,
-        )
-        if (await app.vault.adapter.exists(targetDir)) {
-          report.issues.push({
-            sourcePath,
-            targetPath,
-            reason: 'target_exists',
-          })
-          continue
-        }
-
-        await app.vault.adapter.mkdir(targetDir)
-        createdTargetDir = true
-        if (await app.vault.adapter.exists(targetPath)) {
-          await removeEmptyDirIfPresent(app.vault.adapter, targetDir)
-          report.issues.push({
-            sourcePath,
-            targetPath,
-            reason: 'target_exists',
-          })
-          continue
-        }
-        await app.vault.adapter.rename(sourcePath, targetPath)
-        report.migrated.push({ name, sourcePath, targetPath })
-      } catch (error) {
-        if (targetDir && createdTargetDir) {
-          try {
-            await removeEmptyDirIfPresent(app.vault.adapter, targetDir)
-          } catch (cleanupError) {
-            console.warn(
-              `[YOLO] Failed to clean up skill migration target ${targetDir}.`,
-              cleanupError,
-            )
-          }
-        }
-        report.issues.push({
-          sourcePath,
-          ...(targetDir
-            ? {
-                targetPath: normalizePath(
-                  `${targetDir}/${SKILL_PACKAGE_ENTRY_FILE_NAME}`,
-                ),
-              }
-            : {}),
-          reason: 'migration_failed',
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
-  }
-
-  return report
-}
-
-/** Run all vault-skill upgrades in dependency order at startup. */
-export async function migrateVaultSkillsToDirectoryPackages(
-  app: App,
-  settings?: SkillSettings,
-): Promise<LegacySkillPackageMigrationReport> {
-  await migrateVaultSkillFrontmatter(app, settings)
-  return migrateLegacySkillFilesToPackages(app, settings)
 }

--- a/src/core/skills/liteSkills.ts
+++ b/src/core/skills/liteSkills.ts
@@ -10,7 +10,7 @@ import {
   getBuiltinLiteSkillByName,
   listBuiltinLiteSkills,
 } from './builtinSkills'
-import { parseFrontmatter, validateSkillName } from './skillValidation'
+import { parseFrontmatter } from './skillValidation'
 
 export type LiteSkillMode = 'lazy' | 'always'
 
@@ -185,7 +185,7 @@ const listSkillPathsInDir = async (
       paths.push(skillPath)
     }
   }
-  // Directory packages take precedence over legacy single-file skills with
+  // Directory packages take precedence over single-file skills with
   // the same frontmatter name. This preserves package resources when both
   // formats are present without moving or renaming either user file.
   return [
@@ -195,21 +195,12 @@ const listSkillPathsInDir = async (
       .filter((path) => {
         const fileName = path.slice(path.lastIndexOf('/') + 1)
         return (
-          fileName !== YOLO_SKILLS_INDEX_FILE_NAME && fileName.endsWith('.md')
+          fileName !== YOLO_SKILLS_INDEX_FILE_NAME &&
+          (fileName.endsWith('.md') || fileName.endsWith('.markdown'))
         )
       })
       .sort((a, b) => a.localeCompare(b)),
   ]
-}
-
-const getSkillPackageDirName = (skillPath: string): string | null => {
-  const suffix = `/${SKILL_PACKAGE_ENTRY_FILE_NAME}`
-  if (!skillPath.endsWith(suffix)) {
-    return null
-  }
-  const packageDir = skillPath.slice(0, -suffix.length)
-  const slashIndex = packageDir.lastIndexOf('/')
-  return packageDir.slice(slashIndex + 1) || null
 }
 
 export const getSkillPackageDirPath = (skillPath: string): string | null => {
@@ -322,12 +313,7 @@ const buildSkillRegistry = async ({
         frontmatter,
         isReadOnly: !managedSkillDirs.has(skillsDir),
       })
-      const packageDirName = getSkillPackageDirName(path)
-      if (
-        !entry ||
-        validateSkillName(entry.name).length > 0 ||
-        (packageDirName !== null && packageDirName !== entry.name)
-      ) {
+      if (!entry) {
         continue
       }
       if (vaultClaimed.has(entry.name)) {
@@ -815,7 +801,7 @@ export function rewriteSkillFrontmatterIdToName(
 /**
  * One-time, idempotent migration of vault skill files from the legacy
  * `id + name` frontmatter to the converged `name`-only form. Scans standard
- * directory packages plus root-level legacy Markdown sources and, when a file
+ * directory packages plus root-level Markdown sources and, when a file
  * carries a valid `id`, promotes `id` -> `name` and removes the `id` line.
  * Files without a valid `id` are skipped. Per-file failures are logged and
  * skipped without aborting the batch.

--- a/src/core/skills/skillValidation.test.ts
+++ b/src/core/skills/skillValidation.test.ts
@@ -1,11 +1,8 @@
 import {
   parseFrontmatter,
-  validateCompatibility,
-  validateDescription,
   validateDirectoryPackage,
   validateSingleFileSkill,
   validateSkillName,
-  wrapMarkdownAsSkillPackage,
 } from './skillValidation'
 
 // ---------------------------------------------------------------------------
@@ -121,13 +118,11 @@ describe('parseFrontmatter', () => {
 // ---------------------------------------------------------------------------
 
 describe('validateSkillName', () => {
-  it('passes for valid names', () => {
+  it('accepts any non-empty string without enforcing a naming convention', () => {
     expect(validateSkillName('pdf-processing')).toEqual([])
-    expect(validateSkillName('data-analysis')).toEqual([])
-    expect(validateSkillName('code-review')).toEqual([])
-    expect(validateSkillName('a')).toEqual([])
-    expect(validateSkillName('skill123')).toEqual([])
-    expect(validateSkillName('my-skill-v2')).toEqual([])
+    expect(validateSkillName('PDF Processing')).toEqual([])
+    expect(validateSkillName('技能')).toEqual([])
+    expect(validateSkillName('a'.repeat(65))).toEqual([])
   })
 
   it('fails when name is missing', () => {
@@ -143,134 +138,6 @@ describe('validateSkillName', () => {
     expect(validateSkillName('   ')).toEqual([
       { field: 'name', message: 'missing' },
     ])
-  })
-
-  it('fails when name exceeds 64 characters', () => {
-    const longName = 'a'.repeat(65)
-    const errors = validateSkillName(longName)
-    expect(errors).toContainEqual({
-      field: 'name',
-      message: 'exceeds 64 characters',
-    })
-  })
-
-  it('fails when name contains uppercase', () => {
-    expect(validateSkillName('PDF-Processing')).toContainEqual({
-      field: 'name',
-      message: 'uppercase not allowed',
-    })
-  })
-
-  it('fails when name starts with hyphen', () => {
-    expect(validateSkillName('-pdf')).toContainEqual({
-      field: 'name',
-      message: 'cannot start or end with hyphen',
-    })
-  })
-
-  it('fails when name ends with hyphen', () => {
-    expect(validateSkillName('pdf-')).toContainEqual({
-      field: 'name',
-      message: 'cannot start or end with hyphen',
-    })
-  })
-
-  it('fails when name contains consecutive hyphens', () => {
-    expect(validateSkillName('pdf--processing')).toContainEqual({
-      field: 'name',
-      message: 'consecutive hyphens not allowed',
-    })
-  })
-
-  it('fails when name contains invalid characters', () => {
-    expect(validateSkillName('my_skill')).toContainEqual({
-      field: 'name',
-      message: 'only lowercase letters, numbers, and hyphens allowed',
-    })
-    expect(validateSkillName('my skill')).toContainEqual({
-      field: 'name',
-      message: 'only lowercase letters, numbers, and hyphens allowed',
-    })
-    expect(validateSkillName('技能')).toContainEqual({
-      field: 'name',
-      message: 'only lowercase letters, numbers, and hyphens allowed',
-    })
-  })
-
-  it('passes for single character name', () => {
-    expect(validateSkillName('a')).toEqual([])
-    expect(validateSkillName('1')).toEqual([])
-  })
-
-  it('passes for exactly 64 characters', () => {
-    const name = 'a'.repeat(64)
-    expect(validateSkillName(name)).toEqual([])
-  })
-})
-
-// ---------------------------------------------------------------------------
-// validateDescription
-// ---------------------------------------------------------------------------
-
-describe('validateDescription', () => {
-  it('passes for valid description', () => {
-    expect(validateDescription('Extracts text from PDF files.')).toEqual([])
-  })
-
-  it('fails when description is missing', () => {
-    expect(validateDescription(undefined)).toEqual([
-      { field: 'description', message: 'missing' },
-    ])
-    expect(validateDescription(null)).toEqual([
-      { field: 'description', message: 'missing' },
-    ])
-    expect(validateDescription('')).toEqual([
-      { field: 'description', message: 'missing' },
-    ])
-    expect(validateDescription('   ')).toEqual([
-      { field: 'description', message: 'missing' },
-    ])
-  })
-
-  it('fails when description exceeds 1024 characters', () => {
-    const longDesc = 'a'.repeat(1025)
-    expect(validateDescription(longDesc)).toContainEqual({
-      field: 'description',
-      message: 'exceeds 1024 characters',
-    })
-  })
-
-  it('passes for exactly 1024 characters', () => {
-    const desc = 'a'.repeat(1024)
-    expect(validateDescription(desc)).toEqual([])
-  })
-})
-
-// ---------------------------------------------------------------------------
-// validateCompatibility
-// ---------------------------------------------------------------------------
-
-describe('validateCompatibility', () => {
-  it('passes when not provided', () => {
-    expect(validateCompatibility(undefined)).toEqual([])
-    expect(validateCompatibility(null)).toEqual([])
-  })
-
-  it('passes for valid compatibility string', () => {
-    expect(validateCompatibility('Requires Python 3.14+ and uv')).toEqual([])
-  })
-
-  it('fails when exceeds 500 characters', () => {
-    const longCompat = 'a'.repeat(501)
-    expect(validateCompatibility(longCompat)).toContainEqual({
-      field: 'compatibility',
-      message: 'exceeds 500 characters',
-    })
-  })
-
-  it('passes for exactly 500 characters', () => {
-    const compat = 'a'.repeat(500)
-    expect(validateCompatibility(compat)).toEqual([])
   })
 })
 
@@ -318,78 +185,26 @@ describe('validateDirectoryPackage', () => {
     })
   })
 
-  it('fails when name is invalid and description is missing', () => {
-    const content = ['---', 'name: My-Skill', '---'].join('\n')
+  it('accepts missing description and a non-standard name', () => {
+    const content = ['---', 'name: My Skill', '---'].join('\n')
     const files = [{ relativePath: 'SKILL.md', content }]
-    const errors = validateDirectoryPackage('My-Skill', files)
+    expect(validateDirectoryPackage('different-folder', files)).toEqual([])
+  })
+
+  it('fails when name is missing', () => {
+    const content = ['---', 'description: No name', '---'].join('\n')
+    const files = [{ relativePath: 'SKILL.md', content }]
+    const errors = validateDirectoryPackage('my-skill', files)
     expect(errors).toContainEqual({
       field: 'name',
-      message: 'uppercase not allowed',
-    })
-    expect(errors).toContainEqual({
-      field: 'description',
       message: 'missing',
     })
   })
 
-  it('fails when description is missing', () => {
-    const content = ['---', 'name: my-skill', '---'].join('\n')
+  it('does not require frontmatter.name to match the folder name', () => {
+    const content = ['---', 'name: pdf-processing', '---'].join('\n')
     const files = [{ relativePath: 'SKILL.md', content }]
-    const errors = validateDirectoryPackage('my-skill', files)
-    expect(errors).toContainEqual({
-      field: 'description',
-      message: 'missing',
-    })
-  })
-
-  it('validates optional compatibility field', () => {
-    const content = [
-      '---',
-      'name: my-skill',
-      'description: A skill.',
-      `compatibility: ${'x'.repeat(501)}`,
-      '---',
-    ].join('\n')
-    const files = [{ relativePath: 'SKILL.md', content }]
-    const errors = validateDirectoryPackage('my-skill', files)
-    expect(errors).toContainEqual({
-      field: 'compatibility',
-      message: 'exceeds 500 characters',
-    })
-  })
-
-  it('fails when frontmatter.name does not match folder name', () => {
-    const content = [
-      '---',
-      'name: pdf-processing',
-      'description: A useful skill.',
-      '---',
-    ].join('\n')
-    const files = [{ relativePath: 'SKILL.md', content }]
-    const errors = validateDirectoryPackage('different-folder', files)
-    expect(errors).toContainEqual({
-      field: 'name',
-      message: 'must match folder name',
-    })
-  })
-
-  it('does not report mismatch when name is already invalid', () => {
-    const content = [
-      '---',
-      'name: PDF-Processing',
-      'description: A useful skill.',
-      '---',
-    ].join('\n')
-    const files = [{ relativePath: 'SKILL.md', content }]
-    const errors = validateDirectoryPackage('pdf-processing', files)
-    expect(errors).toContainEqual({
-      field: 'name',
-      message: 'uppercase not allowed',
-    })
-    expect(errors).not.toContainEqual({
-      field: 'name',
-      message: 'must match folder name',
-    })
+    expect(validateDirectoryPackage('different-folder', files)).toEqual([])
   })
 
   it('passes with all optional fields valid', () => {
@@ -450,14 +265,9 @@ describe('validateSingleFileSkill', () => {
     })
   })
 
-  it('requires a standards-valid name and description before wrapping', () => {
+  it('accepts a non-standard name without description', () => {
     const content = ['---', 'name: Any Name With Spaces', '---'].join('\n')
-    expect(validateSingleFileSkill(content)).toEqual(
-      expect.arrayContaining([
-        { field: 'name', message: 'uppercase not allowed' },
-        { field: 'description', message: 'missing' },
-      ]),
-    )
+    expect(validateSingleFileSkill(content)).toEqual([])
   })
 
   it('passes with all frontmatter fields', () => {
@@ -472,32 +282,5 @@ describe('validateSingleFileSkill', () => {
       'Body content.',
     ].join('\n')
     expect(validateSingleFileSkill(content)).toEqual([])
-  })
-
-  it('wraps a single Markdown input as <frontmatter.name>/SKILL.md', () => {
-    const content = [
-      '---',
-      'name: imported-skill',
-      'description: Imported from one Markdown file.',
-      '---',
-      '# Instructions',
-    ].join('\n')
-
-    expect(wrapMarkdownAsSkillPackage(content)).toEqual({
-      package: {
-        name: 'imported-skill',
-        description: 'Imported from one Markdown file.',
-        files: [{ relativePath: 'SKILL.md', content }],
-      },
-      errors: [],
-    })
-  })
-
-  it('does not derive package identity from an invalid input filename', () => {
-    const content = ['---', 'description: Missing name.', '---'].join('\n')
-    const result = wrapMarkdownAsSkillPackage(content)
-
-    expect(result.package).toBeNull()
-    expect(result.errors).toContainEqual({ field: 'name', message: 'missing' })
   })
 })

--- a/src/core/skills/skillValidation.ts
+++ b/src/core/skills/skillValidation.ts
@@ -1,7 +1,4 @@
-/**
- * Agent Skills 开放标准校验模块。
- * 参考规范:https://agentskills.io/specification
- */
+/** Skill Markdown parsing and minimum import validation. */
 
 import { parseYaml } from 'obsidian'
 
@@ -10,87 +7,9 @@ export type ValidationError = {
   message: string
 }
 
-// ---------------------------------------------------------------------------
-// name 字段校验
-// ---------------------------------------------------------------------------
-
-/**
- * Agent Skills 标准 name 规则:
- * - 1-64 字符
- * - 仅允许小写字母 (a-z)、数字 (0-9)、连字符 (-)
- * - 不能以连字符开头或结尾
- * - 不能包含连续连字符 (--)
- */
-const SKILL_NAME_CHARS_PATTERN = /^[a-z0-9-]+$/
-
 export function validateSkillName(name: unknown): ValidationError[] {
-  const errors: ValidationError[] = []
-
   if (typeof name !== 'string' || name.trim().length === 0) {
-    errors.push({ field: 'name', message: 'missing' })
-    return errors
-  }
-
-  const trimmed = name.trim()
-
-  if (trimmed.length > 64) {
-    errors.push({ field: 'name', message: 'exceeds 64 characters' })
-  }
-
-  if (/[A-Z]/.test(trimmed)) {
-    errors.push({ field: 'name', message: 'uppercase not allowed' })
-  } else if (!SKILL_NAME_CHARS_PATTERN.test(trimmed)) {
-    errors.push({
-      field: 'name',
-      message: 'only lowercase letters, numbers, and hyphens allowed',
-    })
-  } else if (trimmed.startsWith('-') || trimmed.endsWith('-')) {
-    errors.push({
-      field: 'name',
-      message: 'cannot start or end with hyphen',
-    })
-  } else if (trimmed.includes('--')) {
-    errors.push({
-      field: 'name',
-      message: 'consecutive hyphens not allowed',
-    })
-  }
-
-  return errors
-}
-
-// ---------------------------------------------------------------------------
-// description 字段校验
-// ---------------------------------------------------------------------------
-
-export function validateDescription(description: unknown): ValidationError[] {
-  const errors: ValidationError[] = []
-
-  if (typeof description !== 'string' || description.trim().length === 0) {
-    errors.push({ field: 'description', message: 'missing' })
-    return errors
-  }
-
-  if (description.trim().length > 1024) {
-    errors.push({
-      field: 'description',
-      message: 'exceeds 1024 characters',
-    })
-  }
-
-  return errors
-}
-
-// ---------------------------------------------------------------------------
-// compatibility 字段校验(可选)
-// ---------------------------------------------------------------------------
-
-export function validateCompatibility(
-  compatibility: unknown,
-): ValidationError[] {
-  if (compatibility === undefined || compatibility === null) return []
-  if (typeof compatibility === 'string' && compatibility.trim().length > 500) {
-    return [{ field: 'compatibility', message: 'exceeds 500 characters' }]
+    return [{ field: 'name', message: 'missing' }]
   }
   return []
 }
@@ -141,12 +60,9 @@ export type FileEntry = {
   data?: ArrayBuffer
 }
 
-/**
- * 对文件夹格式的 skill 包进行完整校验(Agent Skills 标准)。
- * 当 dirName 提供时,会校验 frontmatter.name 与 dirName 是否一致。
- */
+/** Validate only the fields YOLO needs to load a directory skill package. */
 export function validateDirectoryPackage(
-  dirName: string,
+  _dirName: string,
   files: FileEntry[],
 ): ValidationError[] {
   const errors: ValidationError[] = []
@@ -169,81 +85,15 @@ export function validateDirectoryPackage(
     return errors
   }
 
-  // 3. 校验 name 字段
-  const nameErrors = validateSkillName(frontmatter.name)
-  errors.push(...nameErrors)
-
-  // 4. name 必须与文件夹名一致(Agent Skills 规范要求)
-  if (
-    nameErrors.length === 0 &&
-    typeof frontmatter.name === 'string' &&
-    frontmatter.name.trim() !== dirName
-  ) {
-    errors.push({ field: 'name', message: 'must match folder name' })
-  }
-
-  // 5. 校验 description 字段
-  errors.push(...validateDescription(frontmatter.description))
-
-  // 6. 校验可选字段
-  errors.push(...validateCompatibility(frontmatter.compatibility))
-
-  return errors
+  return validateSkillName(frontmatter.name)
 }
 
-/**
- * 校验将被包装为 `<name>/SKILL.md` 的单个 Markdown 输入。
- * 单文件只是导入边界，落盘后仍必须是完整的标准目录包。
- */
+/** Validate only the fields YOLO needs to load a single-file skill. */
 export function validateSingleFileSkill(content: string): ValidationError[] {
   const frontmatter = parseFrontmatter(content)
   if (!frontmatter) {
     return [{ field: 'frontmatter', message: 'missing or invalid' }]
   }
 
-  return [
-    ...validateSkillName(frontmatter.name),
-    ...validateDescription(frontmatter.description),
-    ...validateCompatibility(frontmatter.compatibility),
-  ]
-}
-
-export type WrappedMarkdownSkillPackage = {
-  name: string
-  description: string
-  files: FileEntry[]
-}
-
-/**
- * 把通过标准校验的单 Markdown 输入包装成目录包。
- * 返回校验错误而不猜测文件名，确保身份始终来自 frontmatter.name。
- */
-export function wrapMarkdownAsSkillPackage(content: string): {
-  package: WrappedMarkdownSkillPackage | null
-  errors: ValidationError[]
-} {
-  const errors = validateSingleFileSkill(content)
-  if (errors.length > 0) {
-    return { package: null, errors }
-  }
-
-  const frontmatter = parseFrontmatter(content)
-  if (
-    typeof frontmatter?.name !== 'string' ||
-    typeof frontmatter.description !== 'string'
-  ) {
-    return {
-      package: null,
-      errors: [{ field: 'frontmatter', message: 'missing or invalid' }],
-    }
-  }
-
-  return {
-    package: {
-      name: frontmatter.name.trim(),
-      description: frontmatter.description.trim(),
-      files: [{ relativePath: 'SKILL.md', content }],
-    },
-    errors: [],
-  }
+  return validateSkillName(frontmatter.name)
 }

--- a/src/core/skills/templates.ts
+++ b/src/core/skills/templates.ts
@@ -11,12 +11,13 @@ export const getSkillsPathAwareTemplate = (
 
 export const YOLO_SKILLS_INDEX_TEMPLATE = `# YOLO Skills
 
-Store standard Agent Skills directory packages here.
+Store YOLO skills here in either supported form.
 
-- Required layout: \`YOLO/skills/<name>/SKILL.md\`
-- The directory name must exactly match frontmatter \`name\`.
-- Required frontmatter: \`name\` (kebab-case unique identifier) and \`description\`; \`mode\` (\`lazy\` | \`always\`) is optional.
-- Keep supporting \`scripts/\`, \`references/\`, \`assets/\`, and other resources inside the same \`<name>/\` package.
+- Simple skill: \`YOLO/skills/<readable-name>.md\`
+- Skill package with resources: \`YOLO/skills/<folder>/SKILL.md\`
+- Required frontmatter: a non-empty \`name\`; \`description\` and \`mode\` (\`lazy\` | \`always\`) are optional.
+- Keep supporting \`scripts/\`, \`references/\`, \`assets/\`, and other resources inside the package folder.
+- Preserve existing filenames and package folder names when editing skills.
 `
 
 export const YOLO_OBSIDIAN_OUTPUT_FORMAT_TEMPLATE = `---
@@ -110,20 +111,18 @@ Obsidian vaults contain the user's real data. Prefer minimal edits, explicit ver
 
 ## Anatomy of a Skill
 
-Every YOLO skill is a self-contained directory package stored in the vault's \`YOLO/skills/\` folder:
+YOLO supports simple Markdown skills and directory packages. Use a single Markdown file by default; use a package only when the skill needs supporting resources:
 
 ~~~
 YOLO/skills/
-├── meeting-notes/
-│   ├── SKILL.md
-│   └── references/
+├── meeting-notes.md
 ├── pdf-editor/
 │   ├── SKILL.md
 │   └── scripts/
 └── ...
 ~~~
 
-Each package has a required \`SKILL.md\` entry file with two parts, plus optional resources used by its workflow:
+The Markdown entry file—either \`<readable-name>.md\` or a package's \`SKILL.md\`—has two parts. Packages may also contain supporting resources:
 
 ### Frontmatter (YAML, required)
 
@@ -182,12 +181,12 @@ Key principle: When a skill supports multiple variations or domains, split into 
 ~~~
 # Instead of one monolithic "data-analysis" skill:
 YOLO/skills/
-├── bigquery-finance/SKILL.md
-├── bigquery-sales/SKILL.md
-└── bigquery-product/SKILL.md
+├── bigquery-finance.md
+├── bigquery-sales.md
+└── bigquery-product.md
 ~~~
 
-This way, when the user asks about sales metrics, only \`bigquery-sales/SKILL.md\` activates and loads.
+This way, when the user asks about sales metrics, only \`bigquery-sales.md\` activates and loads.
 
 ## Available Tools
 
@@ -243,7 +242,7 @@ Before creating something new, check what already exists:
 ~~~
 fs_list YOLO/skills/          -> see current inventory
 fs_search <topic keywords>    -> find related skills
-fs_read <similar-skill>/SKILL.md -> study patterns that work (prefer line ranges when a section is known)
+fs_read <similar-skill-path>    -> study patterns that work (prefer line ranges when a section is known)
 ~~~
 
 This avoids duplication and helps maintain consistency across the vault's skill collection.
@@ -261,7 +260,7 @@ Analyze each concrete example by considering:
 Write the frontmatter first, then the body.
 
 Frontmatter checklist:
-- \`name\` is kebab-case, unique, and exactly matches the package directory name
+- \`name\` is stable and unique
 - \`description\` clearly states what the skill does and when to trigger it
 
 Body guidelines:
@@ -272,12 +271,20 @@ Body guidelines:
 
 ### Step 5: Write to Vault
 
+For a simple skill, keep the user-facing filename readable:
+
 ~~~
-fs_create_dir { path: "YOLO/skills/<skill-name>" }
-fs_write { path: "YOLO/skills/<skill-name>/SKILL.md", content: "..." }
+fs_write { path: "YOLO/skills/<readable-name>.md", content: "..." }
 ~~~
 
-Put scripts, references, assets, and other supporting files under the same package directory. For updates to existing skills, prefer \`fs_edit\` to make minimal, targeted changes rather than rewriting the entire entry file.
+Only create a directory package when the skill needs scripts, references, assets, or other supporting files:
+
+~~~
+fs_create_dir { path: "YOLO/skills/<folder>" }
+fs_write { path: "YOLO/skills/<folder>/SKILL.md", content: "..." }
+~~~
+
+For updates, preserve the skill's existing filename or package folder and prefer \`fs_edit\` for minimal, targeted changes.
 
 ### Step 6: Verify and Iterate
 
@@ -301,8 +308,8 @@ Before finalizing any skill, verify:
 
 - [ ] Frontmatter includes \`name\` and \`description\`
 - [ ] Description states clear trigger conditions (not buried in body)
-- [ ] \`name\` is kebab-case and matches the package directory name
-- [ ] The entry file is exactly \`<name>/SKILL.md\`, with all supporting resources kept inside \`<name>/\`
+- [ ] \`name\` is stable and unique
+- [ ] A simple skill remains a readable Markdown file; supporting resources stay inside a package folder with \`SKILL.md\`
 - [ ] Workflow is executable with available tools (\`fs_list\`, \`fs_search\`, \`fs_read\`, \`fs_edit\`, \`fs_write\`, \`fs_delete\`, \`fs_create_dir\`, \`fs_move\`)
 - [ ] Instructions are concise and avoid redundant background
 - [ ] Output pattern is defined where consistency matters

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -481,7 +481,7 @@ export const en: TranslationKeys = {
       skillsCount: '{count} skills',
       skillsCountWithEnabled: '{count} skills (enabled {enabled})',
       skillsGlobalDesc:
-        'Skills are discovered from built-in skills, {path}/*.md files, and {path}/<name>/SKILL.md packages. Disable a skill here to block it for all agents.',
+        'Skills are discovered from built-in skills, {path}/*.md files, and {path}/<folder>/SKILL.md packages. Disable a skill here to block it for all agents.',
       yoloBaseDir: 'YOLO base folder',
       yoloBaseDirDesc:
         'Enter a vault-relative path (without a leading /). Example: use YOLO at vault root, or setting/YOLO under the setting folder.',
@@ -502,15 +502,15 @@ export const en: TranslationKeys = {
       yoloBaseDirConflictMessage:
         '{target} already exists and contains files. Nothing was moved to avoid overwriting or merging data. Choose an empty or nonexistent folder.',
       skillsSourcePath:
-        'Source: built-in skills + {path}/*.md + {path}/<name>/SKILL.md',
+        'Source: built-in skills + {path}/*.md + {path}/<folder>/SKILL.md',
       refreshSkills: 'Refresh',
       skillsEmptyHint:
-        'No skills found. Create a {path}/<name>/SKILL.md package.',
+        'No skills found. Create a Markdown file or a folder containing SKILL.md under {path}.',
       createSkillTemplates: 'Initialize Skills system',
       skillsTemplateCreated: 'Skills system initialized in {path}.',
       importSkill: 'Import Skill',
       importSkillDesc:
-        'Import skill packages into {path}. Single Markdown files are wrapped as <name>/SKILL.md; folders keep SKILL.md and all package resources.',
+        'Import skills into {path}. Markdown files keep their filenames; folders keep their names, SKILL.md, and all package resources.',
       importSkillDropzoneText: 'Drag & drop skill files or folders here',
       importSkillBrowseFiles: 'Browse Files',
       importSkillBrowseFolder: 'Browse Folder',
@@ -529,19 +529,6 @@ export const en: TranslationKeys = {
       importSkillErrNoFrontmatter:
         'missing metadata header (---) at the top of the file',
       importSkillErrNoName: 'missing "name" field in metadata',
-      importSkillErrNameTooLong: '"name" is too long (max 64 characters)',
-      importSkillErrNameUppercase: '"name" must be all lowercase',
-      importSkillErrNameHyphenEdge: '"name" cannot start or end with a hyphen',
-      importSkillErrNameDoubleHyphen:
-        '"name" cannot contain consecutive hyphens (--)',
-      importSkillErrNameInvalidChars:
-        '"name" can only contain lowercase letters, numbers, and hyphens',
-      importSkillErrNameMismatch: '"name" must match the folder name',
-      importSkillErrNoDescription: 'missing "description" field in metadata',
-      importSkillErrDescTooLong:
-        '"description" is too long (max 1024 characters)',
-      importSkillErrCompatTooLong:
-        '"compatibility" is too long (max 500 characters)',
       importSkillConflictTitle: 'Skill already exists',
       importSkillConflictMessage:
         'A skill with the same name already exists. Do you want to overwrite it?',
@@ -551,7 +538,7 @@ export const en: TranslationKeys = {
       importSkillConflictSkip: 'Skip conflicts',
       importSkillUnsafePath: 'Refused unsafe path in "{name}": {path}',
       importSkillDuplicateInBatch:
-        'Duplicate skill name in this batch: "{name}" (from "{source}"). Only the first occurrence is kept.',
+        'Duplicate import destination in this batch: "{name}" (from "{source}"). Only the first occurrence is kept.',
       importSkillFromUrlPlaceholder: 'Paste a GitHub URL (repo / blob / tree)',
       importSkillFromUrlFetch: 'Fetch',
       importSkillFromUrlFetching: 'Fetching...',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -481,7 +481,7 @@ export const en: TranslationKeys = {
       skillsCount: '{count} skills',
       skillsCountWithEnabled: '{count} skills (enabled {enabled})',
       skillsGlobalDesc:
-        'Skills are discovered from built-in skills and {path}/<name>/SKILL.md packages. Disable a skill here to block it for all agents.',
+        'Skills are discovered from built-in skills, {path}/*.md files, and {path}/<name>/SKILL.md packages. Disable a skill here to block it for all agents.',
       yoloBaseDir: 'YOLO base folder',
       yoloBaseDirDesc:
         'Enter a vault-relative path (without a leading /). Example: use YOLO at vault root, or setting/YOLO under the setting folder.',
@@ -501,7 +501,8 @@ export const en: TranslationKeys = {
       yoloBaseDirConflictTitle: 'YOLO root was not moved',
       yoloBaseDirConflictMessage:
         '{target} already exists and contains files. Nothing was moved to avoid overwriting or merging data. Choose an empty or nonexistent folder.',
-      skillsSourcePath: 'Source: built-in skills + {path}/<name>/SKILL.md',
+      skillsSourcePath:
+        'Source: built-in skills + {path}/*.md + {path}/<name>/SKILL.md',
       refreshSkills: 'Refresh',
       skillsEmptyHint:
         'No skills found. Create a {path}/<name>/SKILL.md package.',
@@ -569,27 +570,13 @@ export const en: TranslationKeys = {
       deleteSkillConfirm: 'Delete',
       deleteSkillSuccess: '"{name}" has been deleted.',
       deleteSkillError: 'Failed to delete "{name}": {error}',
-      deleteSkillInvalidPackage: 'Invalid skill package path',
-      deleteSkillNotFound: 'Skill package not found',
+      deleteSkillNotFound: 'Skill not found',
       deleteSkillBatchMessage:
-        'Are you sure you want to delete {count} skill package(s), including all resources? This cannot be undone.',
+        'Are you sure you want to delete {count} skill(s), including package resources? This cannot be undone.',
       deleteSkillBatchSuccess: 'Deleted {count} skill(s).',
       deleteSkillBatchBtn: 'Delete',
       deleteSkillSelectAll: 'Select all',
       deleteSkillCancel: 'Cancel',
-      skillPackageMigrationIssues:
-        '{count} legacy skill file(s) need attention. YOLO did not overwrite or delete them:',
-      skillPackageMigrationInvalidFrontmatter:
-        '{path}: missing or invalid YAML frontmatter; file was kept.',
-      skillPackageMigrationInvalidName:
-        '{path}: frontmatter name must be 1–64 lowercase letters, numbers, or hyphens; file was kept.',
-      skillPackageMigrationConflict:
-        '{path}: target {target} already exists; file was kept.',
-      skillPackageMigrationFileFailed:
-        '{path}: migration failed ({error}); file was kept.',
-      skillPackageMigrationUnknownError: 'Unknown error',
-      skillPackageMigrationFailed:
-        'YOLO could not finish upgrading legacy skill files. The source files were kept; review the console and move them manually.',
       selectSkills: 'Select',
       agents: 'Agents',
       agentsDesc: 'Click Configure to edit each agent profile and prompt.',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -508,7 +508,7 @@ export const it: DeepPartial<TranslationKeys> = {
       skillsCount: '{count} competenze',
       skillsCountWithEnabled: '{count} competenze (abilitate {enabled})',
       skillsGlobalDesc:
-        'Le skill vengono rilevate dalle skill integrate e dai pacchetti {path}/<name>/SKILL.md. Disabilitale qui per bloccarle su tutti gli agent.',
+        'Le skill vengono rilevate dalle skill integrate, dai file {path}/*.md e dai pacchetti {path}/<name>/SKILL.md. Disabilitale qui per bloccarle su tutti gli agent.',
       yoloBaseDir: 'Cartella base YOLO',
       yoloBaseDirDesc:
         'Inserisci un percorso relativo al vault (senza / iniziale). Esempio: YOLO nella radice del vault, oppure setting/YOLO nella cartella setting.',
@@ -528,7 +528,8 @@ export const it: DeepPartial<TranslationKeys> = {
       yoloBaseDirConflictTitle: 'La cartella base YOLO non è stata spostata',
       yoloBaseDirConflictMessage:
         '{target} esiste già e contiene file. Nessun contenuto è stato spostato per evitare sovrascritture o fusioni. Scegli una cartella vuota o inesistente.',
-      skillsSourcePath: 'Origine: skill integrate + {path}/<name>/SKILL.md',
+      skillsSourcePath:
+        'Origine: skill integrate + {path}/*.md + {path}/<name>/SKILL.md',
       refreshSkills: 'Aggiorna',
       skillsEmptyHint:
         'Nessuna skill trovata. Crea un pacchetto {path}/<name>/SKILL.md.',
@@ -587,27 +588,13 @@ export const it: DeepPartial<TranslationKeys> = {
       deleteSkillConfirm: 'Elimina',
       deleteSkillSuccess: '"{name}" è stata eliminata.',
       deleteSkillError: 'Impossibile eliminare "{name}": {error}',
-      deleteSkillInvalidPackage: 'Percorso del pacchetto skill non valido',
-      deleteSkillNotFound: 'Pacchetto skill non trovato',
+      deleteSkillNotFound: 'Skill non trovata',
       deleteSkillBatchMessage:
-        'Sei sicuro di voler eliminare {count} pacchetti skill, incluse tutte le risorse? Questa azione non può essere annullata.',
+        'Sei sicuro di voler eliminare {count} skill, incluse le risorse dei pacchetti? Questa azione non può essere annullata.',
       deleteSkillBatchSuccess: 'Eliminate {count} skill.',
       deleteSkillBatchBtn: 'Elimina',
       deleteSkillSelectAll: 'Seleziona tutto',
       deleteSkillCancel: 'Annulla',
-      skillPackageMigrationIssues:
-        '{count} file skill legacy richiedono attenzione. YOLO non li ha sovrascritti o eliminati:',
-      skillPackageMigrationInvalidFrontmatter:
-        '{path}: frontmatter YAML mancante o non valido; il file è stato conservato.',
-      skillPackageMigrationInvalidName:
-        '{path}: il nome nel frontmatter deve contenere 1–64 lettere minuscole, numeri o trattini; il file è stato conservato.',
-      skillPackageMigrationConflict:
-        '{path}: la destinazione {target} esiste già; il file è stato conservato.',
-      skillPackageMigrationFileFailed:
-        '{path}: migrazione non riuscita ({error}); il file è stato conservato.',
-      skillPackageMigrationUnknownError: 'Errore sconosciuto',
-      skillPackageMigrationFailed:
-        "YOLO non ha potuto completare l'aggiornamento dei file skill legacy. I file sorgente sono stati conservati; controlla la console e spostali manualmente.",
       selectSkills: 'Seleziona',
       agents: 'Agent',
       agentsDesc:

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -508,7 +508,7 @@ export const it: DeepPartial<TranslationKeys> = {
       skillsCount: '{count} competenze',
       skillsCountWithEnabled: '{count} competenze (abilitate {enabled})',
       skillsGlobalDesc:
-        'Le skill vengono rilevate dalle skill integrate, dai file {path}/*.md e dai pacchetti {path}/<name>/SKILL.md. Disabilitale qui per bloccarle su tutti gli agent.',
+        'Le skill vengono rilevate dalle skill integrate, dai file {path}/*.md e dai pacchetti {path}/<folder>/SKILL.md. Disabilitale qui per bloccarle su tutti gli agent.',
       yoloBaseDir: 'Cartella base YOLO',
       yoloBaseDirDesc:
         'Inserisci un percorso relativo al vault (senza / iniziale). Esempio: YOLO nella radice del vault, oppure setting/YOLO nella cartella setting.',
@@ -529,15 +529,15 @@ export const it: DeepPartial<TranslationKeys> = {
       yoloBaseDirConflictMessage:
         '{target} esiste già e contiene file. Nessun contenuto è stato spostato per evitare sovrascritture o fusioni. Scegli una cartella vuota o inesistente.',
       skillsSourcePath:
-        'Origine: skill integrate + {path}/*.md + {path}/<name>/SKILL.md',
+        'Origine: skill integrate + {path}/*.md + {path}/<folder>/SKILL.md',
       refreshSkills: 'Aggiorna',
       skillsEmptyHint:
-        'Nessuna skill trovata. Crea un pacchetto {path}/<name>/SKILL.md.',
+        'Nessuna skill trovata. Crea un file Markdown o una cartella contenente SKILL.md in {path}.',
       createSkillTemplates: 'Inizializza sistema Skills',
       skillsTemplateCreated: 'Sistema Skills inizializzato in {path}.',
       importSkill: 'Importa Skill',
       importSkillDesc:
-        'Importa pacchetti skill in {path}. I singoli file Markdown vengono inseriti in <name>/SKILL.md; le cartelle conservano SKILL.md e tutte le risorse.',
+        'Importa skill in {path}. I file Markdown mantengono il nome; le cartelle mantengono il nome, SKILL.md e tutte le risorse.',
       importSkillDropzoneText: 'Trascina file o cartelle skill qui',
       importSkillBrowseFiles: 'Sfoglia File',
       importSkillBrowseFolder: 'Sfoglia Cartella',
@@ -556,21 +556,6 @@ export const it: DeepPartial<TranslationKeys> = {
       importSkillErrNoFrontmatter:
         'intestazione metadati (---) mancante in cima al file',
       importSkillErrNoName: 'campo "name" mancante nei metadati',
-      importSkillErrNameTooLong: '"name" troppo lungo (massimo 64 caratteri)',
-      importSkillErrNameUppercase: '"name" deve essere tutto minuscolo',
-      importSkillErrNameHyphenEdge:
-        '"name" non può iniziare o terminare con un trattino',
-      importSkillErrNameDoubleHyphen:
-        '"name" non può contenere trattini consecutivi (--)',
-      importSkillErrNameInvalidChars:
-        '"name" può contenere solo lettere minuscole, numeri e trattini',
-      importSkillErrNameMismatch:
-        '"name" deve corrispondere al nome della cartella',
-      importSkillErrNoDescription: 'campo "description" mancante nei metadati',
-      importSkillErrDescTooLong:
-        '"description" troppo lungo (massimo 1024 caratteri)',
-      importSkillErrCompatTooLong:
-        '"compatibility" troppo lungo (massimo 500 caratteri)',
       importSkillConflictTitle: 'Skill già esistente',
       importSkillConflictMessage:
         'Esiste già una skill con lo stesso nome. Vuoi sovrascriverla?',
@@ -581,7 +566,7 @@ export const it: DeepPartial<TranslationKeys> = {
       importSkillUnsafePath:
         'Percorso non sicuro rifiutato in "{name}": {path}',
       importSkillDuplicateInBatch:
-        'Nome skill duplicato in questo batch: "{name}" (da "{source}"). Viene mantenuta solo la prima occorrenza.',
+        'Destinazione di importazione duplicata in questo batch: "{name}" (da "{source}"). Viene mantenuta solo la prima occorrenza.',
       deleteSkillTitle: 'Elimina skill',
       deleteSkillMessage:
         'Sei sicuro di voler eliminare il pacchetto skill "{name}", incluse tutte le risorse? Questa azione non può essere annullata.',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -436,7 +436,7 @@ export const zh: TranslationKeys = {
       skillsCount: '{count} 个技能',
       skillsCountWithEnabled: '{count} 个技能（已启用 {enabled} 个）',
       skillsGlobalDesc:
-        '技能会从内置技能与 {path}/<name>/SKILL.md 目录包中自动发现。在这里禁用后，所有 Agent 都无法使用。',
+        '技能会从内置技能、{path}/*.md 文件与 {path}/<name>/SKILL.md 目录包中自动发现。在这里禁用后，所有 Agent 都无法使用。',
       yoloBaseDir: 'YOLO 根目录',
       yoloBaseDirDesc:
         '填写库内相对路径（不要以 / 开头）。例如：放在库根目录填 YOLO；放在 setting 文件夹下填 setting/YOLO。',
@@ -455,7 +455,7 @@ export const zh: TranslationKeys = {
       yoloBaseDirConflictTitle: 'YOLO 根目录未移动',
       yoloBaseDirConflictMessage:
         '{target} 已存在且包含文件。为避免覆盖或合并数据，本次未移动任何内容。请选择空目录或尚不存在的路径。',
-      skillsSourcePath: '来源：内置技能 + {path}/<name>/SKILL.md',
+      skillsSourcePath: '来源：内置技能 + {path}/*.md + {path}/<name>/SKILL.md',
       refreshSkills: '刷新',
       skillsEmptyHint: '未发现技能。请创建 {path}/<name>/SKILL.md 目录包。',
       createSkillTemplates: '初始化 Skills 系统',
@@ -515,27 +515,13 @@ export const zh: TranslationKeys = {
       deleteSkillConfirm: '删除',
       deleteSkillSuccess: '已删除「{name}」。',
       deleteSkillError: '删除「{name}」失败：{error}',
-      deleteSkillInvalidPackage: '技能包路径无效',
-      deleteSkillNotFound: '未找到技能包',
+      deleteSkillNotFound: '未找到技能',
       deleteSkillBatchMessage:
-        '确定要删除 {count} 个技能包及其全部资源吗？此操作无法撤销。',
+        '确定要删除 {count} 个技能及其目录包资源吗？此操作无法撤销。',
       deleteSkillBatchSuccess: '已删除 {count} 个技能。',
       deleteSkillBatchBtn: '删除',
       deleteSkillSelectAll: '全选',
       deleteSkillCancel: '取消',
-      skillPackageMigrationIssues:
-        '有 {count} 个旧技能文件需要处理。YOLO 未覆盖或删除它们：',
-      skillPackageMigrationInvalidFrontmatter:
-        '{path}：缺少或包含无效的 YAML frontmatter；已保留原文件。',
-      skillPackageMigrationInvalidName:
-        '{path}：frontmatter name 必须为 1–64 位小写字母、数字或连字符；已保留原文件。',
-      skillPackageMigrationConflict:
-        '{path}：目标 {target} 已存在；已保留原文件。',
-      skillPackageMigrationFileFailed:
-        '{path}：迁移失败（{error}）；已保留原文件。',
-      skillPackageMigrationUnknownError: '未知错误',
-      skillPackageMigrationFailed:
-        'YOLO 未能完成旧技能文件升级。原文件已保留，请查看控制台后手动移动。',
       selectSkills: '选择',
       agents: 'Agents',
       agentsDesc: '点击配置以编辑每个 Agent 的资料与提示词。',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -436,7 +436,7 @@ export const zh: TranslationKeys = {
       skillsCount: '{count} 个技能',
       skillsCountWithEnabled: '{count} 个技能（已启用 {enabled} 个）',
       skillsGlobalDesc:
-        '技能会从内置技能、{path}/*.md 文件与 {path}/<name>/SKILL.md 目录包中自动发现。在这里禁用后，所有 Agent 都无法使用。',
+        '技能会从内置技能、{path}/*.md 文件与 {path}/<folder>/SKILL.md 目录包中自动发现。在这里禁用后，所有 Agent 都无法使用。',
       yoloBaseDir: 'YOLO 根目录',
       yoloBaseDirDesc:
         '填写库内相对路径（不要以 / 开头）。例如：放在库根目录填 YOLO；放在 setting 文件夹下填 setting/YOLO。',
@@ -455,14 +455,16 @@ export const zh: TranslationKeys = {
       yoloBaseDirConflictTitle: 'YOLO 根目录未移动',
       yoloBaseDirConflictMessage:
         '{target} 已存在且包含文件。为避免覆盖或合并数据，本次未移动任何内容。请选择空目录或尚不存在的路径。',
-      skillsSourcePath: '来源：内置技能 + {path}/*.md + {path}/<name>/SKILL.md',
+      skillsSourcePath:
+        '来源：内置技能 + {path}/*.md + {path}/<folder>/SKILL.md',
       refreshSkills: '刷新',
-      skillsEmptyHint: '未发现技能。请创建 {path}/<name>/SKILL.md 目录包。',
+      skillsEmptyHint:
+        '未发现技能。请在 {path} 下创建 Markdown 文件或包含 SKILL.md 的文件夹。',
       createSkillTemplates: '初始化 Skills 系统',
       skillsTemplateCreated: '已在 {path} 完成 Skills 系统初始化。',
       importSkill: '导入技能',
       importSkillDesc:
-        '将技能包导入到 {path}。单个 Markdown 会包装为 <name>/SKILL.md；文件夹会保留 SKILL.md 与全部包资源。',
+        '将技能导入到 {path}。Markdown 保留原文件名；文件夹保留原目录名、SKILL.md 与全部包资源。',
       importSkillDropzoneText: '拖拽技能文件或文件夹到此处',
       importSkillBrowseFiles: '选择文件',
       importSkillBrowseFolder: '选择文件夹',
@@ -480,15 +482,6 @@ export const zh: TranslationKeys = {
       importSkillErrNoSkillMd: '文件夹中缺少 SKILL.md 文件',
       importSkillErrNoFrontmatter: '文件顶部缺少元数据头',
       importSkillErrNoName: '元数据中缺少 "name" 字段',
-      importSkillErrNameTooLong: '"name" 过长（最多 64 个字符）',
-      importSkillErrNameUppercase: '"name" 必须全部小写',
-      importSkillErrNameHyphenEdge: '"name" 不能以连字符开头或结尾',
-      importSkillErrNameDoubleHyphen: '"name" 不能包含连续的连字符',
-      importSkillErrNameInvalidChars: '"name" 只能包含小写字母、数字和连字符',
-      importSkillErrNameMismatch: '"name" 必须与文件夹名称一致',
-      importSkillErrNoDescription: '元数据中缺少 "description" 字段',
-      importSkillErrDescTooLong: '"description" 过长（最多 1024 个字符）',
-      importSkillErrCompatTooLong: '"compatibility" 过长（最多 500 个字符）',
       importSkillConflictTitle: '技能已存在',
       importSkillConflictMessage: '已存在同名技能，是否覆盖？',
       importSkillConflictOverwrite: '全部覆盖',
@@ -497,7 +490,7 @@ export const zh: TranslationKeys = {
       importSkillConflictSkip: '跳过冲突',
       importSkillUnsafePath: '已拒绝「{name}」中的不安全路径：{path}',
       importSkillDuplicateInBatch:
-        '本次导入中存在同名技能：「{name}」（来自「{source}」），仅保留第一个。',
+        '本次导入中存在重复目标路径：「{name}」（来自「{source}」），仅保留第一个。',
       importSkillFromUrlPlaceholder: '粘贴 GitHub 链接（仓库 / blob / tree）',
       importSkillFromUrlFetch: '获取',
       importSkillFromUrlFetching: '获取中...',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -415,20 +415,12 @@ export type TranslationKeys = {
       deleteSkillConfirm?: string
       deleteSkillSuccess?: string
       deleteSkillError?: string
-      deleteSkillInvalidPackage?: string
       deleteSkillNotFound?: string
       deleteSkillBatchMessage?: string
       deleteSkillBatchSuccess?: string
       deleteSkillBatchBtn?: string
       deleteSkillSelectAll?: string
       deleteSkillCancel?: string
-      skillPackageMigrationIssues?: string
-      skillPackageMigrationInvalidFrontmatter?: string
-      skillPackageMigrationInvalidName?: string
-      skillPackageMigrationConflict?: string
-      skillPackageMigrationFileFailed?: string
-      skillPackageMigrationUnknownError?: string
-      skillPackageMigrationFailed?: string
       selectSkills?: string
       agents?: string
       agentsDesc?: string

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -385,15 +385,6 @@ export type TranslationKeys = {
       importSkillErrNoSkillMd?: string
       importSkillErrNoFrontmatter?: string
       importSkillErrNoName?: string
-      importSkillErrNameTooLong?: string
-      importSkillErrNameUppercase?: string
-      importSkillErrNameHyphenEdge?: string
-      importSkillErrNameDoubleHyphen?: string
-      importSkillErrNameInvalidChars?: string
-      importSkillErrNameMismatch?: string
-      importSkillErrNoDescription?: string
-      importSkillErrDescTooLong?: string
-      importSkillErrCompatTooLong?: string
       importSkillConflictTitle?: string
       importSkillConflictMessage?: string
       importSkillConflictMessageList?: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,9 +141,8 @@ import {
   setRuntimeComponentService,
 } from './core/runtime-components'
 import {
-  type LegacySkillPackageMigrationReport,
   initializeLiteSkillRegistryService,
-  migrateVaultSkillsToDirectoryPackages,
+  migrateVaultSkillFrontmatter,
   prewarmLiteSkillRegistry,
   updateLiteSkillRegistrySettings,
 } from './core/skills/liteSkills'
@@ -2128,19 +2127,14 @@ export default class YoloPlugin extends Plugin {
     void pruneImageCache(this.app, 30, this.settings)
     void prunePdfTextCache(this.app, 30, this.settings)
     await this.getRagIndexService().initialize()
-    // One-time, idempotent vault-skill upgrade: converge legacy frontmatter,
-    // then move root-level Markdown files into <name>/SKILL.md packages.
+    // One-time, idempotent migration of legacy skill frontmatter. Skill files
+    // themselves remain at their user-chosen paths.
     this.app.workspace.onLayoutReady(() => {
-      void migrateVaultSkillsToDirectoryPackages(this.app, this.settings)
-        .then((report) => this.showSkillPackageMigrationIssues(report))
+      void migrateVaultSkillFrontmatter(this.app, this.settings)
         .catch((error) => {
-          console.error('[YOLO] Vault skill package migration failed', error)
-          new Notice(
-            this.t(
-              'settings.agent.skillPackageMigrationFailed',
-              'YOLO could not finish upgrading legacy skill files. The source files were kept; review the console and move them manually.',
-            ),
-            0,
+          console.error(
+            '[YOLO] Vault skill frontmatter migration failed',
+            error,
           )
         })
         .finally(() => {
@@ -2708,56 +2702,6 @@ export default class YoloPlugin extends Plugin {
     setLLMDebugCaptureEnabled(
       this.settings.debug?.captureRawRequestDebug ?? false,
     )
-  }
-
-  private showSkillPackageMigrationIssues(
-    report: LegacySkillPackageMigrationReport,
-  ): void {
-    if (report.issues.length === 0) {
-      return
-    }
-
-    const details = report.issues.map((issue) => {
-      switch (issue.reason) {
-        case 'invalid_frontmatter':
-          return this.t(
-            'settings.agent.skillPackageMigrationInvalidFrontmatter',
-            '{path}: missing or invalid YAML frontmatter; file was kept.',
-          ).replace('{path}', issue.sourcePath)
-        case 'invalid_name':
-          return this.t(
-            'settings.agent.skillPackageMigrationInvalidName',
-            '{path}: frontmatter name must be 1–64 lowercase letters, numbers, or hyphens; file was kept.',
-          ).replace('{path}', issue.sourcePath)
-        case 'target_exists':
-          return this.t(
-            'settings.agent.skillPackageMigrationConflict',
-            '{path}: target {target} already exists; file was kept.',
-          )
-            .replace('{path}', issue.sourcePath)
-            .replace('{target}', issue.targetPath ?? '')
-        case 'migration_failed':
-          return this.t(
-            'settings.agent.skillPackageMigrationFileFailed',
-            '{path}: migration failed ({error}); file was kept.',
-          )
-            .replace('{path}', issue.sourcePath)
-            .replace(
-              '{error}',
-              issue.error ??
-                this.t(
-                  'settings.agent.skillPackageMigrationUnknownError',
-                  'Unknown error',
-                ),
-            )
-      }
-    })
-
-    const summary = this.t(
-      'settings.agent.skillPackageMigrationIssues',
-      '{count} legacy skill file(s) need attention. YOLO did not overwrite or delete them:',
-    ).replace('{count}', String(report.issues.length))
-    new Notice(`${summary}\n${details.join('\n')}`, 0)
   }
 
   /** Migrate old hidden roots before any service can open files beneath them. */


### PR DESCRIPTION
## Summary

- 停止启动时移动或重命名单文件 Skills，保留用户文件路径与库内链接。
- 正式支持根目录 Markdown 与 `<folder>/SKILL.md` 目录包；目录包同名时优先，但不要求目录名匹配 frontmatter `name`。
- 本地及 GitHub 导入保留来源文件名、目录名、相对结构和二进制资源，不再按 `name` 归一化落盘路径。
- 将导入与发现校验收敛为有效 frontmatter、非空 `name` 和安全路径，并同步管理界面与 Skill Creator 指引。

## Migration behavior

已经被 1.6.4.3 迁移为目录包的 Skills 会继续正常工作；YOLO 不会猜测原文件名或自动反向迁移。用户手动恢复为任意命名的 Markdown 文件后也会被直接识别。

## Validation

- `npx jest src/core/skills/liteSkills.test.ts src/core/skills/skillValidation.test.ts src/core/skills/githubSkillImporter.test.ts --runInBand`
- `npm run type:check`
- `npm run lint:check`

Refs #543