### PR TITLE
[auto-triage] Fix Windows Claude CLI shim detection (#562)

### DIFF
--- a/src/core/cli-runtime/claude/process.test.ts
+++ b/src/core/cli-runtime/claude/process.test.ts
@@ -129,4 +129,21 @@ describe('Claude desktop process support', () => {
       'C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\cli.js',
     )
   })
+
+  it('does not select the extensionless Windows npm shim over the package entrypoint', async () => {
+    const support = await resolveClaudeProcessSupport({
+      loadEnvironment: async () => ({
+        Path: 'C:\\nvm4w\\node_global',
+      }),
+      platform: 'win32',
+      homedir: 'C:\\Users\\me',
+      fileExists: async (path) =>
+        path ===
+        'C:\\nvm4w\\node_global\\node_modules\\@anthropic-ai\\claude-code\\cli.js',
+    })
+
+    expect(support.cliPath).toBe(
+      'C:\\nvm4w\\node_global\\node_modules\\@anthropic-ai\\claude-code\\cli.js',
+    )
+  })
 })

--- a/src/core/cli-runtime/claude/process.ts
+++ b/src/core/cli-runtime/claude/process.ts
@@ -109,7 +109,7 @@ const getClaudeCandidates = ({
     .split(pathSeparator)
     .filter(Boolean)
   const executableNames =
-    platform === 'win32' ? ['claude.exe', 'claude'] : ['claude']
+    platform === 'win32' ? ['claude.exe'] : ['claude']
   const rawConfiguredPath = configuredCliPath?.trim()
   const configuredPath =
     rawConfiguredPath === '~'

--- a/src/core/cli-runtime/claude/process.ts
+++ b/src/core/cli-runtime/claude/process.ts
@@ -108,8 +108,7 @@ const getClaudeCandidates = ({
   const pathEntries = getPathValue(env, platform)
     .split(pathSeparator)
     .filter(Boolean)
-  const executableNames =
-    platform === 'win32' ? ['claude.exe'] : ['claude']
+  const executableNames = platform === 'win32' ? ['claude.exe'] : ['claude']
   const rawConfiguredPath = configuredCliPath?.trim()
   const configuredPath =
     rawConfiguredPath === '~'


### PR DESCRIPTION
## 改动摘要

Windows 自动探测不再把无扩展名的 `claude` shell shim 当作原生可执行文件；npm 安装将继续解析到实际的 `cli-wrapper.cjs`/`cli.js` 入口。新增回归测试覆盖 `C:\nvm4w\node_global\claude` 场景。

## 分析依据

Issue #562 报告 Windows 上检测到 `C:\nvm4w\node_global\claude` 后，Claude Agent SDK 无法启动。当前候选顺序会优先选择这个无扩展名路径，导致 SDK 将 Windows npm shim 当作原生 Claude binary 启动；代码随后已有 npm 包入口探测，但此前被错误候选遮蔽。

原 issue： https://github.com/Lapis0x0/obsidian-yolo/issues/562

## 校验结果

- `npx jest src/core/cli-runtime/claude/process.test.ts --runInBand`
- `npm run type:check`

均通过。