### PR TITLE
docs: 修复 README 中损坏的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,4 +174,4 @@ Development logs are regularly updated on the [blog](https://www.lapis.cafe).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Lapis0x0/obsidian-yolo&type=Date)](https://star-history.com/#Lapis0x0/obsidian-yolo&Type=Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Lapis0x0/obsidian-yolo&type=Date)](https://star-history.dera.page/#Lapis0x0/obsidian-yolo&type=date)

--- a/README_es.md
+++ b/README_es.md
@@ -174,4 +174,4 @@ Los registros de desarrollo se actualizan regularmente en el [blog](https://www.
 
 ## Historial de estrellas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Lapis0x0/obsidian-yolo&type=Date)](https://star-history.com/#Lapis0x0/obsidian-yolo&Type=Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Lapis0x0/obsidian-yolo&type=Date)](https://star-history.dera.page/#Lapis0x0/obsidian-yolo&type=date)

--- a/README_it.md
+++ b/README_it.md
@@ -172,4 +172,4 @@ I log di sviluppo sono regolarmente aggiornati sul [blog](https://www.lapis.cafe
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Lapis0x0/obsidian-yolo&type=Date)](https://star-history.com/#Lapis0x0/obsidian-yolo&Type=Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Lapis0x0/obsidian-yolo&type=Date)](https://star-history.dera.page/#Lapis0x0/obsidian-yolo&type=date)

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -180,4 +180,4 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Lapis0x0/obsidian-yolo&type=Date)](https://star-history.com/#Lapis0x0/obsidian-yolo&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Lapis0x0/obsidian-yolo&type=Date)](https://star-history.dera.page/#Lapis0x0/obsidian-yolo&type=date)


### PR DESCRIPTION
README 中的 Star History 图表目前因 GitHub stargazer 接口限制而无法显示。本项目使用的数据源不依赖 API token，可让图表稳定加载。已将各语言 README 中的图表链接更新为新的地址。