### PR TITLE
fix(learning): remove the staging folder with folder-aware deletion (#545)

### DIFF
--- a/modules/bundled.json
+++ b/modules/bundled.json
@@ -34,7 +34,7 @@
       "manifestUrl": "https://github.com/Lapis0x0/obsidian-yolo/releases/download/module-learning-v0.1.2-dev.0/module.json",
       "manifest": {
         "byteSize": 1910,
-        "sha256": "4f05bac4445aede0d6bdcc4ba6f5cccc5a15125b508a10d9a20e20014a1c4042"
+        "sha256": "f84abc198cf37769a695c74cb3378a35c4af65e06c854ad076126e0f059a1636"
       }
     }
   ]

--- a/modules/learning/src/host/ui/index.test.ts
+++ b/modules/learning/src/host/ui/index.test.ts
@@ -257,6 +257,30 @@ describe('createLearningUiServices memory host', () => {
     generateCardsParallelMock.mockReset()
   })
 
+  it('cleans up staging with folder-aware removal instead of trashing a directory', async () => {
+    const memory = new MemoryLearningHost()
+    const { runtime } = createRuntime()
+    const services = createLearningUiServices(memory.api, {
+      runtime: runtime as never,
+      ownerDocument: {} as Document,
+    })
+
+    const stagingDir =
+      await services.wizardReferences.createStagingDir('First/learning')
+    await services.wizardReferences.writeFile(stagingDir, {
+      name: 'ref.md',
+      contents: 'body',
+    } as never)
+
+    await services.wizardReferences.cleanup(stagingDir)
+
+    // Trashing a *folder* is what fails with EISDIR when the vault deletes
+    // permanently, so the staging folder must not go through trashPath.
+    expect(memory.trashed).not.toContain(stagingDir)
+    expect(memory.api.vault.getEntry(stagingDir)).toBeNull()
+    expect(memory.api.vault.getEntry(`${stagingDir}/ref.md`)).toBeNull()
+  })
+
   it('resolves the managed root dynamically for scans and staging', async () => {
     const memory = new MemoryLearningHost()
     memory.addProject('First/learning', 'alpha')

--- a/modules/learning/src/host/ui/index.ts
+++ b/modules/learning/src/host/ui/index.ts
@@ -206,7 +206,17 @@ export function createLearningUiServices(
     },
     cleanup: async (stagingDir) => {
       assertPathInRoot(stagingDir, getLearningBaseDir(), '_staging')
-      await host.vault.trashPath(stagingDir)
+      // The staging directory is a plugin-owned temporary folder, so remove it
+      // with the folder-aware exact-removal APIs instead of routing a directory
+      // through trashFile. When the vault is configured to delete permanently
+      // (no trashOption / no .trash folder), trashing a *folder* fails with
+      // EISDIR and leaves the staging directory behind, which then surfaces as
+      // a generation failure. This mirrors moveStagedReferences, which already
+      // removes the emptied staging folder via removeEmptyFolderExact.
+      for (const entry of host.vault.listChildren(stagingDir)) {
+        if (entry.kind === 'file') await host.vault.removeFileExact(entry.path)
+      }
+      await host.vault.removeEmptyFolderExact(stagingDir)
     },
   }
 


### PR DESCRIPTION
Fixes #545 — Learning project creation fails at the outline stage with `EISDIR` when the vault is configured to delete permanently.

## Cause

`wizardReferences.cleanup` removed the staging directory with `host.vault.trashPath(stagingDir)`. That routes through `app.fileManager.trashFile(entry)`, which honours the vault's "Deleted files" preference. With no `trashOption` set (permanent delete), trashing a **folder** goes down a file-oriented deletion path and Obsidian raises:

```
Path is a directory: rm returned EISDIR (is a directory) …/YOLO/learning/_staging/<id>
```

so the staging folder is never removed and the failure surfaces as `Generation failed`, with the outline already successfully generated. Retrying reproduces it.

## Change

`cleanup` now uses the same folder-aware route the success path already uses — `moveStagedReferences` moves the staged files out and removes the emptied folder with `removeEmptyFolderExact`, which has `rmdir` semantics and is unaffected by the trash preference.

```ts
for (const entry of host.vault.listChildren(stagingDir)) {
  if (entry.kind === 'file') await host.vault.removeFileExact(entry.path)
}
await host.vault.removeEmptyFolderExact(stagingDir)
```

The staging directory is a plugin-owned temporary folder, so exact removal is the right semantic — it does not belong in the user's trash, and this makes cleanup behave identically across all three "Deleted files" settings.

I scoped this to the module rather than changing `moduleVault.trashPath`, since `trashPath` is also used for deleting user-visible learning projects, where routing through the user's trash preference is correct and shouldn't become a permanent delete.

## Validation

- New regression test: `cleans up staging with folder-aware removal instead of trashing a directory` — asserts the staging folder never goes through `trashPath` and that both the staged file and the directory are gone afterwards.
- `jest modules/learning` — **273 passed**
- `module:typecheck`, prettier and eslint clean on the changed files; module bundle hash rebuilt (`moduleFixture` 4/4).

Note: CI lint on this repo is currently failing on `src/components/UpdateToast.tsx` and `src/features/editor/selection-rewrite/selectionRewriteController.ts`, which are pre-existing on `main` and untouched here (same as noted on #533).
