### PR TITLE
cli 对话在 yolo 中自动命名成功，但是在 cli gui 中却失败

### DIFF
--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -6977,9 +6977,23 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
             if (state.cliConversationId === null && chatMountedRef.current) {
               setCliConversationId(historyConversationId)
             }
-            void state.generateConversationTitle(historyConversationId, [
-              result.userMessage,
-            ])
+            const generatedTitle = await state.generateConversationTitle(
+              historyConversationId,
+              [result.userMessage],
+            )
+            if (generatedTitle && runtimeId === 'codex') {
+              try {
+                await controller.setNativeSessionTitle({
+                  sessionRef: result.sessionRef,
+                  title: generatedTitle,
+                })
+              } catch (error) {
+                console.warn('[YOLO] Failed to synchronize Codex session title', {
+                  conversationId: historyConversationId,
+                  error,
+                })
+              }
+            }
             if (chatMountedRef.current) {
               if (result.overlayError) {
                 console.warn('[YOLO] Failed to save CLI display metadata', {

--- a/src/core/cli-runtime/codex/runtime.test.ts
+++ b/src/core/cli-runtime/codex/runtime.test.ts
@@ -1063,6 +1063,28 @@ describe('CodexCliRuntime', () => {
     )
   })
 
+  it('sets the active Codex thread name through the app-server', async () => {
+    const process = new RpcFakeProcess()
+    const runtime = new CodexCliRuntime({
+      cwd: '/vault',
+      createProcess: async () => process,
+    })
+    await runtime.ensureReady({})
+
+    await runtime.setSessionTitle({
+      sessionRef: { runtimeId: 'codex', nativeSessionId: 'thread-1' },
+      title: 'Review the title synchronization',
+    })
+
+    expect(process.requests).toContainEqual({
+      method: 'thread/name/set',
+      params: {
+        threadId: 'thread-1',
+        name: 'Review the title synchronization',
+      },
+    })
+  })
+
   it('maps Codex user input requests to the shared Ask User card contract', async () => {
     const process = new RpcFakeProcess()
     const runtime = new CodexCliRuntime({

--- a/src/core/cli-runtime/codex/runtime.ts
+++ b/src/core/cli-runtime/codex/runtime.ts
@@ -27,6 +27,7 @@ import type {
   CliRuntimeModel,
   CliRuntimeReadyInput,
   CliRuntimeSkill,
+  CliSessionTitleInput,
   CliSessionHydration,
   CliSessionRef,
   CliSubagentRef,
@@ -431,6 +432,23 @@ export class CodexCliRuntime implements CliRuntime {
     if (this.disposed) throw new Error('Codex CLI runtime has been disposed.')
     this.cliChatMode = update.mode
     this.yoloEnabled = update.yoloEnabled
+  }
+
+  async setSessionTitle({
+    sessionRef,
+    title,
+  }: CliSessionTitleInput): Promise<void> {
+    if (
+      !this.activeSessionRef ||
+      this.activeSessionRef.nativeSessionId !== sessionRef.nativeSessionId
+    ) {
+      throw new Error('Codex session must be active before setting its title.')
+    }
+    const host = await this.getHost()
+    await host.request('thread/name/set', {
+      threadId: sessionRef.nativeSessionId,
+      name: title,
+    })
   }
 
   async sendTurn(input: CliTurnInput): Promise<void> {

--- a/src/core/cli-runtime/conversation-controller.test.ts
+++ b/src/core/cli-runtime/conversation-controller.test.ts
@@ -59,6 +59,10 @@ class FakeCliRuntime implements CliRuntime {
     mode: 'agent' | 'plan'
     yoloEnabled: boolean
   }> = []
+  readonly sessionTitleUpdates: Array<{
+    sessionRef: CliSessionRef
+    title: string
+  }> = []
   openSessionImpl: (ref: CliSessionRef) => Promise<CliSessionHydration> =
     async (ref) => ({ ref, messages: [], compactionBoundaries: [] })
   ensureReadyImpl: (input: CliRuntimeReadyInput) => Promise<void> = async (
@@ -120,6 +124,13 @@ class FakeCliRuntime implements CliRuntime {
     this.permissionProfileUpdates.push(update)
   }
 
+  async setSessionTitle(input: {
+    sessionRef: CliSessionRef
+    title: string
+  }): Promise<void> {
+    this.sessionTitleUpdates.push(input)
+  }
+
   async sendTurn(input: CliTurnInput): Promise<void> {
     this.turnInputs.push(input)
     await this.sendTurnImpl(input)
@@ -160,6 +171,30 @@ class FakeCliRuntime implements CliRuntime {
 }
 
 describe('CliConversationController', () => {
+  it('updates the active provider-native session title only', async () => {
+    const runtime = new FakeCliRuntime()
+    const controller = new CliConversationController(runtime)
+    await controller.ensureReady()
+    const activeSession = controller.getSnapshot().sessionRef!
+
+    await expect(
+      controller.setNativeSessionTitle({
+        sessionRef: activeSession,
+        title: 'Meaningful title',
+      }),
+    ).resolves.toBe(true)
+    await expect(
+      controller.setNativeSessionTitle({
+        sessionRef: { runtimeId: 'codex', nativeSessionId: 'other' },
+        title: 'Stale title',
+      }),
+    ).resolves.toBe(false)
+
+    expect(runtime.sessionTitleUpdates).toEqual([
+      { sessionRef: activeSession, title: 'Meaningful title' },
+    ])
+  })
+
   it('exposes native compaction as pending until its boundary arrives', async () => {
     const runtime = new FakeCliRuntime()
     const compactGate = deferred<undefined>()

--- a/src/core/cli-runtime/conversation-controller.ts
+++ b/src/core/cli-runtime/conversation-controller.ts
@@ -17,6 +17,7 @@ import type {
   CliRuntimeModel,
   CliRuntimeRunState,
   CliRuntimeSkill,
+  CliSessionTitleInput,
   CliSessionHydration,
   CliSessionOverlay,
   CliSessionRef,
@@ -401,6 +402,22 @@ export class CliConversationController {
       })
     this.readyTail = task.catch(() => undefined)
     return task
+  }
+
+  async setNativeSessionTitle(
+    input: CliSessionTitleInput,
+  ): Promise<boolean> {
+    this.assertActive()
+    const operation = this.captureOperation()
+    if (
+      this.snapshot.sessionRef?.runtimeId !== input.sessionRef.runtimeId ||
+      this.snapshot.sessionRef?.nativeSessionId !== input.sessionRef.nativeSessionId
+    ) {
+      return false
+    }
+    if (!operation.runtime.setSessionTitle) return false
+    await operation.runtime.setSessionTitle(input)
+    return this.isCurrent(operation)
   }
 
   async sendTurn({

--- a/src/core/cli-runtime/types.ts
+++ b/src/core/cli-runtime/types.ts
@@ -210,6 +210,11 @@ export type CliQuestionResponse = {
   answer: unknown
 }
 
+export type CliSessionTitleInput = {
+  sessionRef: CliSessionRef
+  title: string
+}
+
 export type CliRuntimeEventListener = (event: CliRuntimeEvent) => void
 
 export type CliRuntime = {
@@ -239,6 +244,8 @@ export type CliRuntime = {
    * start/resume).
    */
   updatePermissionProfile?(update: CliPermissionProfileUpdate): Promise<void>
+  /** Update the provider-native session title when the runtime supports it. */
+  setSessionTitle?(input: CliSessionTitleInput): Promise<void>
   sendTurn(input: CliTurnInput): Promise<void>
   rewriteTurn(input: CliRewriteTurnInput): Promise<void>
   cancel(): Promise<void>

--- a/src/hooks/useChatHistory.ts
+++ b/src/hooks/useChatHistory.ts
@@ -26,6 +26,7 @@ import { Mentionable } from '../types/mentionable'
 import { ToolCallResponseStatus } from '../types/tool-call.types'
 import {
   getConversationDisplayTitle,
+  getGeneratedTitleToApply,
   isUntitledConversationTitle,
 } from '../utils/chat/conversationTitle'
 import {
@@ -589,21 +590,25 @@ export function useChatHistory(): UseChatHistory {
 
         // 再次检查标题是否仍为默认标题，避免竞态条件
         const currentConversation = await chatManager.findById(id)
-        if (
-          currentConversation &&
-          (force || isUntitledConversationTitle(currentConversation.title))
-        ) {
-          await chatManager.updateChat(
-            id,
-            { title: result.title },
-            {
-              touchUpdatedAt: false,
-            },
-          )
-          emitChatHistoryUpdated()
-          await fetchChatList()
-        }
-        return result.title
+        const titleToApply = currentConversation
+          ? getGeneratedTitleToApply({
+              currentTitle: currentConversation.title,
+              generatedTitle: result.title,
+              force,
+            })
+          : null
+        if (!titleToApply) return null
+
+        await chatManager.updateChat(
+          id,
+          { title: titleToApply },
+          {
+            touchUpdatedAt: false,
+          },
+        )
+        emitChatHistoryUpdated()
+        await fetchChatList()
+        return titleToApply
       } finally {
         titleGenerationInFlightRef.current.delete(id)
       }

--- a/src/hooks/useChatHistory.ts
+++ b/src/hooks/useChatHistory.ts
@@ -96,7 +96,7 @@ type UseChatHistory = {
     options?: {
       force?: boolean
     },
-  ) => Promise<void>
+  ) => Promise<string | null>
   chatList: ChatConversationMetadata[]
 }
 
@@ -490,7 +490,7 @@ export function useChatHistory(): UseChatHistory {
       options?: {
         force?: boolean
       },
-    ): Promise<void> => {
+    ): Promise<string | null> => {
       const force = options?.force === true
       const logTitleEvent = (
         reason:
@@ -511,12 +511,12 @@ export function useChatHistory(): UseChatHistory {
       const cooldownUntil = titleGenerationCooldownUntilRef.current.get(id) ?? 0
       if (!force && cooldownUntil > Date.now()) {
         logTitleEvent('cooldown_active')
-        return
+        return null
       }
 
       if (titleGenerationInFlightRef.current.has(id)) {
         logTitleEvent('in_flight')
-        return
+        return null
       }
       titleGenerationInFlightRef.current.add(id)
 
@@ -534,13 +534,13 @@ export function useChatHistory(): UseChatHistory {
 
         if (!conversation) {
           logTitleEvent('conversation_missing')
-          return
+          return null
         }
 
         // 如果标题已经命名过了，不需要再次命名
         if (!force && !isUntitledConversationTitle(conversation.title)) {
           logTitleEvent('already_titled')
-          return
+          return null
         }
 
         const firstUserMessage = messages.find(
@@ -548,7 +548,7 @@ export function useChatHistory(): UseChatHistory {
         )
         if (!firstUserMessage) {
           logTitleEvent('no_user_signal')
-          return
+          return null
         }
 
         const result = await generateConversationTitleText({
@@ -583,7 +583,7 @@ export function useChatHistory(): UseChatHistory {
               Date.now() + AUTO_TITLE_FAILURE_COOLDOWN_MS,
             )
           }
-          return
+          return null
         }
         titleGenerationCooldownUntilRef.current.delete(id)
 
@@ -603,6 +603,7 @@ export function useChatHistory(): UseChatHistory {
           emitChatHistoryUpdated()
           await fetchChatList()
         }
+        return result.title
       } finally {
         titleGenerationInFlightRef.current.delete(id)
       }

--- a/src/utils/chat/conversationTitle.test.ts
+++ b/src/utils/chat/conversationTitle.test.ts
@@ -1,5 +1,6 @@
 import {
   getConversationDisplayTitle,
+  getGeneratedTitleToApply,
   isUntitledConversationTitle,
 } from './conversationTitle'
 
@@ -9,5 +10,21 @@ describe('conversationTitle helpers', () => {
     expect(isUntitledConversationTitle('新对话')).toBe(true)
     expect(isUntitledConversationTitle('Named')).toBe(false)
     expect(getConversationDisplayTitle('', 'Fallback')).toBe('Fallback')
+  })
+
+  it('does not apply an automatic title over a title edited during generation', () => {
+    expect(
+      getGeneratedTitleToApply({
+        currentTitle: '用户手动命名',
+        generatedTitle: '模型生成的标题',
+      }),
+    ).toBeNull()
+    expect(
+      getGeneratedTitleToApply({
+        currentTitle: '用户手动命名',
+        generatedTitle: '模型生成的标题',
+        force: true,
+      }),
+    ).toBe('模型生成的标题')
   })
 })

--- a/src/utils/chat/conversationTitle.ts
+++ b/src/utils/chat/conversationTitle.ts
@@ -15,3 +15,19 @@ export const getConversationDisplayTitle = (
   title: string | null | undefined,
   fallback: string,
 ): string => (isUntitledConversationTitle(title) ? fallback : title!.trim())
+
+/**
+ * Return a generated title only when it is still allowed to replace the
+ * current local title. A manual title always wins unless generation was
+ * explicitly retried by the user.
+ */
+export const getGeneratedTitleToApply = ({
+  currentTitle,
+  generatedTitle,
+  force = false,
+}: {
+  currentTitle: string | null | undefined
+  generatedTitle: string
+  force?: boolean
+}): string | null =>
+  force || isUntitledConversationTitle(currentTitle) ? generatedTitle : null


### PR DESCRIPTION
由私有 Agent Workbench 实现，并由仓库所有者在 Linear 明确批准合并。

Linear: https://linear.app/lapis0x0/issue/AWB-7/cli-对话在-yolo-中自动命名成功但是在-cli-gui-中却失败