### PR TITLE
[auto-triage] 修复空目录清理在 Obsidian 1.13.4 中触发 EISDIR (#556)

### DIFF
--- a/src/core/modules/moduleVault.test.ts
+++ b/src/core/modules/moduleVault.test.ts
@@ -208,7 +208,7 @@ describe('ObsidianModuleVaultCapabilityProvider', () => {
     await expect(api.removeFileExact('notes/card.md')).resolves.toBe(true)
     expect(vault.delete).toHaveBeenNthCalledWith(1, file, true)
     await expect(api.removeEmptyFolderExact('notes/empty')).resolves.toBe(true)
-    expect(vault.delete).toHaveBeenNthCalledWith(2, emptyFolder, false)
+    expect(vault.delete).toHaveBeenNthCalledWith(2, emptyFolder, true)
     await expect(api.removeFileExact('notes/card.md')).resolves.toBe(false)
     await expect(api.removeEmptyFolderExact('notes/empty')).resolves.toBe(false)
     expect(vault.delete).toHaveBeenCalledTimes(2)

--- a/src/core/modules/moduleVault.ts
+++ b/src/core/modules/moduleVault.ts
@@ -449,13 +449,18 @@ function createObsidianModuleVaultCapability({
           if (listing.files.length > 0 || listing.folders.length > 0) {
             return false
           }
-          await app.vault.adapter.rmdir(path, false)
+          // Obsidian 1.13.4 implements rmdir with fs.rm. Passing false for
+          // recursive causes Node to reject directories with ERR_FS_EISDIR.
+          await app.vault.adapter.rmdir(path, true)
           assertAvailable()
           return true
         }
         if (entry.children.length > 0) return false
         // eslint-disable-next-line obsidianmd/prefer-file-manager-trash-file -- Exact rollback must permanently delete only the validated empty folder.
-        await app.vault.delete(entry, false)
+        // The folder has already been verified empty. Force deletion keeps
+        // Obsidian's vault index in sync while avoiding its non-recursive
+        // directory-removal path, which can raise ERR_FS_EISDIR.
+        await app.vault.delete(entry, true)
         return true
       })
     },


### PR DESCRIPTION
## 改动摘要

- `removeEmptyFolderExact` 在目录已确认为空后，使用强制删除语义，避免 Obsidian 1.13.4 将 `recursive: false` 传递给 `fs.rm`。
- 未被 Obsidian 索引但由 adapter 发现的空目录也使用递归删除参数。
- 更新模块 Vault 单元测试，确认空目录使用强制删除。

## 分析依据

Issue #556 的调用链与当前实现一致：索引目录分支调用 `app.vault.delete(entry, false)`，在 Obsidian 1.13.4 中落到 `adapter.rmdir(path, false)`，而 Node 对目录执行 `fs.rm(..., { recursive: false })` 会抛出 `ERR_FS_EISDIR`。目录在调用前已经通过索引子项检查或 adapter listing 确认为空，因此使用强制删除语义不会扩大正常删除范围，同时保留 Obsidian Vault 索引同步路径。

这与已合并的 #546 不同：#546 修复的是 Learning staging 清理调用方通过 `trashPath` 删除目录的问题；本 PR 修复的是 Host exact-removal API 内部仍使用非递归目录删除的问题。

原 issue：https://github.com/Lapis0x0/obsidian-yolo/issues/556

## 校验结果

- `git diff --check`：通过
- `npm run type:check`：未通过，当前 runner 的 TypeScript 报 `Option 'baseUrl' has been removed`
- `npx jest src/core/modules/moduleVault.test.ts --runInBand`：未执行测试，当前依赖环境缺少配置所需的 `ts-jest`
