### PR TITLE
refactor(chat): 统一 Agent 与 CLI 的对话呈现层

### DIFF
--- a/src/components/chat-view/AssistantMessageReasoning.tsx
+++ b/src/components/chat-view/AssistantMessageReasoning.tsx
@@ -185,10 +185,9 @@ const AssistantMessageReasoning = memo(function AssistantMessageReasoning({
       previewHeightRef.current = 0
       previewWidthRef.current = 0
       previewHoldOffsetRef.current = 0
-      track.style.setProperty(
-        '--yolo-assistant-metadata-preview-hold-offset',
-        '0px',
-      )
+      track.setCssProps({
+        '--yolo-assistant-metadata-preview-hold-offset': '0px',
+      })
       return
     }
 

--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -1,6 +1,5 @@
 import { EditorView } from '@codemirror/view'
 import { useMutation } from '@tanstack/react-query'
-import cx from 'clsx'
 import { Download, History, Pencil, Plus, Trash2 } from 'lucide-react'
 import {
   MarkdownView,
@@ -85,7 +84,10 @@ import type {
   ChatUserMessage,
 } from '../../types/chat'
 import { getLatestChatConversationCompaction } from '../../types/chat'
-import type { ChatTimelineItem } from '../../types/chat-timeline'
+import type {
+  ChatTimelineAssistantGroupItem,
+  ChatTimelineItem,
+} from '../../types/chat-timeline'
 import type { ConversationOverrideSettings } from '../../types/conversation-settings.types'
 import type {
   Mentionable,
@@ -137,13 +139,11 @@ import { formatTokenCount } from '../../utils/llm/formatTokenCount'
 import { resolveEffectiveMaxContextTokens } from '../../utils/llm/model-capability-registry'
 import { readTFileContent } from '../../utils/obsidian'
 import { stampUserMessageTimeContext } from '../../utils/prompt/timeContext'
-import DotLoader from '../common/DotLoader'
 import { AcknowledgementModal } from '../modals/AcknowledgementModal'
 
 // removed Prompt Templates feature
 
 import { AssistantSelector } from './AssistantSelector'
-import AssistantToolMessageGroupItem from './AssistantToolMessageGroupItem'
 import { ChatInputDraftHolder } from './chat-input/chatInputDraft'
 import {
   CHAT_MODES,
@@ -165,7 +165,10 @@ import MentionableBadge from './chat-input/MentionableBadge'
 import { editorStateToPlainText } from './chat-input/utils/editor-state-to-plain-text'
 import { ChatRuntimeActionsProvider } from './chat-runtime-actions-context'
 import { getChatSurfacePreset } from './chat-surface-presets'
-import { ChatConversationPane } from './ChatConversationPane'
+import type {
+  ConversationAssistantGroupProps,
+  ConversationTimelineRendererContract,
+} from './conversation-surface-contract'
 import { ChatListDropdown } from './ChatListDropdown'
 import {
   buildAssistantErrorContinuation,
@@ -218,6 +221,7 @@ import {
   useStableChatTimelineItems,
 } from './useChatTimelineReadModel'
 import { useHistoricalUserMessageDismiss } from './useHistoricalUserMessageDismiss'
+import { YoloChatSurface } from './YoloChatSurface'
 import UserMessageItem from './UserMessageItem'
 import ViewToggle from './ViewToggle'
 
@@ -7651,524 +7655,428 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
     [groupedChatMessages],
   )
 
-  const renderChatTimelineItem = useCallback(
-    (timelineItem: ChatTimelineItem) => {
-      if (timelineItem.kind === 'compaction-pending') {
-        return (
-          <div
-            className="yolo-chat-compaction-pending"
-            data-anchor-message-id={timelineItem.anchorMessageId}
-          >
-            <div className="yolo-chat-compaction-pending__loader">
-              <DotLoader text={compactionPendingTitle} />
-            </div>
-            <div className="yolo-chat-compaction-pending__description">
-              {compactionPendingDescription}
-            </div>
-          </div>
+  const buildYoloAssistantGroupProps = useCallback(
+    (
+      messageOrGroup: AssistantToolMessageGroup,
+      timelineItem: ChatTimelineAssistantGroupItem,
+    ): ConversationAssistantGroupProps => {
+      const sourceUserMessageId = getSourceUserMessageIdForGroup(messageOrGroup)
+      const foregroundAgentFooter = getForegroundAgentFooterForGroup(
+        foregroundAgentVisualTurnPlan,
+        messageOrGroup,
+      )
+      const containsCompactionAnchor =
+        compactionDividerAnchorMessageId !== null &&
+        messageOrGroup.some(
+          (message) => message.id === compactionDividerAnchorMessageId,
         )
+      const shouldSuppressCompactionAnchorFooter =
+        containsCompactionAnchor &&
+        Boolean(latestCompactionState?.triggerToolCallId)
+
+      return {
+        conversationId: currentConversationId,
+        conversationRunSummary:
+          timelineItem.groupId === runSummaryAssistantGroupId
+            ? currentConversationRunSummary
+            : undefined,
+        activeBranchKey: activeBranchByUserMessageId.get(
+          sourceUserMessageId ?? '',
+        ),
+        sourceUserMessageId,
+        continuableErrorMessageIds,
+        suppressFooter:
+          shouldSuppressCompactionAnchorFooter ||
+          foregroundAgentFooter?.suppress === true,
+        inlineInfoMessages:
+          foregroundAgentFooter?.inlineInfoMessages ?? messageOrGroup,
+        isApplying: applyMutation.isPending,
+        activeApplyRequestKey,
+        onApply: (...args) => timelineHandlersRef.current.handleApply(...args),
+        onToolMessageUpdate: (...args) =>
+          timelineHandlersRef.current.handleToolMessageUpdate(...args),
+        onToolCallResponseUpdate: (...args) =>
+          timelineHandlersRef.current.handleToolCallResponseUpdate(...args),
+        terminalCommandResultsByToolCallId,
+        subagentResultsByToolCallId,
+        onRecoverToolCall: (...args) =>
+          timelineHandlersRef.current.handleRecoverPendingToolCall(...args),
+        onRecoverAnswerUserQuestion: (...args) =>
+          timelineHandlersRef.current.handleRecoverAnswerUserQuestion(...args),
+        editingAssistantMessageId,
+        onEditStart: (...args) =>
+          timelineHandlersRef.current.handleAssistantGroupEditStart(...args),
+        onEditCancel: (...args) =>
+          timelineHandlersRef.current.handleAssistantMessageEditCancel(...args),
+        onEditSave: (...args) =>
+          timelineHandlersRef.current.handleAssistantMessageEditSave(...args),
+        onDeleteGroup: (...args) =>
+          timelineHandlersRef.current.handleAssistantMessageGroupDelete(
+            ...args,
+          ),
+        onRetryGroup: (...args) =>
+          timelineHandlersRef.current.handleAssistantMessageGroupRetry(...args),
+        onContinueError: (...args) =>
+          timelineHandlersRef.current.handleAssistantErrorContinue(...args),
+        onBranchGroup: (...args) =>
+          timelineHandlersRef.current.handleAssistantMessageGroupBranch(
+            ...args,
+          ),
+        onActiveBranchChange: (...args) =>
+          timelineHandlersRef.current.handleAssistantGroupActiveBranchChange(
+            ...args,
+          ),
+        onQuoteAssistantSelection: (...args) =>
+          timelineHandlersRef.current.handleQuoteAssistantSelection(...args),
+        assistantQuotes: activeAssistantQuotes,
+        onDeleteAssistantQuote: (...args) =>
+          timelineHandlersRef.current.handleDeleteAssistantQuote(...args),
+        onOpenEditSummaryFile: (...args) =>
+          timelineHandlersRef.current.handleOpenEditSummaryFile(...args),
+        onUndoEditSummary: (...args) =>
+          timelineHandlersRef.current.handleUndoEditSummary(...args),
+        undoingEditSummaryTarget,
+        pendingCompactionAnchorMessageId,
+        hidePendingAssistantPlaceholders:
+          shouldHidePendingAssistantPlaceholders,
       }
-
-      if (timelineItem.kind === 'compaction-divider') {
-        return (
-          <div
-            className={cx(
-              'yolo-chat-compaction-divider',
-              timelineItem.renderKey ===
-                `${enteringCompactionDividerAnchorMessageId}-compact-divider` &&
-                'is-entering',
-            )}
-          >
-            <div className="yolo-chat-compaction-divider__title">
-              {compactionDividerTitle}
-            </div>
-            <div className="yolo-chat-compaction-divider__line" />
-            <div className="yolo-chat-compaction-divider__content">
-              <div className="yolo-chat-compaction-divider__description">
-                {compactionDividerDescription}
-              </div>
-            </div>
-          </div>
-        )
-      }
-
-      if (timelineItem.kind === 'assistant-group') {
-        const messageOrGroup = timelineItem.messageIds
-          .map((messageId) => chatTimelineReadModel.messagesById.get(messageId))
-          .filter(
-            (message): message is AssistantToolMessageGroup[number] =>
-              message !== undefined && message.role !== 'user',
-          )
-        if (messageOrGroup.length === 0) {
-          return null
-        }
-        const sourceUserMessageId =
-          getSourceUserMessageIdForGroup(messageOrGroup)
-        const foregroundAgentFooter = getForegroundAgentFooterForGroup(
-          foregroundAgentVisualTurnPlan,
-          messageOrGroup,
-        )
-        const containsCompactionAnchor =
-          compactionDividerAnchorMessageId !== null &&
-          messageOrGroup.some(
-            (message) => message.id === compactionDividerAnchorMessageId,
-          )
-        const shouldSuppressCompactionAnchorFooter =
-          containsCompactionAnchor &&
-          Boolean(latestCompactionState?.triggerToolCallId)
-
-        return (
-          <AssistantToolMessageGroupItem
-            messages={messageOrGroup}
-            conversationId={currentConversationId}
-            conversationRunSummary={
-              timelineItem.groupId === runSummaryAssistantGroupId
-                ? currentConversationRunSummary
-                : undefined
-            }
-            activeBranchKey={activeBranchByUserMessageId.get(
-              sourceUserMessageId ?? '',
-            )}
-            sourceUserMessageId={sourceUserMessageId}
-            continuableErrorMessageIds={continuableErrorMessageIds}
-            suppressFooter={
-              shouldSuppressCompactionAnchorFooter ||
-              foregroundAgentFooter?.suppress === true
-            }
-            inlineInfoMessages={
-              foregroundAgentFooter?.inlineInfoMessages ?? messageOrGroup
-            }
-            showInlineInfo={chatSurfacePreset.assistantActions.showInlineInfo}
-            showRetryAction={chatSurfacePreset.assistantActions.showRetryAction}
-            showInsertAction={
-              chatSurfacePreset.assistantActions.showInsertAction
-            }
-            showCopyAction={chatSurfacePreset.assistantActions.showCopyAction}
-            showBranchAction={
-              chatSurfacePreset.assistantActions.showBranchAction
-            }
-            showEditAction={chatSurfacePreset.assistantActions.showEditAction}
-            showDeleteAction={
-              chatSurfacePreset.assistantActions.showDeleteAction
-            }
-            isApplying={applyMutation.isPending}
-            activeApplyRequestKey={activeApplyRequestKey}
-            onApply={(...args) =>
-              timelineHandlersRef.current.handleApply(...args)
-            }
-            onToolMessageUpdate={(...args) =>
-              timelineHandlersRef.current.handleToolMessageUpdate(...args)
-            }
-            onToolCallResponseUpdate={(...args) =>
-              timelineHandlersRef.current.handleToolCallResponseUpdate(...args)
-            }
-            terminalCommandResultsByToolCallId={
-              terminalCommandResultsByToolCallId
-            }
-            subagentResultsByToolCallId={subagentResultsByToolCallId}
-            onRecoverToolCall={(...args) =>
-              timelineHandlersRef.current.handleRecoverPendingToolCall(...args)
-            }
-            onRecoverAnswerUserQuestion={(...args) =>
-              timelineHandlersRef.current.handleRecoverAnswerUserQuestion(
-                ...args,
-              )
-            }
-            editingAssistantMessageId={editingAssistantMessageId}
-            onEditStart={(...args) =>
-              timelineHandlersRef.current.handleAssistantGroupEditStart(...args)
-            }
-            onEditCancel={(...args) =>
-              timelineHandlersRef.current.handleAssistantMessageEditCancel(
-                ...args,
-              )
-            }
-            onEditSave={(...args) =>
-              timelineHandlersRef.current.handleAssistantMessageEditSave(
-                ...args,
-              )
-            }
-            onDeleteGroup={(...args) =>
-              timelineHandlersRef.current.handleAssistantMessageGroupDelete(
-                ...args,
-              )
-            }
-            onRetryGroup={(...args) =>
-              timelineHandlersRef.current.handleAssistantMessageGroupRetry(
-                ...args,
-              )
-            }
-            onContinueError={(...args) =>
-              timelineHandlersRef.current.handleAssistantErrorContinue(...args)
-            }
-            onBranchGroup={(...args) =>
-              timelineHandlersRef.current.handleAssistantMessageGroupBranch(
-                ...args,
-              )
-            }
-            onActiveBranchChange={(...args) =>
-              timelineHandlersRef.current.handleAssistantGroupActiveBranchChange(
-                ...args,
-              )
-            }
-            onQuoteAssistantSelection={(...args) =>
-              timelineHandlersRef.current.handleQuoteAssistantSelection(...args)
-            }
-            assistantQuotes={activeAssistantQuotes}
-            onDeleteAssistantQuote={(...args) =>
-              timelineHandlersRef.current.handleDeleteAssistantQuote(...args)
-            }
-            onOpenEditSummaryFile={(...args) =>
-              timelineHandlersRef.current.handleOpenEditSummaryFile(...args)
-            }
-            onUndoEditSummary={(...args) =>
-              timelineHandlersRef.current.handleUndoEditSummary(...args)
-            }
-            undoingEditSummaryTarget={undoingEditSummaryTarget}
-            pendingCompactionAnchorMessageId={pendingCompactionAnchorMessageId}
-            hidePendingAssistantPlaceholders={
-              shouldHidePendingAssistantPlaceholders
-            }
-            showQuoteAction={chatSurfacePreset.assistantActions.showQuoteAction}
-          />
-        )
-      }
-
-      if (timelineItem.kind === 'user-message') {
-        const messageOrGroup = chatTimelineReadModel.messagesById.get(
-          timelineItem.messageId,
-        )
-        if (!messageOrGroup || messageOrGroup.role !== 'user') {
-          return null
-        }
-        const messageReasoningLevel =
-          messageReasoningMap.get(messageOrGroup.id) ??
-          normalizeReasoningLevel(messageOrGroup.reasoningLevel) ??
-          reasoningLevel
-
-        return (
-          <UserMessageItem
-            message={messageOrGroup}
-            isFocused={focusedMessageId === messageOrGroup.id}
-            isActionDisabled={isCurrentConversationRunActive}
-            onDelete={() => {
-              timelineHandlersRef.current.handleHistoricalUserMessageDelete(
-                messageOrGroup.id,
-              )
-            }}
-            displayMentionables={messageOrGroup.mentionables}
-            chatUserInputRef={(ref) =>
-              registerChatUserInputRef(messageOrGroup.id, ref)
-            }
-            onControlPopoverOpenChange={(isOpen) => {
-              onHistoricalUserMessageControlPopoverOpenChange(isOpen)
-            }}
-            onInputChange={(content) => {
-              timelineHandlersRef.current.updateHistoricalUserMessage(
-                messageOrGroup.id,
-                (message) => ({
-                  ...message,
-                  content,
-                  promptContent: null,
-                }),
-              )
-            }}
-            onSubmit={(content) => {
-              if (
-                editorStateToPlainText(content).trim() === '' &&
-                messageOrGroup.mentionables.length === 0 &&
-                (messageOrGroup.selectedSkills?.length ?? 0) === 0
-              ) {
-                timelineHandlersRef.current.finalizeHistoricalUserMessageEdit(
-                  messageOrGroup.id,
-                )
-                chatUserInputRefs.current.get(inputMessage.id)?.focus()
-                return
-              }
-              const latestGroupedChatMessages = groupedChatMessagesRef.current
-              const latestGroupedMessageIndex =
-                latestGroupedChatMessages.findIndex(
-                  (candidate) =>
-                    !Array.isArray(candidate) &&
-                    candidate.id === messageOrGroup.id,
-                )
-              if (latestGroupedMessageIndex < 0) {
-                return
-              }
-              const currentConversationModelId =
-                conversationModelIdValueRef.current
-              const modelForThisMessage =
-                messageModelMapRef.current.get(messageOrGroup.id) ??
-                currentConversationModelId
-              const reasoningForThisMessage =
-                messageReasoningMapRef.current.get(messageOrGroup.id) ??
-                messageReasoningLevel
-              const nextMessageModelMap = new Map(messageModelMapRef.current)
-              nextMessageModelMap.set(messageOrGroup.id, modelForThisMessage)
-              // 历史编辑后重新提交是一个新的用户回合 → 打上新的当前时间。
-              const editedUserMessage: ChatUserMessage =
-                stampUserMessageTimeContext(
-                  {
-                    role: 'user',
-                    content,
-                    promptContent: null,
-                    id: messageOrGroup.id,
-                    reasoningLevel: reasoningForThisMessage,
-                    mentionables: messageOrGroup.mentionables,
-                    selectedSkills: messageOrGroup.selectedSkills ?? [],
-                    selectedModelIds: extractSelectedModelIds(
-                      messageOrGroup.mentionables,
-                    ),
-                  },
-                  selectedAssistantTimeContextEnabled,
-                )
-              const inputChatMessages = [
-                ...latestGroupedChatMessages
-                  .slice(0, latestGroupedMessageIndex)
-                  .flatMap((candidate): ChatMessage[] =>
-                    !Array.isArray(candidate) ? [candidate] : candidate,
-                  ),
-                editedUserMessage,
-              ]
-              const requestChatMessages = [
-                ...latestGroupedChatMessages
-                  .slice(0, latestGroupedMessageIndex)
-                  .flatMap((candidate): ChatMessage[] =>
-                    !Array.isArray(candidate)
-                      ? [candidate]
-                      : getDisplayedAssistantToolMessages(
-                          candidate,
-                          activeBranchByUserMessageIdRef.current.get(
-                            getSourceUserMessageIdForGroup(candidate) ?? '',
-                          ),
-                        ),
-                  ),
-                editedUserMessage,
-              ]
-              void timelineHandlersRef.current.handleUserMessageSubmit({
-                inputChatMessages,
-                requestChatMessages,
-                persistedMessageModelMap: nextMessageModelMap,
-              })
-              chatUserInputRefs.current.get(inputMessage.id)?.focus()
-              setMessageModelMap(nextMessageModelMap)
-              setMessageReasoningMap((prev) => {
-                const next = new Map(prev)
-                next.set(messageOrGroup.id, reasoningForThisMessage)
-                return next
-              })
-            }}
-            onFocus={() => {
-              setFocusedMessageId(messageOrGroup.id)
-            }}
-            onMentionablesChange={(mentionables) => {
-              const currentMessage = chatMessagesStateRef.current.find(
-                (message): message is ChatUserMessage =>
-                  message.role === 'user' && message.id === messageOrGroup.id,
-              )
-              if (currentMessage) {
-                releaseHighlightIds(
-                  collectRemovedSelectionHighlightIds(
-                    currentMessage.mentionables,
-                    mentionables,
-                  ),
-                )
-              }
-              timelineHandlersRef.current.updateHistoricalUserMessage(
-                messageOrGroup.id,
-                (message) => {
-                  const prevKeys = message.mentionables.map((m) =>
-                    getMentionableKey(serializeMentionable(m)),
-                  )
-                  const nextKeys = mentionables.map((m) =>
-                    getMentionableKey(serializeMentionable(m)),
-                  )
-                  const nextKeySet = new Set(nextKeys)
-                  const isSameMentionables =
-                    prevKeys.length === nextKeys.length &&
-                    prevKeys.every((key) => nextKeySet.has(key))
-
-                  return {
-                    ...message,
-                    mentionables,
-                    promptContent: isSameMentionables
-                      ? message.promptContent
-                      : null,
-                  }
-                },
-              )
-            }}
-            onSelectedSkillsChange={(selectedSkills) => {
-              timelineHandlersRef.current.updateHistoricalUserMessage(
-                messageOrGroup.id,
-                (message) => ({
-                  ...message,
-                  selectedSkills,
-                  promptContent: null,
-                  snapshotRef: undefined,
-                }),
-              )
-            }}
-            modelId={
-              messageModelMap.get(messageOrGroup.id) ?? conversationModelId
-            }
-            onModelChange={(id) => {
-              setMessageModelMap((prev) => {
-                const next = new Map(prev)
-                next.set(messageOrGroup.id, id)
-                return next
-              })
-              setConversationModelId(id)
-              conversationModelIdRef.current.set(currentConversationId, id)
-              const nextReasoningLevel = getReasoningLevelForModelId(id)
-              setReasoningLevel(nextReasoningLevel)
-              conversationReasoningLevelRef.current.set(
-                currentConversationId,
-                nextReasoningLevel,
-              )
-              setInputMessage((prev) => ({
-                ...prev,
-                reasoningLevel: nextReasoningLevel,
-              }))
-            }}
-            reasoningLevel={messageReasoningLevel}
-            onReasoningChange={(level) => {
-              setMessageReasoningMap((prev) => {
-                const next = new Map(prev)
-                next.set(messageOrGroup.id, level)
-                return next
-              })
-              setChatMessages((prevChatHistory) =>
-                prevChatHistory.map((msg) =>
-                  msg.role === 'user' && msg.id === messageOrGroup.id
-                    ? {
-                        ...msg,
-                        reasoningLevel: level,
-                      }
-                    : msg,
-                ),
-              )
-              setReasoningLevel(level)
-              conversationReasoningLevelRef.current.set(
-                currentConversationId,
-                level,
-              )
-              void persistReasoningLevelForModel(
-                conversationModelIdValueRef.current,
-                level,
-              )
-            }}
-            currentAssistantId={conversationAssistantId}
-            currentChatMode={chatMode}
-            onSelectChatModeForConversation={(...args) =>
-              timelineHandlersRef.current.handleChatModeChange(...args)
-            }
-            showReasoningSelect={
-              chatSurfacePreset.userMessage.showReasoningSelect
-            }
-            allowAgentModeOption={
-              chatSurfacePreset.userMessage.allowAgentModeOption
-            }
-          />
-        )
-      }
-
-      if (timelineItem.kind === 'query-progress') {
-        return <QueryProgress state={queryProgress} />
-      }
-
-      if (timelineItem.kind === 'continue-response') {
-        return (
-          <div className="yolo-continue-response-button-container">
-            <button
-              type="button"
-              className="yolo-continue-response-button"
-              onClick={handleContinueResponse}
-            >
-              <div>Continue response</div>
-            </button>
-          </div>
-        )
-      }
-
-      return <div className="yolo-chat-bottom-anchor" aria-hidden="true" />
     },
     [
-      activeAssistantQuotes,
       activeApplyRequestKey,
+      activeAssistantQuotes,
       activeBranchByUserMessageId,
       applyMutation.isPending,
-      chatTimelineReadModel.messagesById,
-      chatSurfacePreset,
-      chatMode,
       compactionDividerAnchorMessageId,
-      compactionDividerDescription,
-      compactionPendingDescription,
-      compactionPendingTitle,
-      compactionDividerTitle,
-      conversationAssistantId,
-      conversationModelId,
       continuableErrorMessageIds,
       currentConversationId,
+      currentConversationRunSummary,
       editingAssistantMessageId,
-      enteringCompactionDividerAnchorMessageId,
-      firstUserMessageId,
-      focusedMessageId,
-      groupedChatMessages,
-      handleApply,
-      handleAssistantGroupActiveBranchChange,
-      handleAssistantGroupEditStart,
-      handleAssistantMessageGroupBranch,
-      handleAssistantMessageGroupDelete,
-      handleAssistantMessageGroupRetry,
-      handleAssistantMessageEditCancel,
-      handleAssistantMessageEditSave,
-      handleHistoricalUserMessageDelete,
-      handleChatModeChange,
-      handleContinueResponse,
-      handleOpenEditSummaryFile,
-      handleQuoteAssistantSelection,
-      handleRecoverAnswerUserQuestion,
-      handleRecoverPendingToolCall,
-      handleToolCallResponseUpdate,
-      handleToolMessageUpdate,
-      handleUndoEditSummary,
-      handleUserMessageSubmit,
-      inputMessage.id,
-      isCurrentConversationRunActive,
-      runSummaryAssistantGroupId,
-      latestCompactionState?.triggerToolCallId,
-      messageModelMap,
-      messageReasoningMap,
-      pendingCompactionAnchorMessageId,
-      queryProgress,
-      reasoningLevel,
-      selectedAssistantTimeContextEnabled,
       foregroundAgentVisualTurnPlan,
+      latestCompactionState?.triggerToolCallId,
+      pendingCompactionAnchorMessageId,
+      runSummaryAssistantGroupId,
       shouldHidePendingAssistantPlaceholders,
+      subagentResultsByToolCallId,
+      terminalCommandResultsByToolCallId,
       undoingEditSummaryTarget,
-      updateHistoricalUserMessage,
-      finalizeHistoricalUserMessageEdit,
     ],
   )
 
-  const renderRuntimeAwareChatTimelineItem = useCallback(
-    (timelineItem: ChatTimelineItem) => (
-      <ChatRuntimeActionsProvider
-        actions={runtimeActions}
-        conversation={currentConversationRef}
-        resolveConversationScope={resolveRuntimeActionConversation}
-      >
-        {renderChatTimelineItem(timelineItem)}
-      </ChatRuntimeActionsProvider>
-    ),
+  const renderYoloUserMessage = useCallback(
+    (message: ChatUserMessage) => {
+      const messageReasoningLevel =
+        messageReasoningMap.get(message.id) ??
+        normalizeReasoningLevel(message.reasoningLevel) ??
+        reasoningLevel
+
+      return (
+        <UserMessageItem
+          message={message}
+          isFocused={focusedMessageId === message.id}
+          isActionDisabled={isCurrentConversationRunActive}
+          onDelete={() => {
+            timelineHandlersRef.current.handleHistoricalUserMessageDelete(
+              message.id,
+            )
+          }}
+          displayMentionables={message.mentionables}
+          chatUserInputRef={(ref) => registerChatUserInputRef(message.id, ref)}
+          onControlPopoverOpenChange={(isOpen) => {
+            onHistoricalUserMessageControlPopoverOpenChange(isOpen)
+          }}
+          onInputChange={(content) => {
+            timelineHandlersRef.current.updateHistoricalUserMessage(
+              message.id,
+              (message) => ({
+                ...message,
+                content,
+                promptContent: null,
+              }),
+            )
+          }}
+          onSubmit={(content) => {
+            if (
+              editorStateToPlainText(content).trim() === '' &&
+              message.mentionables.length === 0 &&
+              (message.selectedSkills?.length ?? 0) === 0
+            ) {
+              timelineHandlersRef.current.finalizeHistoricalUserMessageEdit(
+                message.id,
+              )
+              chatUserInputRefs.current.get(inputMessage.id)?.focus()
+              return
+            }
+            const latestGroupedChatMessages = groupedChatMessagesRef.current
+            const latestGroupedMessageIndex =
+              latestGroupedChatMessages.findIndex(
+                (candidate) =>
+                  !Array.isArray(candidate) && candidate.id === message.id,
+              )
+            if (latestGroupedMessageIndex < 0) {
+              return
+            }
+            const currentConversationModelId =
+              conversationModelIdValueRef.current
+            const modelForThisMessage =
+              messageModelMapRef.current.get(message.id) ??
+              currentConversationModelId
+            const reasoningForThisMessage =
+              messageReasoningMapRef.current.get(message.id) ??
+              messageReasoningLevel
+            const nextMessageModelMap = new Map(messageModelMapRef.current)
+            nextMessageModelMap.set(message.id, modelForThisMessage)
+            // 历史编辑后重新提交是一个新的用户回合 → 打上新的当前时间。
+            const editedUserMessage: ChatUserMessage =
+              stampUserMessageTimeContext(
+                {
+                  role: 'user',
+                  content,
+                  promptContent: null,
+                  id: message.id,
+                  reasoningLevel: reasoningForThisMessage,
+                  mentionables: message.mentionables,
+                  selectedSkills: message.selectedSkills ?? [],
+                  selectedModelIds: extractSelectedModelIds(
+                    message.mentionables,
+                  ),
+                },
+                selectedAssistantTimeContextEnabled,
+              )
+            const inputChatMessages = [
+              ...latestGroupedChatMessages
+                .slice(0, latestGroupedMessageIndex)
+                .flatMap((candidate): ChatMessage[] =>
+                  !Array.isArray(candidate) ? [candidate] : candidate,
+                ),
+              editedUserMessage,
+            ]
+            const requestChatMessages = [
+              ...latestGroupedChatMessages
+                .slice(0, latestGroupedMessageIndex)
+                .flatMap((candidate): ChatMessage[] =>
+                  !Array.isArray(candidate)
+                    ? [candidate]
+                    : getDisplayedAssistantToolMessages(
+                        candidate,
+                        activeBranchByUserMessageIdRef.current.get(
+                          getSourceUserMessageIdForGroup(candidate) ?? '',
+                        ),
+                      ),
+                ),
+              editedUserMessage,
+            ]
+            void timelineHandlersRef.current.handleUserMessageSubmit({
+              inputChatMessages,
+              requestChatMessages,
+              persistedMessageModelMap: nextMessageModelMap,
+            })
+            chatUserInputRefs.current.get(inputMessage.id)?.focus()
+            setMessageModelMap(nextMessageModelMap)
+            setMessageReasoningMap((prev) => {
+              const next = new Map(prev)
+              next.set(message.id, reasoningForThisMessage)
+              return next
+            })
+          }}
+          onFocus={() => {
+            setFocusedMessageId(message.id)
+          }}
+          onMentionablesChange={(mentionables) => {
+            const currentMessage = chatMessagesStateRef.current.find(
+              (candidate): candidate is ChatUserMessage =>
+                candidate.role === 'user' && candidate.id === message.id,
+            )
+            if (currentMessage) {
+              releaseHighlightIds(
+                collectRemovedSelectionHighlightIds(
+                  currentMessage.mentionables,
+                  mentionables,
+                ),
+              )
+            }
+            timelineHandlersRef.current.updateHistoricalUserMessage(
+              message.id,
+              (message) => {
+                const prevKeys = message.mentionables.map((m) =>
+                  getMentionableKey(serializeMentionable(m)),
+                )
+                const nextKeys = mentionables.map((m) =>
+                  getMentionableKey(serializeMentionable(m)),
+                )
+                const nextKeySet = new Set(nextKeys)
+                const isSameMentionables =
+                  prevKeys.length === nextKeys.length &&
+                  prevKeys.every((key) => nextKeySet.has(key))
+
+                return {
+                  ...message,
+                  mentionables,
+                  promptContent: isSameMentionables
+                    ? message.promptContent
+                    : null,
+                }
+              },
+            )
+          }}
+          onSelectedSkillsChange={(selectedSkills) => {
+            timelineHandlersRef.current.updateHistoricalUserMessage(
+              message.id,
+              (message) => ({
+                ...message,
+                selectedSkills,
+                promptContent: null,
+                snapshotRef: undefined,
+              }),
+            )
+          }}
+          modelId={messageModelMap.get(message.id) ?? conversationModelId}
+          onModelChange={(id) => {
+            setMessageModelMap((prev) => {
+              const next = new Map(prev)
+              next.set(message.id, id)
+              return next
+            })
+            setConversationModelId(id)
+            conversationModelIdRef.current.set(currentConversationId, id)
+            const nextReasoningLevel = getReasoningLevelForModelId(id)
+            setReasoningLevel(nextReasoningLevel)
+            conversationReasoningLevelRef.current.set(
+              currentConversationId,
+              nextReasoningLevel,
+            )
+            setInputMessage((prev) => ({
+              ...prev,
+              reasoningLevel: nextReasoningLevel,
+            }))
+          }}
+          reasoningLevel={messageReasoningLevel}
+          onReasoningChange={(level) => {
+            setMessageReasoningMap((prev) => {
+              const next = new Map(prev)
+              next.set(message.id, level)
+              return next
+            })
+            setChatMessages((prevChatHistory) =>
+              prevChatHistory.map((msg) =>
+                msg.role === 'user' && msg.id === message.id
+                  ? {
+                      ...msg,
+                      reasoningLevel: level,
+                    }
+                  : msg,
+              ),
+            )
+            setReasoningLevel(level)
+            conversationReasoningLevelRef.current.set(
+              currentConversationId,
+              level,
+            )
+            void persistReasoningLevelForModel(
+              conversationModelIdValueRef.current,
+              level,
+            )
+          }}
+          currentAssistantId={conversationAssistantId}
+          currentChatMode={chatMode}
+          onSelectChatModeForConversation={(...args) =>
+            timelineHandlersRef.current.handleChatModeChange(...args)
+          }
+          showReasoningSelect={
+            chatSurfacePreset.userMessage.showReasoningSelect
+          }
+          allowAgentModeOption={
+            chatSurfacePreset.userMessage.allowAgentModeOption
+          }
+        />
+      )
+    },
     [
-      currentConversationRef,
-      renderChatTimelineItem,
-      resolveRuntimeActionConversation,
-      runtimeActions,
+      chatSurfacePreset,
+      chatMode,
+      conversationAssistantId,
+      conversationModelId,
+      currentConversationId,
+      focusedMessageId,
+      getReasoningLevelForModelId,
+      inputMessage.id,
+      isCurrentConversationRunActive,
+      messageModelMap,
+      messageReasoningMap,
+      onHistoricalUserMessageControlPopoverOpenChange,
+      persistReasoningLevelForModel,
+      reasoningLevel,
+      registerChatUserInputRef,
+      releaseHighlightIds,
+      selectedAssistantTimeContextEnabled,
     ],
   )
+
+  const renderYoloQueryProgress = useCallback(
+    () => <QueryProgress state={queryProgress} />,
+    [queryProgress],
+  )
+
+  const renderYoloContinueResponse = useCallback(
+    () => (
+      <div className="yolo-continue-response-button-container">
+        <button
+          type="button"
+          className="yolo-continue-response-button"
+          onClick={handleContinueResponse}
+        >
+          <div>Continue response</div>
+        </button>
+      </div>
+    ),
+    [handleContinueResponse],
+  )
+
+  const yoloTimelineRendererContract =
+    useMemo<ConversationTimelineRendererContract>(
+      () => ({
+        messagesById: chatTimelineReadModel.messagesById,
+        preset: chatSurfacePreset,
+        compaction: {
+          pendingTitle: compactionPendingTitle,
+          pendingDescription: compactionPendingDescription,
+          dividerTitle: compactionDividerTitle,
+          dividerDescription: compactionDividerDescription,
+          isDividerEntering: (item) =>
+            item.renderKey ===
+            `${enteringCompactionDividerAnchorMessageId}-compact-divider`,
+        },
+        renderUserMessage: renderYoloUserMessage,
+        getAssistantGroupProps: buildYoloAssistantGroupProps,
+        wrapAssistantGroup: (content) => (
+          <ChatRuntimeActionsProvider
+            actions={runtimeActions}
+            conversation={currentConversationRef}
+            resolveConversationScope={resolveRuntimeActionConversation}
+          >
+            {content}
+          </ChatRuntimeActionsProvider>
+        ),
+        renderQueryProgress: renderYoloQueryProgress,
+        renderContinueResponse: renderYoloContinueResponse,
+        bottomAnchorClassName: 'yolo-chat-bottom-anchor',
+      }),
+      [
+        chatSurfacePreset,
+        chatTimelineReadModel.messagesById,
+        compactionDividerDescription,
+        compactionDividerTitle,
+        compactionPendingDescription,
+        compactionPendingTitle,
+        currentConversationRef,
+        enteringCompactionDividerAnchorMessageId,
+        buildYoloAssistantGroupProps,
+        renderYoloContinueResponse,
+        renderYoloQueryProgress,
+        renderYoloUserMessage,
+        resolveRuntimeActionConversation,
+        runtimeActions,
+      ],
+    )
 
   const chatTimelineRenderVersion = useCallback(
     (timelineItem: ChatTimelineItem): string => {
@@ -8616,7 +8524,7 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
           onDeleteAssistantQuote={handleDeleteAssistantQuote}
         />
       ) : (
-        <ChatConversationPane
+        <YoloChatSurface
           chatMode={chatMode}
           yoloEnabled={yoloEnabled}
           showEmptyState={showEmptyState}
@@ -8628,7 +8536,7 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
           chatMessagesRef={chatMessagesRef}
           onScrollContainerChange={setChatMessagesElement}
           onBottomSentinelChange={setChatBottomSentinelElement}
-          renderChatTimelineItem={renderRuntimeAwareChatTimelineItem}
+          timelineRendererContract={yoloTimelineRendererContract}
           editingAssistantMessageId={editingAssistantMessageId}
           hasEarlierMessages={hasEarlierMessages}
           hasNewerMessages={hasNewerMessages}

--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -165,10 +165,6 @@ import MentionableBadge from './chat-input/MentionableBadge'
 import { editorStateToPlainText } from './chat-input/utils/editor-state-to-plain-text'
 import { ChatRuntimeActionsProvider } from './chat-runtime-actions-context'
 import { getChatSurfacePreset } from './chat-surface-presets'
-import type {
-  ConversationAssistantGroupProps,
-  ConversationTimelineRendererContract,
-} from './conversation-surface-contract'
 import { ChatListDropdown } from './ChatListDropdown'
 import {
   buildAssistantErrorContinuation,
@@ -202,6 +198,10 @@ import {
   resolveCliRuntimePreference,
 } from './cliRuntimePreferences'
 import Composer from './Composer'
+import type {
+  ConversationAssistantGroupProps,
+  ConversationTimelineRendererContract,
+} from './conversation-surface-contract'
 import { useActiveViewState } from './hooks/useActiveViewState'
 import { useSnippetEntries } from './hooks/useSnippetEntries'
 import { getInputOverlayReserveHeight } from './inputOverlayReserve'
@@ -221,9 +221,9 @@ import {
   useStableChatTimelineItems,
 } from './useChatTimelineReadModel'
 import { useHistoricalUserMessageDismiss } from './useHistoricalUserMessageDismiss'
-import { YoloChatSurface } from './YoloChatSurface'
 import UserMessageItem from './UserMessageItem'
 import ViewToggle from './ViewToggle'
+import { YoloChatSurface } from './YoloChatSurface'
 
 const WORKSPACE_WIDE_HEADER_MIN_WIDTH = 1200
 const MESSAGE_NAVIGATOR_MIN_ANCHORS = 3
@@ -2477,10 +2477,6 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
       )
     })
   }, [activeBranchByUserMessageId, groupedChatMessages])
-
-  const firstUserMessageId = useMemo(() => {
-    return chatMessages.find((message) => message.role === 'user')?.id
-  }, [chatMessages])
 
   const effectiveCompactionState = useMemo(
     () =>

--- a/src/components/chat-view/ChatConversationPane.tsx
+++ b/src/components/chat-view/ChatConversationPane.tsx
@@ -18,7 +18,7 @@ import type {
 import { InstallationIncompleteBanner } from './InstallationIncompleteBanner'
 import { SharedConversationSurface } from './SharedConversationSurface'
 
-type ChatConversationPaneProps = {
+export type ChatConversationPaneProps = {
   chatMode: ChatMode
   yoloEnabled: boolean
   showEmptyState: boolean

--- a/src/components/chat-view/CliChatSurface.test.tsx
+++ b/src/components/chat-view/CliChatSurface.test.tsx
@@ -58,15 +58,29 @@ jest.mock('./UserMessageItem', () => ({
   default: ({
     message,
     isActionDisabled,
+    showReasoningSelect,
+    showModelControl,
+    showPlaceholder,
+    allowAgentModeOption,
   }: {
     message: ChatUserMessage
     isActionDisabled?: boolean
+    showReasoningSelect?: boolean
+    showModelControl?: boolean
+    showPlaceholder?: boolean
+    allowAgentModeOption?: boolean
   }) => {
     const { editorStateToPlainText } = jest.requireActual(
       './chat-input/utils/editor-state-to-plain-text',
     )
     return (
-      <div data-action-disabled={String(isActionDisabled)}>
+      <div
+        data-action-disabled={String(isActionDisabled)}
+        data-reasoning-select={String(showReasoningSelect)}
+        data-model-control={String(showModelControl)}
+        data-placeholder={String(showPlaceholder)}
+        data-agent-mode={String(allowAgentModeOption)}
+      >
         {editorStateToPlainText(message.content)}
       </div>
     )
@@ -83,6 +97,8 @@ const mockedAssistantGroup = jest.fn(
     showInlineInfo?: boolean
     showEditAction?: boolean
     showDeleteAction?: boolean
+    showBranchAction?: boolean
+    showQuoteAction?: boolean
     conversationRunSummary?: { anchorMessageId?: string }
   }) => {
     const { useChatRuntimeActions } = jest.requireActual(
@@ -100,6 +116,8 @@ const mockedAssistantGroup = jest.fn(
         {props.showInlineInfo ? <span>Inline info</span> : null}
         {props.showEditAction ? <button>Edit</button> : null}
         {props.showDeleteAction ? <button>Delete</button> : null}
+        {props.showBranchAction ? <button>Branch</button> : null}
+        {props.showQuoteAction ? <button>Quote</button> : null}
       </div>
     )
   },
@@ -368,6 +386,19 @@ describe('CliChatSurface', () => {
     expect(html).toContain('Inline info')
     expect(html).not.toContain('Edit')
     expect(html).not.toContain('Delete')
+    expect(html).not.toContain('Branch')
+    expect(html).toContain('Quote')
+  })
+
+  it('assembles the CLI user-message preset without host-only controls', () => {
+    const html = renderSurface(
+      makeSnapshot({ messages: [makeUser('user-1', 'Prompt')] }),
+    )
+
+    expect(html).toContain('data-reasoning-select="false"')
+    expect(html).toContain('data-model-control="false"')
+    expect(html).toContain('data-placeholder="false"')
+    expect(html).toContain('data-agent-mode="false"')
   })
 
   it('does not bind a new running turn to the previous assistant footer', () => {

--- a/src/components/chat-view/CliChatSurface.tsx
+++ b/src/components/chat-view/CliChatSurface.tsx
@@ -32,18 +32,19 @@ import type { ChatTimelineItem } from '../../types/chat-timeline'
 import type { MentionableAssistantQuote } from '../../types/mentionable'
 import type { GroupEditSummary } from '../../utils/chat/editSummary'
 import { buildChatTimelineItems } from '../../utils/chat/timeline'
-import DotLoader from '../common/DotLoader'
 
 import AssistantErrorCard from './AssistantErrorCard'
 import AssistantMessageReasoning from './AssistantMessageReasoning'
-import AssistantToolMessageGroupItem from './AssistantToolMessageGroupItem'
 import { CliRuntimeControls } from './chat-input/CliRuntimeControls'
 import { editorStateToPlainText } from './chat-input/utils/editor-state-to-plain-text'
 import { ChatRuntimeActionsProvider } from './chat-runtime-actions-context'
-import { ChatConversationPane } from './ChatConversationPane'
+import { getChatSurfacePreset } from './chat-surface-presets'
+import type { ChatSurfacePreset } from './chat-surface-presets'
 import { CliSubagentProvider } from './cli-subagent-context'
 import type { AcceptedCliDraft } from './cliChatIntegration'
 import { buildCliSubagentReadModel } from './cliSubagentReadModel'
+import type { ConversationTimelineRendererContract } from './conversation-surface-contract'
+import { ConversationSurface } from './ConversationSurface'
 import { useAutoScroll } from './useAutoScroll'
 import { useChatHistoryWindow } from './useChatHistoryWindow'
 import {
@@ -193,6 +194,7 @@ function CliUserMessage({
   turnConfiguration,
   cachedModels,
   onControlPopoverOpenChange,
+  preset,
 }: {
   message: ChatUserMessage
   isFocused: boolean
@@ -207,6 +209,7 @@ function CliUserMessage({
   turnConfiguration?: CliTurnConfiguration
   cachedModels?: readonly CliRuntimeModel[]
   onControlPopoverOpenChange?: (isOpen: boolean) => void
+  preset: ChatSurfacePreset
 }) {
   const canonicalMessage = useMemo(
     () => toEditableUserMessage(message),
@@ -276,8 +279,8 @@ function CliUserMessage({
       onSelectedSkillsChange={(selectedSkills) =>
         setDraft((current) => ({ ...current, selectedSkills }))
       }
-      showReasoningSelect={false}
-      showModelControl={false}
+      showReasoningSelect={preset.userMessage.showReasoningSelect}
+      showModelControl={preset.userMessage.showModelControl}
       runtimeControls={
         <CliRuntimeControls
           configuration={editorConfiguration}
@@ -298,8 +301,8 @@ function CliUserMessage({
           }}
         />
       }
-      showPlaceholder={false}
-      allowAgentModeOption={false}
+      showPlaceholder={preset.userMessage.showPlaceholder}
+      allowAgentModeOption={preset.userMessage.allowAgentModeOption}
     />
   )
 }
@@ -650,16 +653,25 @@ export function CliChatSurface({
     snapshot.messages,
   ])
 
-  const renderTimelineItem = useCallback(
-    (timelineItem: ChatTimelineItem): ReactNode => {
-      if (timelineItem.kind === 'bottom-anchor') {
-        return <div className="yolo-cli-chat-surface__bottom-anchor" />
-      }
-
-      if (timelineItem.kind === 'user-message') {
-        const message = readModel.messagesById.get(timelineItem.messageId)
-        if (message?.role !== 'user') return null
-        return (
+  const surfacePreset = getChatSurfacePreset('cli')
+  const timelineRendererContract =
+    useMemo<ConversationTimelineRendererContract>(
+      () => ({
+        messagesById: readModel.messagesById,
+        preset: surfacePreset,
+        compaction: {
+          pendingTitle: t('chat.compaction.pendingTitle', '正在压缩上下文'),
+          pendingDescription: t(
+            'chat.compaction.pendingStatus',
+            '正在整理上下文，稍后将从新的上下文继续。',
+          ),
+          dividerTitle: t('chat.compaction.dividerTitle', '从这里继续当前任务'),
+          dividerDescription: t(
+            'chat.compaction.dividerDescription',
+            '以上对话已压缩为摘要，以下回复基于摘要继续',
+          ),
+        },
+        renderUserMessage: (message) => (
           <CliUserMessage
             key={message.id}
             message={message}
@@ -695,12 +707,100 @@ export function CliChatSurface({
             onControlPopoverOpenChange={
               onHistoricalUserMessageControlPopoverOpenChange
             }
+            preset={surfacePreset}
           />
-        )
-      }
-
-      if (timelineItem.kind === 'pending-response') {
-        return (
+        ),
+        getAssistantGroupProps: (messageGroup, timelineItem) => {
+          if (!snapshot.sessionRef) return null
+          const sourceUserMessage = getSourceUserMessageForGroup(
+            snapshot.messages,
+            timelineItem.messageIds,
+          )
+          return {
+            conversationId: getNativeConversationId(snapshot.sessionRef),
+            conversationRunSummary:
+              timelineItem.groupId === runSummaryAssistantGroupId
+                ? runSummary
+                : undefined,
+            isApplying: false,
+            activeApplyRequestKey: null,
+            onApply: noop,
+            onToolMessageUpdate: noopToolMessageUpdate,
+            onRecoverAnswerUserQuestion: noop,
+            onEditStart: noop,
+            onEditCancel: noop,
+            onEditSave: noop,
+            onDeleteGroup: noop,
+            onRetryGroup: () => {
+              if (!sourceUserMessage) return
+              void onRewriteUserMessage(
+                sourceUserMessage,
+                toEditableUserMessage(sourceUserMessage),
+                snapshot.turnConfigurationByUserMessageId?.[
+                  sourceUserMessage.id
+                ],
+              ).catch(() => undefined)
+            },
+            onBranchGroup: noop,
+            onQuoteAssistantSelection,
+            assistantQuotes,
+            onDeleteAssistantQuote,
+            onOpenEditSummaryFile: handleOpenEditSummaryFile,
+          }
+        },
+        getAssistantActionOverrides: (_messageGroup, timelineItem) => ({
+          showRetryAction:
+            getSourceUserMessageForGroup(
+              snapshot.messages,
+              timelineItem.messageIds,
+            ) !== null,
+        }),
+        wrapAssistantGroup: (content) => {
+          if (!snapshot.sessionRef) return content
+          return (
+            <CliSubagentProvider
+              value={{
+                actions,
+                sessionRef: snapshot.sessionRef,
+                presentationsByToolCallId:
+                  cliSubagentReadModel.presentationsByToolCallId,
+              }}
+            >
+              <ChatRuntimeActionsProvider
+                actions={actions}
+                conversation={snapshot.sessionRef}
+              >
+                {content}
+              </ChatRuntimeActionsProvider>
+            </CliSubagentProvider>
+          )
+        },
+        renderUnboundAssistantGroup: (messageGroup) => {
+          const errorMessage = messageGroup
+            .flatMap((message) =>
+              message.role === 'assistant' &&
+              message.metadata?.generationState === 'error' &&
+              message.metadata.errorMessage
+                ? [message.metadata.errorMessage]
+                : [],
+            )
+            .at(0)
+          return (
+            <div className="yolo-chat-messages-assistant">
+              <AssistantErrorCard
+                errorMessage={
+                  errorMessage ??
+                  snapshot.error ??
+                  t(
+                    'chat.cliSurface.unboundMessageError',
+                    'CLI 会话尚未建立，无法显示这条 Provider 消息。',
+                  )
+                }
+              />
+            </div>
+          )
+        },
+        renderPendingResponse: () => (
           <div className="yolo-chat-messages-assistant">
             <AssistantMessageReasoning
               reasoning=""
@@ -708,172 +808,32 @@ export function CliChatSurface({
               generationState="streaming"
             />
           </div>
-        )
-      }
-
-      if (timelineItem.kind === 'compaction-pending') {
-        return (
-          <div
-            className="yolo-chat-compaction-pending"
-            data-anchor-message-id={timelineItem.anchorMessageId}
-          >
-            <div className="yolo-chat-compaction-pending__loader">
-              <DotLoader
-                text={t('chat.compaction.pendingTitle', '正在压缩上下文')}
-              />
-            </div>
-            <div className="yolo-chat-compaction-pending__description">
-              {t(
-                'chat.compaction.pendingStatus',
-                '正在整理上下文，稍后将从新的上下文继续。',
-              )}
-            </div>
-          </div>
-        )
-      }
-
-      if (timelineItem.kind === 'compaction-divider') {
-        return (
-          <div className="yolo-chat-compaction-divider">
-            <div className="yolo-chat-compaction-divider__title">
-              {t('chat.compaction.dividerTitle', '从这里继续当前任务')}
-            </div>
-            <div className="yolo-chat-compaction-divider__line" />
-            <div className="yolo-chat-compaction-divider__content">
-              <div className="yolo-chat-compaction-divider__description">
-                {t(
-                  'chat.compaction.dividerDescription',
-                  '以上对话已压缩为摘要，以下回复基于摘要继续',
-                )}
-              </div>
-            </div>
-          </div>
-        )
-      }
-
-      if (timelineItem.kind !== 'assistant-group') return null
-
-      const messageGroup = timelineItem.messageIds
-        .map((messageId) => readModel.messagesById.get(messageId))
-        .filter(
-          (message): message is AssistantToolMessageGroup[number] =>
-            message !== undefined && message.role !== 'user',
-        )
-      if (messageGroup.length === 0) return null
-      if (!snapshot.sessionRef) {
-        const errorMessage = messageGroup
-          .flatMap((message) =>
-            message.role === 'assistant' &&
-            message.metadata?.generationState === 'error' &&
-            message.metadata.errorMessage
-              ? [message.metadata.errorMessage]
-              : [],
-          )
-          .at(0)
-        return (
-          <div className="yolo-chat-messages-assistant">
-            <AssistantErrorCard
-              errorMessage={
-                errorMessage ??
-                snapshot.error ??
-                t(
-                  'chat.cliSurface.unboundMessageError',
-                  'CLI 会话尚未建立，无法显示这条 Provider 消息。',
-                )
-              }
-            />
-          </div>
-        )
-      }
-      const nativeConversationId = getNativeConversationId(snapshot.sessionRef)
-      const sourceUserMessage = getSourceUserMessageForGroup(
+        ),
+        bottomAnchorClassName: 'yolo-cli-chat-surface__bottom-anchor',
+      }),
+      [
+        actions,
+        assistantQuotes,
+        focusedUserMessageId,
+        handleOpenEditSummaryFile,
+        cachedModels,
+        cliSubagentReadModel.presentationsByToolCallId,
+        isConversationBusy,
+        onHistoricalUserMessageControlPopoverOpenChange,
+        onDeleteAssistantQuote,
+        onQuoteAssistantSelection,
+        onRewriteUserMessage,
+        readModel.messagesById,
+        runSummary,
+        runSummaryAssistantGroupId,
+        snapshot.sessionRef,
+        snapshot.configuration,
         snapshot.messages,
-        timelineItem.messageIds,
-      )
-
-      return (
-        <CliSubagentProvider
-          value={{
-            actions,
-            sessionRef: snapshot.sessionRef,
-            presentationsByToolCallId:
-              cliSubagentReadModel.presentationsByToolCallId,
-          }}
-        >
-          <ChatRuntimeActionsProvider
-            actions={actions}
-            conversation={snapshot.sessionRef}
-          >
-            <AssistantToolMessageGroupItem
-              messages={messageGroup}
-              conversationId={nativeConversationId}
-              conversationRunSummary={
-                timelineItem.groupId === runSummaryAssistantGroupId
-                  ? runSummary
-                  : undefined
-              }
-              showInlineInfo
-              showRetryAction={sourceUserMessage !== null}
-              showInsertAction
-              showCopyAction
-              showBranchAction={false}
-              showEditAction={false}
-              showDeleteAction={false}
-              showQuoteAction
-              isApplying={false}
-              activeApplyRequestKey={null}
-              onApply={noop}
-              onToolMessageUpdate={noopToolMessageUpdate}
-              onRecoverAnswerUserQuestion={noop}
-              onEditStart={noop}
-              onEditCancel={noop}
-              onEditSave={noop}
-              onDeleteGroup={noop}
-              onRetryGroup={() => {
-                if (!sourceUserMessage) return
-                void onRewriteUserMessage(
-                  sourceUserMessage,
-                  toEditableUserMessage(sourceUserMessage),
-                  snapshot.turnConfigurationByUserMessageId?.[
-                    sourceUserMessage.id
-                  ],
-                ).catch(() => undefined)
-              }}
-              onBranchGroup={noop}
-              onQuoteAssistantSelection={onQuoteAssistantSelection}
-              assistantQuotes={assistantQuotes}
-              onDeleteAssistantQuote={onDeleteAssistantQuote}
-              onOpenEditSummaryFile={handleOpenEditSummaryFile}
-            />
-          </ChatRuntimeActionsProvider>
-        </CliSubagentProvider>
-      )
-    },
-    [
-      actions,
-      assistantQuotes,
-      conversationId,
-      focusedUserMessageId,
-      handleOpenEditSummaryFile,
-      cachedModels,
-      cliSubagentReadModel.presentationsByToolCallId,
-      isConversationBusy,
-      onHistoricalUserMessageControlPopoverOpenChange,
-      onDeleteAssistantQuote,
-      onQuoteAssistantSelection,
-      onRewriteUserMessage,
-      readModel.messagesById,
-      runSummary,
-      runSummaryAssistantGroupId,
-      snapshot.sessionRef,
-      snapshot.configuration,
-      snapshot.messages,
-      snapshot.runtimeId,
-      snapshot.turnConfigurationByUserMessageId,
-      t,
-    ],
-  )
-
+        snapshot.runtimeId,
+        snapshot.turnConfigurationByUserMessageId,
+        t,
+      ],
+    )
   const renderVersion = useCallback(
     (timelineItem: ChatTimelineItem): string => {
       const baseVersion = getCliTimelineRenderVersion(
@@ -900,7 +860,7 @@ export function CliChatSurface({
   )
 
   return (
-    <ChatConversationPane
+    <ConversationSurface
       chatMode="agent"
       yoloEnabled={false}
       showEmptyState={showEmptyState}
@@ -912,7 +872,7 @@ export function CliChatSurface({
       chatMessagesRef={chatMessagesRef}
       onScrollContainerChange={setChatMessagesElement}
       onBottomSentinelChange={setBottomSentinelElement}
-      renderChatTimelineItem={renderTimelineItem}
+      timelineRendererContract={timelineRendererContract}
       editingAssistantMessageId={null}
       hasEarlierMessages={hasEarlierMessages}
       hasNewerMessages={hasNewerMessages}

--- a/src/components/chat-view/CliChatSurface.tsx
+++ b/src/components/chat-view/CliChatSurface.tsx
@@ -23,7 +23,6 @@ import type {
   CliTurnConfiguration,
 } from '../../core/cli-runtime'
 import type {
-  AssistantToolMessageGroup,
   ChatMessage,
   ChatToolMessage,
   ChatUserMessage,

--- a/src/components/chat-view/ConversationSurface.tsx
+++ b/src/components/chat-view/ConversationSurface.tsx
@@ -1,0 +1,35 @@
+import { useCallback } from 'react'
+
+import type { ChatTimelineItem } from '../../types/chat-timeline'
+
+import {
+  ChatConversationPane,
+  type ChatConversationPaneProps,
+} from './ChatConversationPane'
+import type { ConversationTimelineRendererContract } from './conversation-surface-contract'
+import { renderConversationTimelineItem } from './conversation-timeline-renderer'
+
+export type ConversationSurfaceContract = Omit<
+  ChatConversationPaneProps,
+  'renderChatTimelineItem'
+> & {
+  timelineRendererContract: ConversationTimelineRendererContract
+}
+
+export function ConversationSurface({
+  timelineRendererContract,
+  ...surfaceProps
+}: ConversationSurfaceContract) {
+  const renderTimelineItem = useCallback(
+    (item: ChatTimelineItem) =>
+      renderConversationTimelineItem(item, timelineRendererContract),
+    [timelineRendererContract],
+  )
+
+  return (
+    <ChatConversationPane
+      {...surfaceProps}
+      renderChatTimelineItem={renderTimelineItem}
+    />
+  )
+}

--- a/src/components/chat-view/YoloChatSurface.tsx
+++ b/src/components/chat-view/YoloChatSurface.tsx
@@ -1,0 +1,10 @@
+import {
+  ConversationSurface,
+  type ConversationSurfaceContract,
+} from './ConversationSurface'
+
+export type YoloChatSurfaceProps = ConversationSurfaceContract
+
+export function YoloChatSurface(props: YoloChatSurfaceProps) {
+  return <ConversationSurface {...props} />
+}

--- a/src/components/chat-view/chat-surface-presets.ts
+++ b/src/components/chat-view/chat-surface-presets.ts
@@ -11,11 +11,13 @@ export type AssistantActionSurfacePreset = {
 
 export type UserMessageSurfacePreset = {
   showReasoningSelect: boolean
+  showModelControl: boolean
+  showPlaceholder: boolean
   allowAgentModeOption: boolean
 }
 
 export type ChatSurfacePreset = {
-  id: 'chat' | 'quick-ask'
+  id: 'chat' | 'cli' | 'quick-ask'
   assistantActions: AssistantActionSurfacePreset
   userMessage: UserMessageSurfacePreset
 }
@@ -38,7 +40,28 @@ export const CHAT_SURFACE_PRESETS: Record<
     },
     userMessage: {
       showReasoningSelect: true,
+      showModelControl: true,
+      showPlaceholder: true,
       allowAgentModeOption: true,
+    },
+  },
+  cli: {
+    id: 'cli',
+    assistantActions: {
+      showInlineInfo: true,
+      showRetryAction: true,
+      showInsertAction: true,
+      showCopyAction: true,
+      showBranchAction: false,
+      showEditAction: false,
+      showDeleteAction: false,
+      showQuoteAction: true,
+    },
+    userMessage: {
+      showReasoningSelect: false,
+      showModelControl: false,
+      showPlaceholder: false,
+      allowAgentModeOption: false,
     },
   },
   'quick-ask': {
@@ -55,6 +78,8 @@ export const CHAT_SURFACE_PRESETS: Record<
     },
     userMessage: {
       showReasoningSelect: false,
+      showModelControl: false,
+      showPlaceholder: false,
       allowAgentModeOption: false,
     },
   },

--- a/src/components/chat-view/conversation-surface-contract.ts
+++ b/src/components/chat-view/conversation-surface-contract.ts
@@ -1,0 +1,72 @@
+import type { ReactNode } from 'react'
+
+import type {
+  AssistantToolMessageGroup,
+  ChatMessage,
+  ChatUserMessage,
+} from '../../types/chat'
+import type {
+  ChatTimelineAssistantGroupItem,
+  ChatTimelineItem,
+} from '../../types/chat-timeline'
+
+import type { AssistantToolMessageGroupItemProps } from './AssistantToolMessageGroupItem'
+import type {
+  AssistantActionSurfacePreset,
+  ChatSurfacePreset,
+} from './chat-surface-presets'
+
+export type ConversationAssistantGroupProps = Omit<
+  AssistantToolMessageGroupItemProps,
+  | 'messages'
+  | 'showInlineInfo'
+  | 'showRetryAction'
+  | 'showInsertAction'
+  | 'showCopyAction'
+  | 'showBranchAction'
+  | 'showEditAction'
+  | 'showDeleteAction'
+  | 'showQuoteAction'
+>
+
+export type ConversationTimelineRendererContract = {
+  messagesById: ReadonlyMap<string, ChatMessage>
+  preset: ChatSurfacePreset
+  compaction: {
+    pendingTitle: string
+    pendingDescription: string
+    dividerTitle: string
+    dividerDescription: string
+    isDividerEntering?: (item: ChatTimelineItem) => boolean
+  }
+  renderUserMessage: (
+    message: ChatUserMessage,
+    item: Extract<ChatTimelineItem, { kind: 'user-message' }>,
+  ) => ReactNode
+  getAssistantGroupProps: (
+    messages: AssistantToolMessageGroup,
+    item: ChatTimelineAssistantGroupItem,
+  ) => ConversationAssistantGroupProps | null
+  getAssistantActionOverrides?: (
+    messages: AssistantToolMessageGroup,
+    item: ChatTimelineAssistantGroupItem,
+  ) => Partial<AssistantActionSurfacePreset>
+  wrapAssistantGroup?: (
+    content: ReactNode,
+    item: ChatTimelineAssistantGroupItem,
+  ) => ReactNode
+  renderUnboundAssistantGroup?: (
+    messages: AssistantToolMessageGroup,
+    item: ChatTimelineAssistantGroupItem,
+  ) => ReactNode
+  renderQueryProgress?: (
+    item: Extract<ChatTimelineItem, { kind: 'query-progress' }>,
+  ) => ReactNode
+  renderPendingResponse?: (
+    item: Extract<ChatTimelineItem, { kind: 'pending-response' }>,
+  ) => ReactNode
+  renderContinueResponse?: (
+    item: Extract<ChatTimelineItem, { kind: 'continue-response' }>,
+  ) => ReactNode
+  bottomAnchorClassName: string
+}

--- a/src/components/chat-view/conversation-timeline-renderer.test.tsx
+++ b/src/components/chat-view/conversation-timeline-renderer.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import type { ChatAssistantMessage } from '../../types/chat'
+import type { ChatTimelineAssistantGroupItem } from '../../types/chat-timeline'
+
+jest.mock('./AssistantToolMessageGroupItem', () => ({
+  __esModule: true,
+  default: ({
+    showBranchAction,
+    showQuoteAction,
+  }: {
+    showBranchAction?: boolean
+    showQuoteAction?: boolean
+  }) => (
+    <div
+      data-branch={String(showBranchAction)}
+      data-quote={String(showQuoteAction)}
+    />
+  ),
+}))
+
+import { getChatSurfacePreset } from './chat-surface-presets'
+import type { ConversationTimelineRendererContract } from './conversation-surface-contract'
+import { renderConversationTimelineItem } from './conversation-timeline-renderer'
+
+const assistant: ChatAssistantMessage = {
+  role: 'assistant',
+  id: 'assistant-1',
+  content: 'Done',
+  metadata: { generationState: 'completed' },
+}
+
+const assistantItem: ChatTimelineAssistantGroupItem = {
+  kind: 'assistant-group',
+  id: assistant.id,
+  renderKey: assistant.id,
+  groupId: assistant.id,
+  messageIds: [assistant.id],
+  revision: 1,
+  estimatedHeight: 100,
+}
+
+const makeContract = (): ConversationTimelineRendererContract => ({
+  messagesById: new Map([[assistant.id, assistant]]),
+  preset: getChatSurfacePreset('cli'),
+  compaction: {
+    pendingTitle: 'Pending',
+    pendingDescription: 'Pending description',
+    dividerTitle: 'Divider',
+    dividerDescription: 'Divider description',
+  },
+  renderUserMessage: () => null,
+  getAssistantGroupProps: () =>
+    ({
+      conversationId: 'conversation-1',
+      isApplying: false,
+      activeApplyRequestKey: null,
+    }) as ReturnType<
+      ConversationTimelineRendererContract['getAssistantGroupProps']
+    >,
+  bottomAnchorClassName: 'yolo-test-bottom-anchor',
+})
+
+describe('renderConversationTimelineItem', () => {
+  it('applies assistant action capabilities from the surface preset', () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationTimelineItem(assistantItem, makeContract())}</>,
+    )
+
+    expect(html).toContain('data-branch="false"')
+    expect(html).toContain('data-quote="true"')
+  })
+
+  it('allows an adapter to narrow a per-group preset capability', () => {
+    const contract = makeContract()
+    contract.getAssistantActionOverrides = () => ({ showQuoteAction: false })
+
+    const html = renderToStaticMarkup(
+      <>{renderConversationTimelineItem(assistantItem, contract)}</>,
+    )
+
+    expect(html).toContain('data-quote="false"')
+  })
+
+  it('renders nothing for an unknown timeline kind', () => {
+    const unknownItem = {
+      ...assistantItem,
+      kind: 'future-kind',
+    } as unknown as Parameters<typeof renderConversationTimelineItem>[0]
+
+    expect(
+      renderConversationTimelineItem(unknownItem, makeContract()),
+    ).toBeNull()
+  })
+})

--- a/src/components/chat-view/conversation-timeline-renderer.tsx
+++ b/src/components/chat-view/conversation-timeline-renderer.tsx
@@ -1,9 +1,6 @@
 import type { ReactNode } from 'react'
 
-import type {
-  AssistantToolMessageGroup,
-  ChatUserMessage,
-} from '../../types/chat'
+import type { AssistantToolMessageGroup } from '../../types/chat'
 import type { ChatTimelineItem } from '../../types/chat-timeline'
 import DotLoader from '../common/DotLoader'
 
@@ -52,7 +49,7 @@ export function renderConversationTimelineItem(
   if (item.kind === 'user-message') {
     const message = contract.messagesById.get(item.messageId)
     return message?.role === 'user'
-      ? contract.renderUserMessage(message as ChatUserMessage, item)
+      ? contract.renderUserMessage(message, item)
       : null
   }
 

--- a/src/components/chat-view/conversation-timeline-renderer.tsx
+++ b/src/components/chat-view/conversation-timeline-renderer.tsx
@@ -1,0 +1,108 @@
+import type { ReactNode } from 'react'
+
+import type {
+  AssistantToolMessageGroup,
+  ChatUserMessage,
+} from '../../types/chat'
+import type { ChatTimelineItem } from '../../types/chat-timeline'
+import DotLoader from '../common/DotLoader'
+
+import AssistantToolMessageGroupItem from './AssistantToolMessageGroupItem'
+import type { ConversationTimelineRendererContract } from './conversation-surface-contract'
+
+export function renderConversationTimelineItem(
+  item: ChatTimelineItem,
+  contract: ConversationTimelineRendererContract,
+): ReactNode {
+  if (item.kind === 'compaction-pending') {
+    return (
+      <div
+        className="yolo-chat-compaction-pending"
+        data-anchor-message-id={item.anchorMessageId}
+      >
+        <div className="yolo-chat-compaction-pending__loader">
+          <DotLoader text={contract.compaction.pendingTitle} />
+        </div>
+        <div className="yolo-chat-compaction-pending__description">
+          {contract.compaction.pendingDescription}
+        </div>
+      </div>
+    )
+  }
+
+  if (item.kind === 'compaction-divider') {
+    const enteringClass = contract.compaction.isDividerEntering?.(item)
+      ? ' is-entering'
+      : ''
+    return (
+      <div className={`yolo-chat-compaction-divider${enteringClass}`}>
+        <div className="yolo-chat-compaction-divider__title">
+          {contract.compaction.dividerTitle}
+        </div>
+        <div className="yolo-chat-compaction-divider__line" />
+        <div className="yolo-chat-compaction-divider__content">
+          <div className="yolo-chat-compaction-divider__description">
+            {contract.compaction.dividerDescription}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (item.kind === 'user-message') {
+    const message = contract.messagesById.get(item.messageId)
+    return message?.role === 'user'
+      ? contract.renderUserMessage(message as ChatUserMessage, item)
+      : null
+  }
+
+  if (item.kind === 'assistant-group') {
+    const messages = item.messageIds
+      .map((messageId) => contract.messagesById.get(messageId))
+      .filter(
+        (message): message is AssistantToolMessageGroup[number] =>
+          message !== undefined && message.role !== 'user',
+      )
+    if (messages.length === 0) return null
+
+    const assistantGroupProps = contract.getAssistantGroupProps(messages, item)
+    if (!assistantGroupProps) {
+      return contract.renderUnboundAssistantGroup?.(messages, item) ?? null
+    }
+    const actions = {
+      ...contract.preset.assistantActions,
+      ...contract.getAssistantActionOverrides?.(messages, item),
+    }
+    const content = (
+      <AssistantToolMessageGroupItem
+        messages={messages}
+        {...assistantGroupProps}
+        showInlineInfo={actions.showInlineInfo}
+        showRetryAction={actions.showRetryAction}
+        showInsertAction={actions.showInsertAction}
+        showCopyAction={actions.showCopyAction}
+        showBranchAction={actions.showBranchAction}
+        showEditAction={actions.showEditAction}
+        showDeleteAction={actions.showDeleteAction}
+        showQuoteAction={actions.showQuoteAction}
+      />
+    )
+    return contract.wrapAssistantGroup?.(content, item) ?? content
+  }
+
+  if (item.kind === 'query-progress') {
+    return contract.renderQueryProgress?.(item) ?? null
+  }
+  if (item.kind === 'pending-response') {
+    return contract.renderPendingResponse?.(item) ?? null
+  }
+  if (item.kind === 'continue-response') {
+    return contract.renderContinueResponse?.(item) ?? null
+  }
+
+  if (item.kind === 'bottom-anchor') {
+    return <div className={contract.bottomAnchorClassName} aria-hidden="true" />
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

- 冻结 ConversationSurface 呈现契约（timeline items + preset + handlers + slots）：新增 `conversation-surface-contract.ts`、统一 timeline renderer 与 `ConversationSurface` 薄封装
- `CliChatSurface` 瘦身为 CLI 数据适配器（snapshot → 契约），原先硬编码的 assistant action 开关收编进 `cli` preset；Agent 侧经 `YoloChatSurface` 对称接入同一 surface
- compaction-pending / compaction-divider 等两侧逐字重复的呈现分支合并为单点；呈现差异只能经 preset / handlers / slot 表达，共用层无 runtime 特例分支，为后续消息入场动画与工具调用折叠提供单点修改位置
- `Chat.tsx` 删除内联 timeline 渲染实现，净减少 92 行

## Test plan

- [x] `npx jest` 相关三套件（CliChatSurface / AssistantToolMessageGroupItem / conversation-timeline-renderer）：34 tests 通过
- [x] `npm run type:check` 通过
- [x] 手动冒烟：Agent ↔ CLI 切换、发送一轮消息、工具卡展示、空态、滚动与 footer 外注输入栏

Made with [Cursor](https://cursor.com)