### PR TITLE
perf(chat): 修复 Agent 编辑文件时主线程被全文 diff 冻结

### DIFF
--- a/src/components/chat-view/AssistantEditSummary.tsx
+++ b/src/components/chat-view/AssistantEditSummary.tsx
@@ -86,7 +86,12 @@ const AssistantEditSummary = memo(function AssistantEditSummary({
               '{count} file(s) changed',
             ).replace('{count}', String(summary.totalFiles))}
           </span>
-          {renderDeltaPair(summary.totalAddedLines, summary.totalRemovedLines)}
+          {summary.totalLineStatsAvailable
+            ? renderDeltaPair(
+                summary.totalAddedLines,
+                summary.totalRemovedLines,
+              )
+            : null}
         </div>
         {showUndo ? (
           <button

--- a/src/components/chat-view/AssistantToolMessageGroupItem.tsx
+++ b/src/components/chat-view/AssistantToolMessageGroupItem.tsx
@@ -32,7 +32,10 @@ import {
   hasMatchingToolMessageForRequests,
   shouldRenderAssistantToolPreview,
 } from '../../utils/chat/assistantToolPreview'
-import type { GroupEditSummary } from '../../utils/chat/editSummary'
+import type {
+  FileChangeStats,
+  GroupEditSummary,
+} from '../../utils/chat/editSummary'
 import {
   collectGroupEditSummary,
   countFileChangeStats,
@@ -912,12 +915,15 @@ function AssistantToolMessageGroupItem({
       .join('|')
   }, [baseGroupEditSummary])
 
-  // Cached per-file {addedLines, removedLines} derived from the cumulative
-  // first→latest snapshot diff. Keyed by snapshotFetchKey entries so it
-  // survives re-renders of baseGroupEditSummary that don't touch the file
-  // set (e.g. tool-call entries appended during the same round).
+  // Cached per-file stats derived from the cumulative first→latest snapshot
+  // diff. Keyed by snapshotFetchKey entries so it survives re-renders of
+  // baseGroupEditSummary that don't touch the file set (e.g. tool-call entries
+  // appended during the same round). Carries `lineStatsAvailable` along with
+  // the numbers: the recomputation can come back unavailable (oversized file
+  // or diff timeout), and applying its 0/0 while leaving the original
+  // availability flag alone would render a confident, wrong "0".
   const [enrichedFileCounts, setEnrichedFileCounts] = useState<
-    Record<string, { addedLines: number; removedLines: number }>
+    Record<string, FileChangeStats>
   >({})
 
   useEffect(() => {
@@ -964,8 +970,7 @@ function AssistantToolMessageGroupItem({
         return [key, counts] as const
       })
 
-      const next: Record<string, { addedLines: number; removedLines: number }> =
-        {}
+      const next: Record<string, FileChangeStats> = {}
       for (const entry of entries) {
         if (entry) {
           next[entry[0]] = entry[1]
@@ -997,6 +1002,7 @@ function AssistantToolMessageGroupItem({
         ...file,
         addedLines: enriched.addedLines,
         removedLines: enriched.removedLines,
+        lineStatsAvailable: enriched.lineStatsAvailable,
       }
     })
     return {
@@ -1007,6 +1013,11 @@ function AssistantToolMessageGroupItem({
         (sum, file) => sum + file.removedLines,
         0,
       ),
+      // 合计跟着补齐后的逐文件数字一起重算，所以可用性也要重新判断：补齐结果
+      // 里只要有一个文件算不出行数，这里的合计就是残缺的。
+      totalLineStatsAvailable:
+        baseGroupEditSummary.totalLineStatsAvailable &&
+        files.every((file) => file.lineStatsAvailable),
     }
   }, [baseGroupEditSummary, enrichedFileCounts])
 

--- a/src/components/chat-view/AssistantToolMessageGroupItem.tsx
+++ b/src/components/chat-view/AssistantToolMessageGroupItem.tsx
@@ -1013,11 +1013,20 @@ function AssistantToolMessageGroupItem({
         (sum, file) => sum + file.removedLines,
         0,
       ),
-      // 合计跟着补齐后的逐文件数字一起重算，所以可用性也要重新判断：补齐结果
-      // 里只要有一个文件算不出行数，这里的合计就是残缺的。
+      // 合计跟着补齐后的逐文件数字一起重算，所以补齐结果算不出行数时合计也就
+      // 残缺了。只看「被补齐覆盖过的」文件：没被覆盖的文件其可用性已经体现在
+      // baseGroupEditSummary.totalLineStatsAvailable 里，而用 files.every()
+      // 会误伤只报告整轮增删的 provider（Claude CLI 把每个文件都标成不可用，
+      // 合计却是准确的）。
       totalLineStatsAvailable:
         baseGroupEditSummary.totalLineStatsAvailable &&
-        files.every((file) => file.lineStatsAvailable),
+        baseGroupEditSummary.files.every((file) => {
+          const enriched =
+            enrichedFileCounts[
+              `${file.path}::${file.firstRoundId}::${file.latestRoundId}`
+            ]
+          return !enriched || enriched.lineStatsAvailable
+        }),
     }
   }, [baseGroupEditSummary, enrichedFileCounts])
 

--- a/src/components/chat-view/AssistantToolMessageGroupItem.tsx
+++ b/src/components/chat-view/AssistantToolMessageGroupItem.tsx
@@ -17,7 +17,7 @@ import type { AgentConversationRunSummary } from '../../core/agent/service'
 import { isCliToolCallCapability } from '../../core/cli-runtime/tool-call'
 import { InvalidToolNameException } from '../../core/mcp/exception'
 import { parseToolName } from '../../core/mcp/tool-name-utils'
-import { readEditReviewSnapshot } from '../../database/json/chat/editReviewSnapshotStore'
+import { readEditReviewSnapshots } from '../../database/json/chat/editReviewSnapshotStore'
 import {
   AssistantToolMessageGroup,
   ChatAssistantMessage,
@@ -929,44 +929,40 @@ function AssistantToolMessageGroupItem({
     const files = baseGroupEditSummary.files
 
     void (async () => {
-      const entries = await Promise.all(
-        files.map(async (file) => {
-          const [firstSnapshot, latestSnapshot] = await Promise.all([
-            readEditReviewSnapshot({
-              app,
-              conversationId,
-              roundId: file.firstRoundId,
-              filePath: file.path,
-              settings,
-            }),
-            readEditReviewSnapshot({
-              app,
-              conversationId,
-              roundId: file.latestRoundId,
-              filePath: file.path,
-              settings,
-            }),
-          ])
-
-          if (!firstSnapshot || !latestSnapshot) {
-            return null
-          }
-
-          const counts = countFileChangeStats({
-            beforeContent: firstSnapshot.beforeContent,
-            afterContent: latestSnapshot.afterContent,
-            beforeExists: firstSnapshot.beforeExists,
-            afterExists: latestSnapshot.afterExists,
-          })
-
-          const key = `${file.path}::${file.firstRoundId}::${file.latestRoundId}`
-          return [key, counts] as const
-        }),
-      )
+      // 一次读盘取出所有需要的快照。逐个 readEditReviewSnapshot 会把整个会话
+      // 的快照库（含每个文件的前后全文）读盘并 JSON.parse 2×N 遍，全在主线程。
+      const snapshots = await readEditReviewSnapshots({
+        app,
+        conversationId,
+        keys: files.flatMap((file) => [
+          { roundId: file.firstRoundId, filePath: file.path },
+          { roundId: file.latestRoundId, filePath: file.path },
+        ]),
+        settings,
+      })
 
       if (cancelled) {
         return
       }
+
+      const entries = files.map((file, index) => {
+        const firstSnapshot = snapshots[index * 2]
+        const latestSnapshot = snapshots[index * 2 + 1]
+
+        if (!firstSnapshot || !latestSnapshot) {
+          return null
+        }
+
+        const counts = countFileChangeStats({
+          beforeContent: firstSnapshot.beforeContent,
+          afterContent: latestSnapshot.afterContent,
+          beforeExists: firstSnapshot.beforeExists,
+          afterExists: latestSnapshot.afterExists,
+        })
+
+        const key = `${file.path}::${file.firstRoundId}::${file.latestRoundId}`
+        return [key, counts] as const
+      })
 
       const next: Record<string, { addedLines: number; removedLines: number }> =
         {}

--- a/src/core/tools/file-editing-support.ts
+++ b/src/core/tools/file-editing-support.ts
@@ -2,9 +2,11 @@ import type { App } from 'obsidian'
 
 import { upsertEditReviewSnapshot } from '../../database/json/chat/editReviewSnapshotStore'
 import type { YoloSettings } from '../../settings/schema/setting.types'
+import type { ToolEditSummary } from '../../types/tool-call.types'
 import {
   createToolEditSummary,
   deriveToolEditUndoStatus,
+  hasFileContentChanged,
 } from '../../utils/chat/editSummary'
 import { editUndoSnapshotStore } from '../../utils/chat/editUndoSnapshotStore'
 import type { PromptSourceWatcher } from '../agent/promptSourceWatcher'
@@ -55,16 +57,14 @@ export const buildFileChangeSummary = async ({
   toolCallId?: string
   appliedAt: number
 }): Promise<LocalToolCallResultMetadata | undefined> => {
-  let editSummary = createToolEditSummary({
-    path,
+  const changed = hasFileContentChanged({
     beforeContent,
     afterContent,
     beforeExists,
     afterExists,
-    reviewRoundId: roundId,
   })
 
-  if (toolCallId && editSummary) {
+  if (toolCallId && changed) {
     editUndoSnapshotStore.set({
       toolCallId,
       path,
@@ -76,7 +76,12 @@ export const buildFileChangeSummary = async ({
     })
   }
 
-  if (conversationId && roundId && editSummary) {
+  // 有会话上下文时，最终展示的行数来自 review 快照（它统计的是本轮累计，而
+  // 不是本次编辑），会把 `createToolEditSummary` 自己算的数字整个覆盖掉。所以
+  // 先拿到快照，再用它的数字建摘要——否则同一份内容要跑两次全文 diff，其中
+  // 一次的结果算完就被丢弃。
+  let editSummary: ToolEditSummary | undefined
+  if (changed && conversationId && roundId) {
     const snapshot = await upsertEditReviewSnapshot({
       app,
       conversationId,
@@ -88,17 +93,27 @@ export const buildFileChangeSummary = async ({
       afterExists,
       settings,
     })
-    editSummary = {
-      ...editSummary,
-      files: editSummary.files.map((file) => ({
-        ...file,
+    editSummary = createToolEditSummary({
+      path,
+      beforeContent,
+      afterContent,
+      beforeExists,
+      afterExists,
+      reviewRoundId: roundId,
+      counts: {
         addedLines: snapshot.addedLines,
         removedLines: snapshot.removedLines,
-        reviewRoundId: roundId,
-      })),
-      totalAddedLines: snapshot.addedLines,
-      totalRemovedLines: snapshot.removedLines,
-    }
+      },
+    })
+  } else {
+    editSummary = createToolEditSummary({
+      path,
+      beforeContent,
+      afterContent,
+      beforeExists,
+      afterExists,
+      reviewRoundId: roundId,
+    })
   }
 
   if (!editSummary) {

--- a/src/core/tools/file-editing-support.ts
+++ b/src/core/tools/file-editing-support.ts
@@ -103,6 +103,7 @@ export const buildFileChangeSummary = async ({
       counts: {
         addedLines: snapshot.addedLines,
         removedLines: snapshot.removedLines,
+        lineStatsAvailable: snapshot.lineStatsAvailable,
       },
     })
   } else {

--- a/src/database/json/chat/editReviewSnapshotStore.test.ts
+++ b/src/database/json/chat/editReviewSnapshotStore.test.ts
@@ -4,6 +4,7 @@ import {
   clearAllEditReviewSnapshotStores,
   deleteEditReviewSnapshotStore,
   readEditReviewSnapshot,
+  readEditReviewSnapshots,
   upsertEditReviewSnapshot,
 } from './editReviewSnapshotStore'
 
@@ -243,5 +244,55 @@ describe('editReviewSnapshotStore', () => {
         filePath: 'note.md',
       }),
     ).resolves.toBeNull()
+  })
+
+  it('reads many snapshots with a single store read', async () => {
+    const { app, adapter } = createApp()
+
+    await upsertEditReviewSnapshot({
+      app,
+      conversationId: 'conv-1',
+      roundId: 'round-1',
+      filePath: 'a.md',
+      beforeContent: 'a',
+      afterContent: ['a', 'a2'].join('\n'),
+    })
+    await upsertEditReviewSnapshot({
+      app,
+      conversationId: 'conv-1',
+      roundId: 'round-2',
+      filePath: 'b.md',
+      beforeContent: 'b',
+      afterContent: ['b', 'b2'].join('\n'),
+    })
+
+    const readSpy = jest.spyOn(adapter, 'read')
+    const snapshots = await readEditReviewSnapshots({
+      app,
+      conversationId: 'conv-1',
+      keys: [
+        { roundId: 'round-1', filePath: 'a.md' },
+        { roundId: 'round-2', filePath: 'b.md' },
+        { roundId: 'round-3', filePath: 'missing.md' },
+      ],
+    })
+
+    expect(snapshots).toMatchObject([
+      { filePath: 'a.md', afterContent: ['a', 'a2'].join('\n') },
+      { filePath: 'b.md', afterContent: ['b', 'b2'].join('\n') },
+      null,
+    ])
+    // 逐个 readEditReviewSnapshot 会把整个快照库读盘并 JSON.parse 一遍/次。
+    expect(readSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads nothing from disk when no keys are requested', async () => {
+    const { app, adapter } = createApp()
+    const readSpy = jest.spyOn(adapter, 'read')
+
+    await expect(
+      readEditReviewSnapshots({ app, conversationId: 'conv-1', keys: [] }),
+    ).resolves.toEqual([])
+    expect(readSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/database/json/chat/editReviewSnapshotStore.ts
+++ b/src/database/json/chat/editReviewSnapshotStore.ts
@@ -235,6 +235,34 @@ export const readEditReviewSnapshot = async ({
   return store.snapshots[buildSnapshotKey(roundId, filePath)] ?? null
 }
 
+/**
+ * 一次读盘取出多个快照。
+ *
+ * `readEditReviewSnapshot` 每调用一次就要把整个会话的快照库读盘并 `JSON.parse`
+ * 一遍，而这个库存着该会话每个 (轮次, 文件) 的前后全文，可以到数 MB。调用方
+ * 需要多个快照时逐个调用，就是把同一份大 JSON 反复解析，全在主线程上。
+ */
+export const readEditReviewSnapshots = async ({
+  app,
+  conversationId,
+  keys,
+  settings,
+}: {
+  app: App
+  conversationId: string
+  keys: ReadonlyArray<{ roundId: string; filePath: string }>
+  settings?: YoloSettingsLike | null
+}): Promise<Array<EditReviewSnapshot | null>> => {
+  if (keys.length === 0) {
+    return []
+  }
+  const store = await readSnapshotStore(app, conversationId, settings)
+  return keys.map(
+    ({ roundId, filePath }) =>
+      store.snapshots[buildSnapshotKey(roundId, filePath)] ?? null,
+  )
+}
+
 export const deleteEditReviewSnapshotStore = async (
   app: App,
   conversationId: string,

--- a/src/database/json/chat/editReviewSnapshotStore.ts
+++ b/src/database/json/chat/editReviewSnapshotStore.ts
@@ -14,6 +14,12 @@ export type EditReviewSnapshot = {
   afterExists: boolean
   addedLines: number
   removedLines: number
+  /**
+   * 行数是否可信。规模过大或 diff 超时的快照拿不到准确行数，UI 据此隐藏
+   * `+N/-M`。旧快照没有这个字段，读取时按 true 兜底（它们写入时能算出数字，
+   * 就说明当时没有触发这两种情况）。
+   */
+  lineStatsAvailable: boolean
   createdAt: number
   updatedAt: number
 }
@@ -92,6 +98,7 @@ const readSnapshotStore = async (
           ...snapshot,
           beforeExists: snapshot.beforeExists ?? true,
           afterExists: snapshot.afterExists ?? true,
+          lineStatsAvailable: snapshot.lineStatsAvailable ?? true,
         },
       ]),
     ) as Record<string, EditReviewSnapshot>
@@ -197,6 +204,7 @@ export const upsertEditReviewSnapshot = async ({
       afterExists,
       addedLines: counts.addedLines,
       removedLines: counts.removedLines,
+      lineStatsAvailable: counts.lineStatsAvailable,
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
     }

--- a/src/features/editor/diff-review/review-model.test.ts
+++ b/src/features/editor/diff-review/review-model.test.ts
@@ -128,6 +128,40 @@ describe('review plan materialization', () => {
     ).toBe(original)
   })
 
+  it('falls back to a whole-document edit instead of diffing a huge file', () => {
+    // vscode-diff 的行对齐在大输入上不接受 timeout，实测 20000 行全量重写要
+    // 17 秒。超限时不跑 diff，改用整篇替换，评审计划仍然可用、可还原。
+    const original = Array.from(
+      { length: 5001 },
+      (_, i) => `原始第 ${i} 行`,
+    ).join('\n')
+    const incoming = Array.from(
+      { length: 5001 },
+      (_, i) => `修改第 ${i} 行`,
+    ).join('\n')
+
+    const started = Date.now()
+    const plan = buildSnapshotReviewPlan(original, incoming)
+    const elapsed = Date.now() - started
+
+    expect(plan.content).toBe(incoming)
+    expect(plan.suggestions.length).toBeGreaterThan(0)
+    expect(elapsed).toBeLessThan(500)
+
+    const restore = ChangeSet.of(
+      plan.suggestions.map((suggestion) =>
+        resolveSuggestionChange(plan.content, suggestion),
+      ),
+      plan.content.length,
+    )
+    expect(applyChanges(plan.content, restore)).toBe(original)
+  })
+
+  it('reports no suggestions when huge content is identical', () => {
+    const huge = Array.from({ length: 5001 }, (_, i) => `第 ${i} 行`).join('\n')
+    expect(buildSnapshotReviewPlan(huge, huge).suggestions).toEqual([])
+  })
+
   it('restores every pending item from materialized ranges', () => {
     const original = 'one\ntwo\nthree\nfour'
     const plan = buildSnapshotReviewPlan(original, 'ONE\ntwo\ninserted\nthree')

--- a/src/features/editor/diff-review/review-model.ts
+++ b/src/features/editor/diff-review/review-model.ts
@@ -89,14 +89,50 @@ export function buildReviewPlanFromEdits(
   return materializeReviewEdits(originalContent, normalizedEdits)
 }
 
+/**
+ * 走 diff 切块的行数上限（单侧）。
+ *
+ * `createLineDiffBlocks` 的时间上限管不住行对齐：vscode-diff 只给「两侧合计
+ * < 1700 行」的 dynamic-programming 路径传了 timeout，更大的输入走
+ * `myersDiffingAlgorithm.compute(sequence1, sequence2)`，没有 timeout 参数
+ * （同 `editSummary.ts` 的 `LINE_STATS_MAX_LINES`）。超限时退化成「整篇替换」
+ * 的单个 edit：`splitEditByParagraphStructure` 仍会按段落拆分，只是拆分依据
+ * 从 diff 块变成整篇的段落结构，段数对不上就退化成一个大评审项。
+ *
+ * 比行数统计宽松得多（那边是 2000），因为评审是用户主动触发的一次性计算，
+ * 而且块的划分质量直接决定能不能逐段接受/拒绝。
+ */
+const REVIEW_DIFF_MAX_LINES = 5000
+
+const countLines = (content: string): number => {
+  let lines = 1
+  for (let index = 0; index < content.length; index++) {
+    if (content[index] === '\n') lines++
+  }
+  return lines
+}
+
 export function buildSnapshotReviewPlan(
   originalContent: string,
   incomingContent: string,
 ): ReviewPlan {
-  const edits = buildSnapshotReviewEdits(
-    originalContent,
-    createLineDiffBlocks(originalContent, incomingContent),
-  )
+  const tooLargeToDiff =
+    countLines(originalContent) > REVIEW_DIFF_MAX_LINES ||
+    countLines(incomingContent) > REVIEW_DIFF_MAX_LINES
+  const edits = tooLargeToDiff
+    ? originalContent === incomingContent
+      ? []
+      : [
+          {
+            from: 0,
+            to: originalContent.length,
+            replacement: incomingContent,
+          },
+        ]
+    : buildSnapshotReviewEdits(
+        originalContent,
+        createLineDiffBlocks(originalContent, incomingContent),
+      )
   return (
     buildReviewPlanFromEdits(originalContent, edits) ?? {
       content: originalContent,

--- a/src/main.ts
+++ b/src/main.ts
@@ -212,7 +212,10 @@ import {
 import { ChatViewNavigator } from './features/chat/chatViewNavigator'
 import { NewTabEmptyStateEnhancer } from './features/chat/newTabEmptyStateEnhancer'
 import { DiffReviewController } from './features/editor/diff-review/diffReviewController'
-import { buildSnapshotReviewPlan } from './features/editor/diff-review/review-model'
+import {
+  buildReviewPlanFromEdits,
+  buildSnapshotReviewPlan,
+} from './features/editor/diff-review/review-model'
 import type { InlineSuggestionGhostPayload } from './features/editor/inline-suggestion/inlineSuggestion'
 import { InlineSuggestionController } from './features/editor/inline-suggestion/inlineSuggestionController'
 import type { QuickAskSelectionScope } from './features/editor/quick-ask/quickAsk.types'
@@ -2070,9 +2073,20 @@ export default class YoloPlugin extends Plugin {
     // If the diff that the overlay would display has zero modified blocks,
     // skip the overlay entirely — otherwise the UI renders "0/0" with every
     // button disabled and no auto-close path, stranding the user.
-    const reviewSuggestions = buildSnapshotReviewPlan(
-      state.originalContent,
-      state.newContent,
+    //
+    // 这里必须和 overlay 构造时的取法一致，否则预检说「有改动」而 overlay 算出
+    // 空计划（或反过来）。`fs_edit` 在打开评审前不写文件，所以此刻文件内容就是
+    // `originalContent`，正是 overlay 用 `reviewEdits` 的前提条件。走这一支还
+    // 顺带避开了一次全量 diff：`fs_edit` 每次走审批都会到这里，而 vscode-diff
+    // 的行对齐在大文件上不接受 timeout（见 editSummary.ts 的
+    // LINE_STATS_MAX_LINES），只为判断「有没有改动」就可能冻住主线程十几秒。
+    const exactPlan =
+      state.viewMode !== 'applied-review' && state.reviewEdits
+        ? buildReviewPlanFromEdits(state.originalContent, state.reviewEdits)
+        : null
+    const reviewSuggestions = (
+      exactPlan ??
+      buildSnapshotReviewPlan(state.originalContent, state.newContent)
     ).suggestions
     if (reviewSuggestions.length === 0) {
       if (state.originalContent !== state.newContent) {

--- a/src/types/tool-call.types.ts
+++ b/src/types/tool-call.types.ts
@@ -99,6 +99,16 @@ export type ToolEditSummary = {
   totalFiles: number
   totalAddedLines: number
   totalRemovedLines: number
+  /**
+   * False when the totals themselves are incomplete — i.e. some file's lines
+   * could not be counted at all, so summing the files under-reports the turn.
+   *
+   * This is NOT the same as every file having `lineStatsAvailable: false`: a
+   * provider that only reports turn-wide insertions/deletions (Claude CLI)
+   * marks each file unavailable while the totals stay exact. Omitted means the
+   * totals are trustworthy.
+   */
+  totalLineStatsAvailable?: boolean
   undoStatus: ToolEditUndoStatus
 }
 

--- a/src/utils/chat/diff.ts
+++ b/src/utils/chat/diff.ts
@@ -4,6 +4,18 @@ import {
   LineRangeMapping,
 } from 'vscode-diff'
 
+/**
+ * 评审视图的 diff 上限。同样不能用 vscode-diff 的「不限时」（0），否则超大
+ * 文档打开评审时会冻住主线程；但这里给的额度远比行数统计
+ * （`editSummary.ts` 的 `LINE_STATS_MAX_COMPUTATION_MS`）宽松：块的划分质量
+ * 直接决定评审能不能按段拆分、拆得对不对，是用户逐条接受/拒绝的依据，而不是
+ * 一个展示用的数字。评审又是用户主动触发的一次性计算，不在 agent 的热路径上。
+ *
+ * 超时的代价是块变粗：`review-model.ts` 的段落拆分要求块内原文段数与新文段数
+ * 相等才逐段拆，块一粗就更容易对不上，退化成整块一个评审项。
+ */
+const REVIEW_DIFF_MAX_COMPUTATION_MS = 1000
+
 export type InlineDiffToken = {
   type: 'same' | 'add' | 'del'
   text: string
@@ -60,7 +72,7 @@ export function createDiffBlocks(
   const advOptions: ILinesDiffComputerOptions = {
     ignoreTrimWhitespace: false,
     computeMoves: true,
-    maxComputationTimeMs: 0,
+    maxComputationTimeMs: REVIEW_DIFF_MAX_COMPUTATION_MS,
   }
   const advDiffComputer = new AdvancedLinesDiffComputer()
   const advLineChanges = advDiffComputer.computeDiff(
@@ -112,7 +124,7 @@ export function createLineDiffBlocks(
   const advOptions: ILinesDiffComputerOptions = {
     ignoreTrimWhitespace: false,
     computeMoves: true,
-    maxComputationTimeMs: 0,
+    maxComputationTimeMs: REVIEW_DIFF_MAX_COMPUTATION_MS,
   }
   const advDiffComputer = new AdvancedLinesDiffComputer()
 
@@ -807,7 +819,7 @@ export function createInlineDiffLines(
   const advOptions: ILinesDiffComputerOptions = {
     ignoreTrimWhitespace: false,
     computeMoves: false,
-    maxComputationTimeMs: 0,
+    maxComputationTimeMs: REVIEW_DIFF_MAX_COMPUTATION_MS,
   }
   const advDiffComputer = new AdvancedLinesDiffComputer()
   const advLineChanges = advDiffComputer.computeDiff(

--- a/src/utils/chat/editSummary.test.ts
+++ b/src/utils/chat/editSummary.test.ts
@@ -361,6 +361,93 @@ describe('editSummary helpers', () => {
     expect(summary?.files[0].lineStatsAvailable).toBe(false)
   })
 
+  it('marks group totals unusable when a file could not be counted', () => {
+    // 合计是逐文件求和，算不出行数的文件贡献 0，合计就少算了——不能让标题
+    // 拿这个残缺的和去冒充完整数字。
+    const unavailable = createToolEditSummary({
+      path: 'huge.md',
+      beforeContent: 'a',
+      afterContent: 'b',
+      counts: { addedLines: 0, removedLines: 0, lineStatsAvailable: false },
+    })
+
+    const result = collectGroupEditSummary([
+      { role: 'assistant', id: 'assistant-1', content: 'done' },
+      {
+        role: 'tool',
+        id: 'tool-1',
+        toolCalls: [
+          {
+            request: { id: 'call-1', name: 'yolo_local__fs_edit' },
+            response: {
+              status: ToolCallResponseStatus.Success,
+              data: {
+                type: 'text',
+                text: '{}',
+                metadata: { editSummary: unavailable },
+              },
+            },
+          },
+        ],
+      },
+    ] as AssistantToolMessageGroup)
+
+    expect(result?.totalLineStatsAvailable).toBe(false)
+  })
+
+  it('keeps group totals usable for providers that only report turn-wide stats', () => {
+    // Claude CLI 只拿得到整轮的 insertions/deletions，于是把每个文件标成
+    // 不可用、把整轮数字放进合计。这种情况下合计是准确的，不能被误伤。
+    const turnWide = {
+      files: [
+        {
+          path: 'a.md',
+          addedLines: 12,
+          removedLines: 3,
+          lineStatsAvailable: false,
+          operation: 'edit' as const,
+          undoStatus: 'unavailable' as const,
+        },
+        {
+          path: 'b.md',
+          addedLines: 0,
+          removedLines: 0,
+          lineStatsAvailable: false,
+          operation: 'edit' as const,
+          undoStatus: 'unavailable' as const,
+        },
+      ],
+      totalFiles: 2,
+      totalAddedLines: 12,
+      totalRemovedLines: 3,
+      undoStatus: 'unavailable' as const,
+    }
+
+    const result = collectGroupEditSummary([
+      { role: 'assistant', id: 'assistant-1', content: 'done' },
+      {
+        role: 'tool',
+        id: 'tool-1',
+        toolCalls: [
+          {
+            request: { id: 'call-1', name: 'yolo_local__fs_edit' },
+            response: {
+              status: ToolCallResponseStatus.Success,
+              data: {
+                type: 'text',
+                text: '{}',
+                metadata: { editSummary: turnWide },
+              },
+            },
+          },
+        ],
+      },
+    ] as AssistantToolMessageGroup)
+
+    expect(result?.totalLineStatsAvailable).toBe(true)
+    expect(result?.files.every((file) => !file.lineStatsAvailable)).toBe(true)
+  })
+
   it('derives partial undo status when file states diverge', () => {
     expect(
       deriveToolEditUndoStatus([

--- a/src/utils/chat/editSummary.test.ts
+++ b/src/utils/chat/editSummary.test.ts
@@ -6,6 +6,7 @@ import {
   countFileChangeStats,
   createToolEditSummary,
   deriveToolEditUndoStatus,
+  hasFileContentChanged,
 } from './editSummary'
 import { editUndoSnapshotStore } from './editUndoSnapshotStore'
 
@@ -189,6 +190,115 @@ describe('editSummary helpers', () => {
       totalAddedLines: 1,
       totalRemovedLines: 0,
     })
+  })
+
+  it('uses caller-provided counts instead of recomputing the diff', () => {
+    const summary = createToolEditSummary({
+      path: 'note.md',
+      beforeContent: ['one', 'two', 'three'].join('\n'),
+      afterContent: ['one', 'dos', 'tres'].join('\n'),
+      counts: { addedLines: 40, removedLines: 2 },
+    })
+
+    expect(summary).toMatchObject({
+      totalAddedLines: 40,
+      totalRemovedLines: 2,
+      files: [{ addedLines: 40, removedLines: 2 }],
+    })
+  })
+
+  it('still reports no summary for unchanged content even with counts given', () => {
+    expect(
+      createToolEditSummary({
+        path: 'note.md',
+        beforeContent: 'same',
+        afterContent: 'same',
+        counts: { addedLines: 9, removedLines: 9 },
+      }),
+    ).toBeUndefined()
+  })
+
+  it('detects whether content changed without computing line stats', () => {
+    expect(
+      hasFileContentChanged({ beforeContent: 'a', afterContent: 'a' }),
+    ).toBe(false)
+    expect(
+      hasFileContentChanged({ beforeContent: 'a', afterContent: 'b' }),
+    ).toBe(true)
+    // 内容相同但存在性不同（创建/删除空文件）仍然算变了。
+    expect(
+      hasFileContentChanged({
+        beforeContent: '',
+        afterContent: '',
+        beforeExists: false,
+        afterExists: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps per-file net deltas independent when several files are edited', () => {
+    // 净增删按 (first, latest) 这对快照缓存；这里确保缓存不会在文件之间串味，
+    // 并且重复调用给出一致结果。
+    const makeGroup = (
+      entries: Array<{ toolCallId: string; path: string }>,
+    ): AssistantToolMessageGroup =>
+      [
+        { role: 'assistant', id: 'assistant-1', content: 'done' },
+        {
+          role: 'tool',
+          id: 'tool-1',
+          toolCalls: entries.map(({ toolCallId, path }) => ({
+            request: { id: toolCallId, name: 'yolo_local__fs_edit' },
+            response: {
+              status: ToolCallResponseStatus.Success,
+              data: {
+                type: 'text',
+                text: '{}',
+                metadata: {
+                  editSummary: createToolEditSummary({
+                    path,
+                    beforeContent: 'placeholder',
+                    afterContent: 'placeholder changed',
+                  }),
+                },
+              },
+            },
+          })),
+        },
+      ] as AssistantToolMessageGroup
+
+    editUndoSnapshotStore.set({
+      toolCallId: 'call-a',
+      path: 'a.md',
+      beforeContent: 'a',
+      afterContent: ['a', 'a2', 'a3'].join('\n'),
+      beforeExists: true,
+      afterExists: true,
+      appliedAt: 1,
+    })
+    editUndoSnapshotStore.set({
+      toolCallId: 'call-b',
+      path: 'b.md',
+      beforeContent: ['b', 'b2', 'b3'].join('\n'),
+      afterContent: 'b',
+      beforeExists: true,
+      afterExists: true,
+      appliedAt: 2,
+    })
+
+    const group = makeGroup([
+      { toolCallId: 'call-a', path: 'a.md' },
+      { toolCallId: 'call-b', path: 'b.md' },
+    ])
+
+    const first = collectGroupEditSummary(group)
+    const second = collectGroupEditSummary(group)
+
+    expect(first?.files).toMatchObject([
+      { path: 'a.md', addedLines: 2, removedLines: 0 },
+      { path: 'b.md', addedLines: 0, removedLines: 2 },
+    ])
+    expect(second?.files).toEqual(first?.files)
   })
 
   it('derives partial undo status when file states diverge', () => {

--- a/src/utils/chat/editSummary.test.ts
+++ b/src/utils/chat/editSummary.test.ts
@@ -197,7 +197,7 @@ describe('editSummary helpers', () => {
       path: 'note.md',
       beforeContent: ['one', 'two', 'three'].join('\n'),
       afterContent: ['one', 'dos', 'tres'].join('\n'),
-      counts: { addedLines: 40, removedLines: 2 },
+      counts: { addedLines: 40, removedLines: 2, lineStatsAvailable: true },
     })
 
     expect(summary).toMatchObject({
@@ -213,7 +213,7 @@ describe('editSummary helpers', () => {
         path: 'note.md',
         beforeContent: 'same',
         afterContent: 'same',
-        counts: { addedLines: 9, removedLines: 9 },
+        counts: { addedLines: 9, removedLines: 9, lineStatsAvailable: true },
       }),
     ).toBeUndefined()
   })
@@ -301,6 +301,66 @@ describe('editSummary helpers', () => {
     expect(second?.files).toEqual(first?.files)
   })
 
+  it('gives up on line stats instead of guessing when the file is too large', () => {
+    // vscode-diff 只给「两侧合计 <1700 行」的 DP 路径传了 timeout，更大的输入
+    // 走无上限的 Myers 行对齐（实测 20000 行全量重写要 17 秒）。超过规模上限时
+    // 宁可不给数字，也不能让主线程跑到算完。
+    const before = Array.from({ length: 2001 }, (_, i) => `原始第 ${i} 行`)
+    const after = Array.from({ length: 2001 }, (_, i) => `修改第 ${i} 行`)
+
+    const started = Date.now()
+    const stats = countFileChangeStats({
+      beforeContent: before.join('\n'),
+      afterContent: after.join('\n'),
+    })
+
+    expect(stats.lineStatsAvailable).toBe(false)
+    // 没有真的去跑 diff——同规模的全量重写在有 timeout 时也要上百毫秒。
+    expect(Date.now() - started).toBeLessThan(50)
+  })
+
+  it('still counts oversized creates and deletes, which need no diff', () => {
+    const huge = Array.from({ length: 5000 }, (_, i) => `第 ${i} 行`).join('\n')
+
+    expect(
+      countFileChangeStats({
+        beforeContent: '',
+        afterContent: huge,
+        beforeExists: false,
+        afterExists: true,
+      }),
+    ).toEqual({ addedLines: 5000, removedLines: 0, lineStatsAvailable: true })
+
+    expect(
+      countFileChangeStats({
+        beforeContent: huge,
+        afterContent: '',
+        beforeExists: true,
+        afterExists: false,
+      }),
+    ).toEqual({ addedLines: 0, removedLines: 5000, lineStatsAvailable: true })
+  })
+
+  it('reports available line stats for ordinary edits', () => {
+    expect(
+      countFileChangeStats({
+        beforeContent: ['one', 'two', 'three'].join('\n'),
+        afterContent: ['one', 'dos', 'three'].join('\n'),
+      }),
+    ).toEqual({ addedLines: 1, removedLines: 1, lineStatsAvailable: true })
+  })
+
+  it('hides the delta on the summary when line stats are unavailable', () => {
+    const summary = createToolEditSummary({
+      path: 'note.md',
+      beforeContent: 'a',
+      afterContent: 'b',
+      counts: { addedLines: 0, removedLines: 0, lineStatsAvailable: false },
+    })
+
+    expect(summary?.files[0].lineStatsAvailable).toBe(false)
+  })
+
   it('derives partial undo status when file states diverge', () => {
     expect(
       deriveToolEditUndoStatus([
@@ -321,6 +381,7 @@ describe('editSummary helpers', () => {
     ).toEqual({
       addedLines: 0,
       removedLines: 2,
+      lineStatsAvailable: true,
     })
   })
 })

--- a/src/utils/chat/editSummary.ts
+++ b/src/utils/chat/editSummary.ts
@@ -49,23 +49,52 @@ export type GroupEditSummary = {
 }
 
 /**
+ * 行数统计的结果。`lineStatsAvailable` 为 false 表示这次没能算出可信的行数，
+ * 此时 `addedLines` / `removedLines` 无意义——`AssistantEditSummary` 会据此
+ * 不渲染 `+N/-M`。撤销和评审都不依赖它。
+ */
+export type FileChangeStats = {
+  addedLines: number
+  removedLines: number
+  lineStatsAvailable: boolean
+}
+
+const UNAVAILABLE_LINE_STATS: FileChangeStats = {
+  addedLines: 0,
+  removedLines: 0,
+  lineStatsAvailable: false,
+}
+
+/**
  * 行数统计跑在主线程上，产出的只是聊天卡片上的 `+N/-M`。
  *
  * vscode-diff 把 `maxComputationTimeMs: 0` 解释为「不限时」
  * （`advancedLinesDiffComputer.js` → `InfiniteTimeout`），而 Myers 是
- * O(N·D)：改动行数接近总行数时退化成 O(N²)。实测「4000 行、前一半全部重写」
- * 这种输入不限时要 13 秒，期间整个 Obsidian 主线程（连窗口按钮）都冻结。
+ * O(N·D)：改动行数接近总行数时退化成 O(N²)。不限时的话「4000 行、前一半全部
+ * 重写」实测要 13 秒，期间整个 Obsidian 主线程（连窗口按钮）都冻结。
  *
  * 注意这个值不是耗时上界：vscode-diff 只在算法的检查点上看时间，两次检查之间
  * 有一整段不可中断的工作。同一输入下把上限设成 25ms 和设成 200ms 实耗几乎一样
  * （都是那一段的长度，实测约 115ms），所以它的作用是「从不限时变成有限」，而不是
  * 「压到 100ms 以内」。取 100ms 是取一个足够宽松的值，让值得精确统计的常规改动
  * （300~2000 行的编辑实测 3~32ms）绝不会被截断。
- *
- * 超时后 vscode-diff 是按区段降级而不是整体放弃，行数统计因此几乎不受影响：
- * 上面那个输入在有上限时仍然给出与不限时完全相同的 +2000/-2000。
  */
 const LINE_STATS_MAX_COMPUTATION_MS = 100
+
+/**
+ * 单侧行数上限，超过就不统计。
+ *
+ * 上面那个时间上限管不住行对齐：vscode-diff 只给「两侧合计 < 1700 行」的
+ * dynamic-programming 路径传了 timeout，超过这个规模走的是
+ * `myersDiffingAlgorithm.compute(sequence1, sequence2)`——没有 timeout 参数，
+ * 行对齐会一直跑到算完。实测全量重写：2000 行 99ms、5000 行 520ms、
+ * 10000 行 1.6 秒、20000 行 17.7 秒。
+ *
+ * 代价取决于改动量 D，而 D 只有算完才知道，所以只能按输入规模保守截断。取 2000
+ * 行是因为它把最坏情况压在 ~100ms：markdown 笔记极少超过这个长度，而超长文件
+ * （通常是代码或数据）损失的只是一个展示数字。
+ */
+const LINE_STATS_MAX_LINES = 2000
 
 const LINE_DIFF_OPTIONS: ILinesDiffComputerOptions = {
   ignoreTrimWhitespace: false,
@@ -76,17 +105,32 @@ const LINE_DIFF_OPTIONS: ILinesDiffComputerOptions = {
 export const countChangedLines = (
   beforeContent: string,
   afterContent: string,
-) => {
+): FileChangeStats => {
   const beforeLines = beforeContent.split('\n')
   const afterLines = afterContent.split('\n')
+
+  if (
+    beforeLines.length > LINE_STATS_MAX_LINES ||
+    afterLines.length > LINE_STATS_MAX_LINES
+  ) {
+    return UNAVAILABLE_LINE_STATS
+  }
+
   const diffComputer = new AdvancedLinesDiffComputer()
-  const changes = diffComputer.computeDiff(
+  const result = diffComputer.computeDiff(
     beforeLines,
     afterLines,
     LINE_DIFF_OPTIONS,
-  ).changes
+  )
 
-  return changes.reduce(
+  // `hitTimeout` 只说明结果是近似的，没说近似到什么程度：超时若发生在行对齐
+  // 完成之前，vscode-diff 会退化成「整份文件全部替换」，把只改了一行的编辑报成
+  // 全删全增。宁可不给数字，也不给一个看起来精确的错数字。
+  if (result.hitTimeout) {
+    return UNAVAILABLE_LINE_STATS
+  }
+
+  return result.changes.reduce<FileChangeStats>(
     (acc, change) => {
       acc.removedLines +=
         change.originalRange.endLineNumberExclusive -
@@ -96,7 +140,7 @@ export const countChangedLines = (
         change.modifiedRange.startLineNumber
       return acc
     },
-    { addedLines: 0, removedLines: 0 },
+    { addedLines: 0, removedLines: 0, lineStatsAvailable: true },
   )
 }
 
@@ -114,15 +158,17 @@ export const countFileChangeStats = ({
   afterContent: string
   beforeExists?: boolean
   afterExists?: boolean
-}) => {
+}): FileChangeStats => {
   if (!beforeExists && !afterExists) {
-    return { addedLines: 0, removedLines: 0 }
+    return { addedLines: 0, removedLines: 0, lineStatsAvailable: true }
   }
 
+  // 纯创建/纯删除不需要 diff，数行即可，无论多大都能给出准确数字。
   if (!beforeExists) {
     return {
       addedLines: countContentLines(afterContent),
       removedLines: 0,
+      lineStatsAvailable: true,
     }
   }
 
@@ -130,6 +176,7 @@ export const countFileChangeStats = ({
     return {
       addedLines: 0,
       removedLines: countContentLines(beforeContent),
+      lineStatsAvailable: true,
     }
   }
 
@@ -203,7 +250,7 @@ export const createToolEditSummary = ({
    * 已经算好的行数。调用方手上已有统计结果时传进来，避免为同一份内容重复跑
    * 一次全文 diff。
    */
-  counts?: { addedLines: number; removedLines: number }
+  counts?: FileChangeStats
 }): ToolEditSummary | undefined => {
   if (
     !hasFileContentChanged({
@@ -216,7 +263,7 @@ export const createToolEditSummary = ({
     return undefined
   }
 
-  const { addedLines, removedLines } =
+  const { addedLines, removedLines, lineStatsAvailable } =
     counts ??
     countFileChangeStats({
       beforeContent,
@@ -230,6 +277,7 @@ export const createToolEditSummary = ({
       path,
       addedLines,
       removedLines,
+      lineStatsAvailable,
       operation: deriveToolEditOperation({ beforeExists, afterExists }),
       undoStatus: 'available',
       reviewRoundId,
@@ -284,13 +332,13 @@ const aggregateUndoStatus = (
  */
 const snapshotPairChangeStatsCache = new WeakMap<
   EditUndoSnapshot,
-  WeakMap<EditUndoSnapshot, { addedLines: number; removedLines: number }>
+  WeakMap<EditUndoSnapshot, FileChangeStats>
 >()
 
 const countSnapshotPairChangeStats = (
   firstSnapshot: EditUndoSnapshot,
   latestSnapshot: EditUndoSnapshot,
-): { addedLines: number; removedLines: number } => {
+): FileChangeStats => {
   let byLatest = snapshotPairChangeStatsCache.get(firstSnapshot)
   if (!byLatest) {
     byLatest = new WeakMap()
@@ -392,12 +440,13 @@ export const collectGroupEditSummary = (
       value.latestToolCallId,
       path,
     )
-    const counts =
+    const counts: FileChangeStats =
       firstSnapshot && latestSnapshot
         ? countSnapshotPairChangeStats(firstSnapshot, latestSnapshot)
         : {
             addedLines: value.addedLines,
             removedLines: value.removedLines,
+            lineStatsAvailable: value.lineStatsAvailable,
           }
     const operation =
       firstSnapshot && latestSnapshot
@@ -412,7 +461,9 @@ export const collectGroupEditSummary = (
       addedLines: counts.addedLines,
       removedLines: counts.removedLines,
       operation,
-      lineStatsAvailable: value.lineStatsAvailable,
+      // 累计统计是重算的，它自己的可用性说了算；只有在拿不到快照、退回逐次
+      // 数字时，才沿用逐次统计聚合出来的可用性。
+      lineStatsAvailable: counts.lineStatsAvailable,
       undoStatus: aggregateUndoStatus(value.statuses),
       firstRoundId: value.firstRoundId,
       latestRoundId: value.latestRoundId,

--- a/src/utils/chat/editSummary.ts
+++ b/src/utils/chat/editSummary.ts
@@ -44,6 +44,8 @@ export type GroupEditSummary = {
   totalFiles: number
   totalAddedLines: number
   totalRemovedLines: number
+  /** 见 `ToolEditSummary.totalLineStatsAvailable`。false 时不展示合计行数。 */
+  totalLineStatsAvailable: boolean
   undoStatus: ToolEditUndoStatus
   hasUndoableFiles: boolean
 }
@@ -289,6 +291,8 @@ export const createToolEditSummary = ({
     totalFiles: 1,
     totalAddedLines: addedLines,
     totalRemovedLines: removedLines,
+    // 单文件摘要的合计就是这个文件本身，文件的行数算不出来，合计也就无从谈起。
+    totalLineStatsAvailable: lineStatsAvailable,
     undoStatus: deriveToolEditUndoStatus(files),
   }
 }
@@ -478,6 +482,12 @@ export const collectGroupEditSummary = (
     totalFiles: files.length,
     totalAddedLines: files.reduce((sum, file) => sum + file.addedLines, 0),
     totalRemovedLines: files.reduce((sum, file) => sum + file.removedLines, 0),
+    // 合计是逐文件求和，所以只要有一个文件的行数没算出来，合计就是残缺的。
+    // 注意不能用 files.every(lineStatsAvailable)：只报告整轮 insertions/deletions
+    // 的 provider（Claude CLI）把每个文件标成不可用，合计却是准确的。
+    totalLineStatsAvailable: entries.every(
+      ({ summary }) => summary.totalLineStatsAvailable !== false,
+    ),
     undoStatus,
     hasUndoableFiles: entries.some(({ summary }) =>
       summary.files.some((file) => file.undoStatus === 'available'),

--- a/src/utils/chat/editSummary.ts
+++ b/src/utils/chat/editSummary.ts
@@ -16,7 +16,10 @@ import type {
 } from '../../types/tool-call.types'
 import { ToolCallResponseStatus } from '../../types/tool-call.types'
 
-import { editUndoSnapshotStore } from './editUndoSnapshotStore'
+import {
+  type EditUndoSnapshot,
+  editUndoSnapshotStore,
+} from './editUndoSnapshotStore'
 
 export type GroupEditSummaryEntry = {
   toolMessageId: string
@@ -45,10 +48,29 @@ export type GroupEditSummary = {
   hasUndoableFiles: boolean
 }
 
+/**
+ * 行数统计跑在主线程上，产出的只是聊天卡片上的 `+N/-M`。
+ *
+ * vscode-diff 把 `maxComputationTimeMs: 0` 解释为「不限时」
+ * （`advancedLinesDiffComputer.js` → `InfiniteTimeout`），而 Myers 是
+ * O(N·D)：改动行数接近总行数时退化成 O(N²)。实测「4000 行、前一半全部重写」
+ * 这种输入不限时要 13 秒，期间整个 Obsidian 主线程（连窗口按钮）都冻结。
+ *
+ * 注意这个值不是耗时上界：vscode-diff 只在算法的检查点上看时间，两次检查之间
+ * 有一整段不可中断的工作。同一输入下把上限设成 25ms 和设成 200ms 实耗几乎一样
+ * （都是那一段的长度，实测约 115ms），所以它的作用是「从不限时变成有限」，而不是
+ * 「压到 100ms 以内」。取 100ms 是取一个足够宽松的值，让值得精确统计的常规改动
+ * （300~2000 行的编辑实测 3~32ms）绝不会被截断。
+ *
+ * 超时后 vscode-diff 是按区段降级而不是整体放弃，行数统计因此几乎不受影响：
+ * 上面那个输入在有上限时仍然给出与不限时完全相同的 +2000/-2000。
+ */
+const LINE_STATS_MAX_COMPUTATION_MS = 100
+
 const LINE_DIFF_OPTIONS: ILinesDiffComputerOptions = {
   ignoreTrimWhitespace: false,
   computeMoves: false,
-  maxComputationTimeMs: 0,
+  maxComputationTimeMs: LINE_STATS_MAX_COMPUTATION_MS,
 }
 
 export const countChangedLines = (
@@ -145,6 +167,23 @@ export const deriveToolEditUndoStatus = (
   return 'partial'
 }
 
+/**
+ * 内容是否真的变了——`createToolEditSummary` 返回 `undefined` 的判据。
+ * 单独导出是为了让调用方在不需要行数的路径上先判断，而不必为了拿这个布尔值
+ * 去跑一次全文 diff。
+ */
+export const hasFileContentChanged = ({
+  beforeContent,
+  afterContent,
+  beforeExists = true,
+  afterExists = true,
+}: {
+  beforeContent: string
+  afterContent: string
+  beforeExists?: boolean
+  afterExists?: boolean
+}): boolean => !(beforeExists === afterExists && beforeContent === afterContent)
+
 export const createToolEditSummary = ({
   path,
   beforeContent,
@@ -152,6 +191,7 @@ export const createToolEditSummary = ({
   beforeExists = true,
   afterExists = true,
   reviewRoundId,
+  counts,
 }: {
   path: string
   beforeContent: string
@@ -159,17 +199,31 @@ export const createToolEditSummary = ({
   beforeExists?: boolean
   afterExists?: boolean
   reviewRoundId?: string
+  /**
+   * 已经算好的行数。调用方手上已有统计结果时传进来，避免为同一份内容重复跑
+   * 一次全文 diff。
+   */
+  counts?: { addedLines: number; removedLines: number }
 }): ToolEditSummary | undefined => {
-  if (beforeExists === afterExists && beforeContent === afterContent) {
+  if (
+    !hasFileContentChanged({
+      beforeContent,
+      afterContent,
+      beforeExists,
+      afterExists,
+    })
+  ) {
     return undefined
   }
 
-  const { addedLines, removedLines } = countFileChangeStats({
-    beforeContent,
-    afterContent,
-    beforeExists,
-    afterExists,
-  })
+  const { addedLines, removedLines } =
+    counts ??
+    countFileChangeStats({
+      beforeContent,
+      afterContent,
+      beforeExists,
+      afterExists,
+    })
 
   const files: ToolEditSummaryFile[] = [
     {
@@ -214,6 +268,48 @@ const aggregateUndoStatus = (
   }
 
   return 'partial'
+}
+
+/**
+ * 一对 undo 快照之间的净增删行数。
+ *
+ * 这是渲染路径上的计算：`collectGroupEditSummary` 由消息组的 `useMemo` 调用，
+ * agent 运行期间每次工具调用的发起/返回、每次正文落盘都会让消息组重渲染，而
+ * 每次重渲染都要把该组「至今编辑过的所有文件」重新统计一遍——代价是
+ * 轮次 × 文件数 × 单次 diff，运行越久越重。
+ *
+ * 快照按 toolCallId 建立后不再变更，所以同一对快照的结果是常量，缓存即可。
+ * 用嵌套 WeakMap 是为了让缓存随快照一起被回收：`editUndoSnapshotStore` 清空
+ * 或删除某次编辑时，对应的缓存自然失效，不需要另写一套失效逻辑。
+ */
+const snapshotPairChangeStatsCache = new WeakMap<
+  EditUndoSnapshot,
+  WeakMap<EditUndoSnapshot, { addedLines: number; removedLines: number }>
+>()
+
+const countSnapshotPairChangeStats = (
+  firstSnapshot: EditUndoSnapshot,
+  latestSnapshot: EditUndoSnapshot,
+): { addedLines: number; removedLines: number } => {
+  let byLatest = snapshotPairChangeStatsCache.get(firstSnapshot)
+  if (!byLatest) {
+    byLatest = new WeakMap()
+    snapshotPairChangeStatsCache.set(firstSnapshot, byLatest)
+  }
+
+  const cached = byLatest.get(latestSnapshot)
+  if (cached) {
+    return cached
+  }
+
+  const counts = countFileChangeStats({
+    beforeContent: firstSnapshot.beforeContent,
+    afterContent: latestSnapshot.afterContent,
+    beforeExists: firstSnapshot.beforeExists,
+    afterExists: latestSnapshot.afterExists,
+  })
+  byLatest.set(latestSnapshot, counts)
+  return counts
 }
 
 export const collectGroupEditSummary = (
@@ -298,12 +394,7 @@ export const collectGroupEditSummary = (
     )
     const counts =
       firstSnapshot && latestSnapshot
-        ? countFileChangeStats({
-            beforeContent: firstSnapshot.beforeContent,
-            afterContent: latestSnapshot.afterContent,
-            beforeExists: firstSnapshot.beforeExists,
-            afterExists: latestSnapshot.afterExists,
-          })
+        ? countSnapshotPairChangeStats(firstSnapshot, latestSnapshot)
         : {
             addedLines: value.addedLines,
             removedLines: value.removedLines,


### PR DESCRIPTION
## 问题

用户反馈：agent 写完文件后整个 Obsidian 卡死，界面任何元素都点不动，连窗口的最小化和关闭按钮都没反应，只能等 agent 跑完才恢复。

## 根因

不是 agent 卡住了，是主线程被同步的全文 diff 反复占满。一条贯穿多处的模式：**手上已有精确信息，却丢掉去跑无上限的全文 diff，而且反复跑**。

关键事实：`vscode-diff` 把 `maxComputationTimeMs: 0` 解释为「不限时」，而 Myers 是 O(N·D)，改动行数接近总行数时退化成 O(N²)。更麻烦的是，**时间上限只管得住一半**——它只给「两侧合计 < 1700 行」的 dynamic-programming 路径传了 timeout，更大的输入走 `myersDiffingAlgorithm.compute(sequence1, sequence2)`，没有 timeout 参数：

```js
if (sequence1.length + sequence2.length < 1700) {
    return this.dynamicProgrammingDiffing.compute(sequence1, sequence2, timeout, ...)  // 传了
}
return this.myersDiffingAlgorithm.compute(sequence1, sequence2);                        // 没传
```

实测单次代价（裸 node，Obsidian 环境相当）：

| 输入 | 不限时耗时 |
|---|---|
| 58KB 中文长段落文档全量改写 | 242 ms |
| 4000 行、前一半重写 | 13 秒 |
| 10000 行全量重写 | 1.6 秒 |
| 20000 行全量重写 | 17.7 秒 |

而这个计算被调用的次数是失控的：

1. **每次写文件 2 次**——`createToolEditSummary` 算一次，`upsertEditReviewSnapshot` 对同样的内容再算一次，而第一次的数字随后被第二次整个覆盖，只有「内容变没变」这个布尔值被用到。
2. **每次消息组重渲染 × 每个被编辑文件 1 次**——`collectGroupEditSummary` 由 `useMemo` 调用，agent 运行期间每次工具调用的发起/返回、每次正文落盘都会重渲染，每次都把该组至今编辑过的所有文件重新统计一遍。代价是 `轮次 × 文件数 × 单次 diff`，运行越久越重。
3. **每次 fs_edit 走审批 1 次**——`openApplyReview` 无条件先跑一次全量 diff，只为判断「评审会不会是空的」，而精确的编辑范围 `reviewEdits` 本就在参数里（overlay 自己就在用它，压根不做 diff）。`fs_edit` 的文件上限是 16MB。

这些全在 renderer 主线程；Obsidian 桌面端自绘标题栏，所以连窗口按钮也归它管；agent 的网络回调同样在主线程排队，于是表现就是「UI 全死、agent 却还在慢慢跑，跑完才恢复」。

## 改动

**消除重复计算**
- `collectGroupEditSummary` 的累计 diff 按快照对做记忆化。快照按 toolCallId 建立后不可变，同一对内容只需算一次；用嵌套 WeakMap，缓存随快照一起回收，不需要另写失效逻辑。
- `buildFileChangeSummary` 先取 review 快照再用它的数字建摘要，那次「算完就被覆盖」的 diff 不再发生。判据抽成 `hasFileContentChanged`。
- `openApplyReview` 的预检复用已有的 `reviewEdits`，与 overlay 构造时同一套取法，正常的 fs_edit 评审路径从此完全不做全量 diff。
- 快照补齐 effect 逐个调用 `readEditReviewSnapshot`，把整个会话的快照库（含每个文件前后全文，可达数 MB）读盘并 `JSON.parse` 了 2×N 遍，改用一次读取。

**给失控的计算兜底**
- 行数统计加时间上限，并在单侧超过 2000 行时直接不统计（时间上限管不住行对齐）。纯创建/纯删除只需数行，不受此限。
- 读取 `hitTimeout`：它只说明结果是近似的，没说近似到什么程度——超时若发生在行对齐完成之前，`vscode-diff` 会退化成「整份文件全部替换」，把只改一行的编辑报成全删全增。宁可不给数字，也不给一个看起来精确的错数字。
- 评审的 snapshot diff 单侧超过 5000 行时退化成整篇替换的单个 edit，段落拆分照常生效（实测 5001 行全量重写从十几秒降到 12ms，评审计划仍可完整还原）。

**让「统计不可用」在 UI 上真正生效**

复用已有的 `lineStatsAvailable`（`AssistantEditSummary` 在它为 false 时本就不渲染 `+N/-M`），并补上 `totalLineStatsAvailable`：卡片标题的合计是逐文件求和，算不出行数的文件贡献 0，会把残缺的和冒充成完整合计。合计的可用性不能用 `files.every()` 推导——只报告整轮 insertions/deletions 的 provider（Claude CLI）把每个文件都标成不可用，合计却是准确的。

## 用户可见的变化

除性能外只有一处：**超大文件（单侧超过 2000 行）的编辑不再显示 `+N/-M`**。撤销和评审都不受影响。这是有意的——在那个规模上，与其显示一个可能严重失真的数字，不如不显示。

## 验证

- `npm run type:check` / `npm run lint:check` 干净
- 全量 Jest：461 套件通过（本地 worktree 的 node_modules 缺 `just-bash`，两个 bash engine 套件因模块解析失败，与本改动无关）
- 新增测试覆盖：规模上限、超时降级、纯创建/删除豁免、记忆化不串味、合计可用性的两种语义、批量读盘只读一次、评审超限退化后仍可还原

## 尚未处理

`openApplyReview` 的预检与 `InlineDiffReviewOverlay` 各自构建一次评审计划，两者口径本就不完全一致（预检用 `state.originalContent`，overlay 用编辑器实时内容），applied-review 路径上会连续构建两次同样的 diff。这是评审入口的既有结构问题，本 PR 只消掉了 agent 热路径的那次 diff，没有动双重构建。正确的修法是让两者共用同一份计划，或取消预检、让 overlay 自己处理空计划并自动关闭——建议另开一轮。

Refs #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
