### PR TITLE
feat(cli): add Grok subscription runtime via ACP

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 
 - **`1.6`**
   - **On-device local embedding models and multiple knowledge bases**: index without any API key, split and manage knowledge bases independently, and let the Agent auto-pick the right one by name.
-  - **CLI chat**: on desktop, drive the Claude Code, Codex, Hermes, or Pi CLI you're already signed into from the same chat surface.
+  - **CLI chat**: on desktop, drive the Claude Code, Codex, Hermes, Pi, or Grok CLI you're already signed into from the same chat surface. Grok reuses an official Grok Build CLI login; it does not reuse an xAI API key.
   - **The new Learning Mode**: turn any topic and reference material into a personalized learning project with structured outlines, knowledge points, flashcards, and an interactive knowledge map, backed by FSRS spaced repetition and Anki `.apkg` import for sustainable long-term review.
 
 - **`1.5`**: Introduces a new Agent runtime that turns AI from Q&A into active collaboration—with full tool calling, MCP, Skills, desktop Bash, subagents, and web search—plus smarter long-session context and memory, refreshed hybrid RAG, focus/PDF awareness, and multi-window chat with background Agents.
@@ -78,7 +78,7 @@
 | A Complete Agent Experience \| Use Codex / Claude Code Inside Obsidian | Turn Vault Knowledge into Lasting Mastery |
 |:--:|:--:|
 | ![Agent Tools](./assets/agenttools.gif) | ![Learning Mode](./assets/learning-mode.gif) |
-| Go beyond answers. YOLO understands and works directly with your Vault, calls tools and MCP servers, and uses Skills to get real work done your way. On desktop, switch in one click to the Claude Code or Codex you are already signed in to and let them work directly in your Vault. | Turn topics and source material into a personal learning system, then use flashcards and FSRS-powered review to move from saved notes to lasting knowledge. |
+| Go beyond answers. YOLO understands and works directly with your Vault, calls tools and MCP servers, and uses Skills to get real work done your way. On desktop, switch in one click to a supported CLI agent you are already signed in to and let it work directly in your Vault. | Turn topics and source material into a personal learning system, then use flashcards and FSRS-powered review to move from saved notes to lasting knowledge. |
 
 ## Features
 
@@ -86,7 +86,7 @@ Beyond the core capabilities above, YOLO also provides:
 
 | Feature | Description |
 |---------|-------------|
-| 🖥️ CLI Agent (Desktop) | Reuse the Claude Code / Codex you are already signed in to locally, and chat with the CLI agent right inside Obsidian |
+| 🖥️ CLI Agent (Desktop) | Reuse a supported locally signed-in CLI agent, including Claude Code, Codex, Hermes, Pi, and Grok, right inside Obsidian |
 | 🔌 External Agent Support | Connect MCP clients such as Hermes and OpenClaw to YOLO's Vault search, or delegate tasks to a configured YOLO Agent |
 | ⚡ Quick Ask | Ask, edit, and continue writing without leaving the editor |
 | 🔎 Vault RAG | Retrieve across your Vault for answers grounded in your own notes |
@@ -104,6 +104,8 @@ Beyond the core capabilities above, YOLO also provides:
 3. Configure your API key in plugin settings, or use your own ChatGPT OAuth / Gemini OAuth:
    - [OpenAI](https://platform.openai.com/api-keys) / [Anthropic](https://console.anthropic.com/settings/keys) / [Gemini](https://aistudio.google.com/apikey) / [Groq](https://console.groq.com/keys)
 4. Open the sidebar to start chatting — or try Quick Ask by typing `@` in the editor
+
+For Grok subscription CLI chat on desktop, install [Grok Build](https://docs.x.ai/build) and run `grok login` (or `grok login --device-auth`) in a terminal first. YOLO asks the official CLI to reuse that cached login and does not copy its OAuth tokens into the Vault. The plugin starts a dedicated Grok ACP process in its default ask-first permission mode; YOLO auto-approval is not offered for this runtime.
 
 ## Installation
 

--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -1932,6 +1932,7 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
         skipImageModelCapabilityCheck={
           mainInputCapabilities.skipsImageModelCapabilityCheck
         }
+        allowImageAttachments={mainInputCapabilities.supportsImageAttachments}
         skillEntries={isCliRuntimeActive ? cliSkillEntries : undefined}
         modelId={conversationModelId}
         onModelChange={handleMainInputModelChange}
@@ -1996,6 +1997,7 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
         onYoloChange={
           isCliRuntimeActive ? handleCliYoloChange : handleYoloChange
         }
+        showYoloToggle={mainInputCapabilities.showsYoloToggle}
         onEditorKeyDown={handleClaudePlanShortcut}
         allowAgentModeOption
         enableResize

--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -1019,6 +1019,7 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
           buildEnvironmentContext: () =>
             buildCliEnvironmentContext({
               app,
+              runtimeId: activeRuntimeId,
               settings,
               currentFile: activeFile,
               currentFileViewState: activeViewState,

--- a/src/components/chat-view/ChatListDropdown.test.tsx
+++ b/src/components/chat-view/ChatListDropdown.test.tsx
@@ -238,6 +238,10 @@ describe('ChatListDropdown', () => {
           runtimeId: 'codex',
           nativeSessionId: 'thread-1',
         }),
+        chat('grok', 'Grok task', {
+          runtimeId: 'grok',
+          nativeSessionId: 'session-grok',
+        }),
       ]),
     )
     const html = rows
@@ -257,7 +261,10 @@ describe('ChatListDropdown', () => {
     expect(html).toContain('aria-label="Claude Code"')
     expect(html).toContain('data-runtime-id="codex"')
     expect(html).toContain('>Codex<')
-    expect(html.match(/data-runtime-id=/g)).toHaveLength(2)
+    expect(html).toContain('data-runtime-id="grok"')
+    expect(html).toContain('>Grok<')
+    expect(html).not.toContain('aria-label="Codex">Grok')
+    expect(html.match(/data-runtime-id=/g)).toHaveLength(3)
   })
 
   // issue #567 Step 3：删除图标从「更多」展开组移回常驻行内图标，顺序为

--- a/src/components/chat-view/ChatListDropdown.tsx
+++ b/src/components/chat-view/ChatListDropdown.tsx
@@ -539,10 +539,7 @@ function TitleInput({
 function ChatRuntimeBadge({ runtimeId }: { runtimeId: CliRuntimeId }) {
   const { t } = useLanguage()
   const descriptor = getCliRuntimeDescriptor(runtimeId)
-  const fullLabel = t(
-    descriptor.labelKey,
-    runtimeId === 'claude-code' ? 'Claude Code' : 'Codex',
-  )
+  const fullLabel = t(descriptor.labelKey, descriptor.defaultLabel)
 
   return (
     <span

--- a/src/components/chat-view/CliChatSurface.tsx
+++ b/src/components/chat-view/CliChatSurface.tsx
@@ -981,15 +981,15 @@ export function CliChatSurface({
         emptyStateWorkspaceTitle={emptyStateWorkspaceTitle}
         emptyStateAskDescription={t(
           'chat.cliSurface.emptyDescription',
-          '连接 Claude Code 或 Codex，直接在本机执行复杂任务',
+          '连接受支持的 CLI Agent，直接在本机执行复杂任务',
         )}
         emptyStateAgentDescription={t(
           'chat.cliSurface.emptyDescription',
-          '连接 Claude Code 或 Codex，直接在本机执行复杂任务',
+          '连接受支持的 CLI Agent，直接在本机执行复杂任务',
         )}
         emptyStateAgentFullDescription={t(
           'chat.cliSurface.emptyDescription',
-          '连接 Claude Code 或 Codex，直接在本机执行复杂任务',
+          '连接受支持的 CLI Agent，直接在本机执行复杂任务',
         )}
         emptyStateIcon={<SquareTerminal size={18} strokeWidth={2} />}
         emptyStateIconMode="cli"

--- a/src/components/chat-view/RuntimeSelector.test.tsx
+++ b/src/components/chat-view/RuntimeSelector.test.tsx
@@ -14,6 +14,8 @@ jest.mock('../../contexts/language-context', () => ({
           'sidebar.runtimeSelector.hermesDescription': 'Hermes on this device',
           'sidebar.runtimeSelector.piLabel': 'pi',
           'sidebar.runtimeSelector.piDescription': 'pi on this device',
+          'sidebar.runtimeSelector.grokLabel': 'Grok',
+          'sidebar.runtimeSelector.grokDescription': 'Grok on this device',
         }) as Record<string, string>
       )[key] ?? key,
   }),
@@ -34,6 +36,10 @@ jest.mock('../../assets/provider-icons/hermes.svg', () => ({
 jest.mock('../../assets/provider-icons/pi.svg', () => ({
   __esModule: true,
   default: 'pi-logo',
+}))
+jest.mock('../../assets/provider-icons/xai.svg', () => ({
+  __esModule: true,
+  default: 'xai-logo',
 }))
 
 import { Platform } from 'obsidian'
@@ -58,12 +64,14 @@ describe('RuntimeSelector', () => {
       'codex',
       'hermes',
       'pi',
+      'grok',
     ])
     expect(resolveAvailableRuntimeId('yolo', true)).toBeUndefined()
     expect(resolveAvailableRuntimeId('claude-code', true)).toBe('claude-code')
     expect(resolveAvailableRuntimeId('codex', true)).toBe('codex')
     expect(resolveAvailableRuntimeId('hermes', true)).toBe('hermes')
     expect(resolveAvailableRuntimeId('pi', true)).toBe('pi')
+    expect(resolveAvailableRuntimeId('grok', true)).toBe('grok')
   })
 
   it('exposes no provider without desktop capability', () => {
@@ -100,6 +108,18 @@ describe('RuntimeSelector', () => {
 
     expect(html).toContain('src="anthropic-logo"')
     expect(html).toContain('data-provider="anthropic"')
+  })
+
+  it('renders Grok with the xAI brand asset', () => {
+    Platform.isDesktop = true
+
+    const html = renderToStaticMarkup(
+      <RuntimeSelector currentRuntimeId="grok" onRuntimeChange={() => {}} />,
+    )
+
+    expect(html).toContain('aria-label="CLI provider: Grok"')
+    expect(html).toContain('src="xai-logo"')
+    expect(html).toContain('data-provider="xai"')
   })
 
   it('renders no runtime entry on mobile even with a stale CLI selection', () => {

--- a/src/components/chat-view/RuntimeSelector.tsx
+++ b/src/components/chat-view/RuntimeSelector.tsx
@@ -172,7 +172,7 @@ export function RuntimeSelector({
 
   const availableOptions = getRuntimeSelectorOptions(cliRuntimeAvailable)
   const currentOption = getCliRuntimeDescriptor(currentRuntimeId)
-  const currentLabel = t(currentOption.labelKey)
+  const currentLabel = t(currentOption.labelKey, currentOption.defaultLabel)
   const accessibleLabel = t('sidebar.runtimeSelector.accessibleLabel').replace(
     '{runtime}',
     currentLabel,
@@ -262,7 +262,7 @@ export function RuntimeSelector({
                 </span>
                 <span className="yolo-runtime-selector__option-copy">
                   <span className="yolo-runtime-selector__option-label">
-                    {t(option.labelKey)}
+                    {t(option.labelKey, option.defaultLabel)}
                   </span>
                   <span className="yolo-runtime-selector__option-description">
                     {t(option.descriptionKey)}

--- a/src/components/chat-view/ViewToggle.tsx
+++ b/src/components/chat-view/ViewToggle.tsx
@@ -56,7 +56,7 @@ const ViewToggle: React.FC<ViewToggleProps> = ({
       label: cliLabel,
       description: t(
         'sidebar.runtimeSelector.cliDescription',
-        'Claude Code or Codex on this device',
+        'Use a supported CLI agent on this device',
       ),
       icon: <SquareTerminal size={14} strokeWidth={2} />,
     },

--- a/src/components/chat-view/chat-input/ChatModeSelect.test.ts
+++ b/src/components/chat-view/chat-input/ChatModeSelect.test.ts
@@ -8,6 +8,7 @@ import {
   chatModeForSave,
   isChatMode,
   isModuleChatMode,
+  isYoloModeActive,
   narrowToMentionChatMode,
   normalizePersistedChatMode,
   resolveEffectiveChatMode,
@@ -33,6 +34,12 @@ describe('ChatModeSelect runtime options', () => {
     expect(shouldShowYoloToggle(availableModes, 'module:learning:chat')).toBe(
       false,
     )
+  })
+
+  it('does not present persisted YOLO state as active when the control is unavailable', () => {
+    expect(isYoloModeActive(false, 'agent', true)).toBe(false)
+    expect(isYoloModeActive(true, 'agent', true)).toBe(true)
+    expect(isYoloModeActive(true, 'plan', true)).toBe(false)
   })
 })
 

--- a/src/components/chat-view/chat-input/ChatModeSelect.tsx
+++ b/src/components/chat-view/chat-input/ChatModeSelect.tsx
@@ -84,6 +84,12 @@ export const shouldShowYoloToggle = (
 ): boolean =>
   availableModes.includes('agent') && mode !== 'plan' && !isModuleChatMode(mode)
 
+export const isYoloModeActive = (
+  showYoloControl: boolean,
+  mode: ChatModeSelectOptionValue,
+  yoloEnabled: boolean,
+): boolean => showYoloControl && isAgentChatMode(mode) && yoloEnabled
+
 export const isChatMode = (value: string): value is ChatMode =>
   value === 'ask' || value === 'agent' || isModuleChatMode(value)
 
@@ -469,7 +475,7 @@ export const ChatModeSelect = forwardRef<
         focusByDelta(-1)
       }
     }
-    const isYoloActive = isAgentChatMode(mode) && yoloEnabled
+    const isYoloActive = isYoloModeActive(showYoloControl, mode, yoloEnabled)
 
     return (
       <DropdownMenu.Root open={isOpen} onOpenChange={handleOpenChange}>

--- a/src/components/chat-view/chat-input/ChatUserInput.cli.test.tsx
+++ b/src/components/chat-view/chat-input/ChatUserInput.cli.test.tsx
@@ -59,6 +59,7 @@ jest.mock('./MessageInputCore', () => ({
         models: unknown[]
         enableSkills: boolean
         enableAttachments: boolean
+        allowImageAttachments: boolean
         skipImageModelCapabilityCheck: boolean
         mentionables: unknown[]
         selectedSkills: unknown[]
@@ -70,6 +71,7 @@ jest.mock('./MessageInputCore', () => ({
         data-model-count={props.models.length}
         data-skills-enabled={String(props.enableSkills)}
         data-attachments-enabled={String(props.enableAttachments)}
+        data-image-attachments-allowed={String(props.allowImageAttachments)}
         data-skip-image-model-check={String(
           props.skipImageModelCapabilityCheck,
         )}
@@ -91,11 +93,21 @@ jest.mock('./ReasoningSelect', () => ({
 
 jest.mock('./ChatModeSelect', () => ({
   ...jest.requireActual('./ChatModeSelect'),
-  ChatModeSelect: () => <span data-control="chat-mode" />,
+  ChatModeSelect: ({ showYoloToggle }: { showYoloToggle?: boolean }) => (
+    <span
+      data-control="chat-mode"
+      data-show-yolo-toggle={String(showYoloToggle)}
+    />
+  ),
 }))
 
 jest.mock('./FileUploadButton', () => ({
-  FileUploadButton: () => <button data-control="attachment" />,
+  FileUploadButton: ({ allowImages }: { allowImages?: boolean }) => (
+    <button
+      data-control="attachment"
+      data-image-files-allowed={String(allowImages)}
+    />
+  ),
 }))
 
 jest.mock('./SubmitButton', () => ({
@@ -165,5 +177,37 @@ describe('ChatUserInput CLI capabilities', () => {
 
     expect(html).toContain('add references')
     expect(html).not.toContain('add references or models')
+  })
+
+  it('passes through a runtime capability that hides the YOLO toggle', () => {
+    const html = renderToStaticMarkup(
+      <ChatUserInput
+        {...baseProps}
+        mentionables={[]}
+        selectedSkills={[]}
+        chatMode="agent"
+        onChatModeChange={jest.fn()}
+        showYoloToggle={false}
+      />,
+    )
+
+    expect(html).toContain('data-control="chat-mode"')
+    expect(html).toContain('data-show-yolo-toggle="false"')
+  })
+
+  it('disables image files while retaining the general attachment control', () => {
+    const html = renderToStaticMarkup(
+      <ChatUserInput
+        {...baseProps}
+        mentionables={[]}
+        selectedSkills={[]}
+        allowImageAttachments={false}
+      />,
+    )
+
+    expect(html).toContain('data-attachments-enabled="true"')
+    expect(html).toContain('data-image-attachments-allowed="false"')
+    expect(html).toContain('data-control="attachment"')
+    expect(html).toContain('data-image-files-allowed="false"')
   })
 })

--- a/src/components/chat-view/chat-input/ChatUserInput.tsx
+++ b/src/components/chat-view/chat-input/ChatUserInput.tsx
@@ -118,6 +118,7 @@ export type ChatUserInputProps = {
   moduleModeOptions?: readonly ModuleChatModeOption[]
   yoloEnabled?: boolean
   onYoloChange?: (enabled: boolean) => void
+  showYoloToggle?: boolean
   controlLayout?: ChatUserInputControlLayout
   onControlPopoverOpenChange?: (isOpen: boolean) => void
   allowAgentModeOption?: boolean
@@ -149,6 +150,7 @@ export type ChatUserInputProps = {
   quickAccessSkillEntries?: LiteSkillEntry[]
   quickAccessSnippetEntries?: SnippetEntry[]
   skipImageModelCapabilityCheck?: boolean
+  allowImageAttachments?: boolean
 }
 
 const DEFAULT_INPUT_HEIGHT = 80
@@ -194,6 +196,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
       moduleModeOptions,
       yoloEnabled = false,
       onYoloChange,
+      showYoloToggle = true,
       controlLayout = 'composer-toolbar',
       onControlPopoverOpenChange,
       allowAgentModeOption = true,
@@ -210,6 +213,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
       quickAccessSkillEntries,
       quickAccessSnippetEntries,
       skipImageModelCapabilityCheck = false,
+      allowImageAttachments = true,
     },
     ref,
   ) => {
@@ -671,6 +675,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
           moduleModeOptions={moduleModeOptions}
           yoloEnabled={yoloEnabled}
           onYoloChange={onYoloChange ?? (() => {})}
+          showYoloToggle={showYoloToggle}
           side="top"
           sideOffset={8}
         />
@@ -887,6 +892,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
               displayMentionablesForDelete={effectiveMentionables}
               enableSkills={enableSkills}
               enableAttachments
+              allowImageAttachments={allowImageAttachments}
               skipImageModelCapabilityCheck={skipImageModelCapabilityCheck}
               selectedSkills={effectiveSelectedSkills}
               setSelectedSkills={enableSkills ? setSelectedSkills : undefined}
@@ -920,6 +926,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
             <div className="yolo-chat-user-input-controls">
               <div className="yolo-chat-user-input-controls__left">
                 <FileUploadButton
+                  allowImages={allowImageAttachments}
                   onUpload={(files) => coreRef.current?.uploadFiles(files)}
                 />
                 {runtimeControls ?? (
@@ -939,6 +946,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
           {!compact && controlLayout === 'composer-toolbar' && (
             <div className="yolo-chat-user-input-send-row">
               <FileUploadButton
+                allowImages={allowImageAttachments}
                 onUpload={(files) => coreRef.current?.uploadFiles(files)}
               />
               <div className="yolo-chat-user-input-send-row__right">

--- a/src/components/chat-view/chat-input/CliRuntimeControls.tsx
+++ b/src/components/chat-view/chat-input/CliRuntimeControls.tsx
@@ -37,10 +37,8 @@ export function CliRuntimeControls({
   const models = configuration?.models.length
     ? configuration.models
     : cachedModels
-  const providerName = t(
-    getCliRuntimeDescriptor(runtimeId).labelKey,
-    runtimeId === 'codex' ? 'Codex' : 'Claude Code',
-  )
+  const descriptor = getCliRuntimeDescriptor(runtimeId)
+  const providerName = t(descriptor.labelKey, descriptor.defaultLabel)
   const providerLabel = providerName.toUpperCase()
   const defaultModelLabel = t(
     'chat.cliControls.defaultModel',

--- a/src/components/chat-view/chat-input/FileUploadButton.test.tsx
+++ b/src/components/chat-view/chat-input/FileUploadButton.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+
+jest.mock('../../../contexts/language-context', () => ({
+  useLanguage: () => ({ t: (_key: string, fallback: string) => fallback }),
+}))
+
+import { FileUploadButton } from './FileUploadButton'
+
+describe('FileUploadButton', () => {
+  it('includes images for runtimes that accept them', () => {
+    const html = renderToStaticMarkup(<FileUploadButton onUpload={() => {}} />)
+
+    expect(html).toContain('accept="image/*,application/pdf')
+  })
+
+  it('keeps document attachments while excluding images for Grok', () => {
+    const html = renderToStaticMarkup(
+      <FileUploadButton allowImages={false} onUpload={() => {}} />,
+    )
+
+    expect(html).toContain('accept="application/pdf')
+    expect(html).not.toContain('image/*')
+  })
+})

--- a/src/components/chat-view/chat-input/FileUploadButton.tsx
+++ b/src/components/chat-view/chat-input/FileUploadButton.tsx
@@ -3,10 +3,15 @@ import type { ChangeEvent } from 'react'
 
 import { useLanguage } from '../../../contexts/language-context'
 
+const DOCUMENT_ACCEPT =
+  'application/pdf,.pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.docx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.pptx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.xlsx,.txt,.md,.markdown,.csv,.tsv,.json,.yaml,.yml,.xml,.log,text/plain,text/markdown,text/csv,text/tab-separated-values,application/json,application/xml,text/xml,application/yaml,text/yaml'
+
 export function FileUploadButton({
   onUpload,
+  allowImages = true,
 }: {
   onUpload: (files: File[]) => void
+  allowImages?: boolean
 }) {
   const { t } = useLanguage()
   const label = t('chat.uploadFile', '添加文件')
@@ -26,7 +31,7 @@ export function FileUploadButton({
     >
       <input
         type="file"
-        accept="image/*,application/pdf,.pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.docx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.pptx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.xlsx,.txt,.md,.markdown,.csv,.tsv,.json,.yaml,.yml,.xml,.log,text/plain,text/markdown,text/csv,text/tab-separated-values,application/json,application/xml,text/xml,application/yaml,text/yaml"
+        accept={allowImages ? `image/*,${DOCUMENT_ACCEPT}` : DOCUMENT_ACCEPT}
         multiple
         onChange={handleFileChange}
         hidden

--- a/src/components/chat-view/chat-input/MessageInputCore.tsx
+++ b/src/components/chat-view/chat-input/MessageInputCore.tsx
@@ -112,6 +112,7 @@ export type MessageInputCoreProps = {
   setSelectedSkills?: (skills: ChatSelectedSkill[]) => void
 
   enableAttachments?: boolean
+  allowImageAttachments?: boolean
   currentModel?: ChatModel | null
   skipImageModelCapabilityCheck?: boolean
 
@@ -170,6 +171,7 @@ const MessageInputCore = forwardRef<MessageInputCoreRef, MessageInputCoreProps>(
       setSelectedSkills,
 
       enableAttachments = true,
+      allowImageAttachments = true,
       currentModel = null,
       skipImageModelCapabilityCheck = false,
 
@@ -290,6 +292,15 @@ const MessageInputCore = forwardRef<MessageInputCoreRef, MessageInputCoreProps>(
 
     const handleCreateImageMentionables = useCallback(
       (mentionableImages: MentionableImage[]) => {
+        if (mentionableImages.length > 0 && !allowImageAttachments) {
+          new Notice(
+            t(
+              'chat.imageUnsupportedByRuntime',
+              'This CLI runtime does not accept image input.',
+            ),
+          )
+          return
+        }
         if (
           mentionableImages.length > 0 &&
           !skipImageModelCapabilityCheck &&
@@ -350,6 +361,7 @@ const MessageInputCore = forwardRef<MessageInputCoreRef, MessageInputCoreProps>(
         setMentionables([...mentionables, ...newMentionableImages])
       },
       [
+        allowImageAttachments,
         currentModel,
         mentionableUnitLabels,
         mentionables,

--- a/src/components/chat-view/useCliRuntimeOrchestration.ts
+++ b/src/components/chat-view/useCliRuntimeOrchestration.ts
@@ -1209,6 +1209,7 @@ export function useCliRuntimeOrchestration({
           async (isCurrent) => {
             const environmentContext = await buildCliEnvironmentContext({
               app,
+              runtimeId: activeRuntimeId,
               settings,
               currentFile: activeFile,
               currentFileViewState: activeViewState,

--- a/src/components/settings/sections/AgentCliPathSection.tsx
+++ b/src/components/settings/sections/AgentCliPathSection.tsx
@@ -117,6 +117,16 @@ export function AgentCliPathSection({ app }: AgentCliPathSectionProps) {
         )}
         placeholder="/opt/homebrew/bin/pi"
       />
+      <CliPathRow
+        app={app}
+        runtimeId="grok"
+        name={t('settings.agent.grokCliPathName', 'Grok CLI path')}
+        desc={t(
+          'settings.agent.grokCliPathDesc',
+          'Custom path to the grok executable — paste the output of "which grok" ("where grok" on Windows). Leave empty to auto-detect. Stored on this device only.',
+        )}
+        placeholder="~/.grok/bin/grok"
+      />
     </>
   )
 }

--- a/src/core/cli-runtime/acp/AcpCliRuntime.test.ts
+++ b/src/core/cli-runtime/acp/AcpCliRuntime.test.ts
@@ -179,6 +179,13 @@ const createRuntime = (agent: FakeAcpAgent, compactCommand?: string) =>
     ...(compactCommand ? { compactCommand } : {}),
   })
 
+/** Grok is the runtime whose capabilities declare `supportsImageAttachments: false`. */
+const createImagelessRuntime = (agent: FakeAcpAgent) =>
+  new AcpCliRuntime('grok', {
+    cwd: '/vault',
+    createProcess: async () => agent,
+  })
+
 const collectEvents = (runtime: AcpCliRuntime): CliRuntimeEvent[] => {
   const events: CliRuntimeEvent[] = []
   runtime.subscribe((event) => events.push(event))
@@ -415,23 +422,16 @@ describe('AcpCliRuntime', () => {
     await runtime.dispose()
   })
 
-  it('rejects image input when the ACP agent explicitly reports no image capability', async () => {
+  it('rejects image input for a runtime that declares no image attachments', async () => {
     const agent = new FakeAcpAgent()
     let promptCalled = false
-    agent.on('initialize', () => ({
-      protocolVersion: 1,
-      agentCapabilities: {
-        loadSession: true,
-        promptCapabilities: { image: false },
-      },
-    }))
     agent.on('session/new', () => ({ sessionId: 'sess-no-images' }))
     agent.on('session/prompt', () => {
       promptCalled = true
       return { stopReason: 'end_turn' }
     })
 
-    const runtime = createRuntime(agent)
+    const runtime = createImagelessRuntime(agent)
     const events = collectEvents(runtime)
     await runtime.ensureReady({})
 
@@ -452,16 +452,16 @@ describe('AcpCliRuntime', () => {
     await runtime.dispose()
   })
 
-  it('requires an explicit ACP image capability before forwarding image blocks', async () => {
+  it('rejects an image carried as a URL, which maps to a resource link rather than an image block', async () => {
     const agent = new FakeAcpAgent()
     let promptCalled = false
-    agent.on('session/new', () => ({ sessionId: 'sess-no-image-capability' }))
+    agent.on('session/new', () => ({ sessionId: 'sess-linked-image' }))
     agent.on('session/prompt', () => {
       promptCalled = true
       return { stopReason: 'end_turn' }
     })
 
-    const runtime = createRuntime(agent)
+    const runtime = createImagelessRuntime(agent)
     await runtime.ensureReady({})
 
     await expect(
@@ -469,12 +469,38 @@ describe('AcpCliRuntime', () => {
         content: [
           {
             type: 'image_url',
-            image_url: { url: 'data:image/png;base64,QUJD' },
+            image_url: { url: 'https://example.com/diagram.png' },
           },
         ],
       }),
     ).rejects.toThrow('does not support image input')
     expect(promptCalled).toBe(false)
+    await runtime.dispose()
+  })
+
+  it('forwards image blocks for an image-capable runtime even when the agent advertises no image capability', async () => {
+    const agent = new FakeAcpAgent()
+    let prompt: unknown
+    agent.on('session/new', () => ({ sessionId: 'sess-silent-capability' }))
+    agent.on('session/prompt', (message) => {
+      prompt = message.params?.prompt
+      return { stopReason: 'end_turn' }
+    })
+
+    const runtime = createRuntime(agent)
+    await runtime.ensureReady({})
+    await runtime.sendTurn({
+      content: [
+        {
+          type: 'image_url',
+          image_url: { url: 'data:image/png;base64,QUJD' },
+        },
+      ],
+    })
+
+    expect(prompt).toEqual([
+      { type: 'image', mimeType: 'image/png', data: 'QUJD' },
+    ])
     await runtime.dispose()
   })
 

--- a/src/core/cli-runtime/acp/AcpCliRuntime.test.ts
+++ b/src/core/cli-runtime/acp/AcpCliRuntime.test.ts
@@ -2,6 +2,8 @@
 import { PassThrough } from 'node:stream'
 /* eslint-enable import/no-nodejs-modules */
 
+import type { InitializeResponse } from '@agentclientprotocol/sdk'
+
 import { ToolCallResponseStatus } from '../../../types/tool-call.types'
 import type { CliRuntimeEvent } from '../types'
 
@@ -132,10 +134,11 @@ class FakeAcpAgent implements AcpProcessLike {
   }
 
   shutdownCalled = false
+  emitExitOnShutdown = true
 
   async shutdown(): Promise<void> {
     this.shutdownCalled = true
-    this.emitExit()
+    if (this.emitExitOnShutdown) this.emitExit()
   }
 
   emitExit(code: number | null = 0): void {
@@ -214,6 +217,162 @@ const createRuntimeWithRecovery = (
 }
 
 describe('AcpCliRuntime', () => {
+  it('authenticates with the selected advertised method before creating a session', async () => {
+    const agent = new FakeAcpAgent()
+    const calls: string[] = []
+    agent.on('initialize', () => {
+      calls.push('initialize')
+      return {
+        protocolVersion: 1,
+        agentCapabilities: { loadSession: true },
+        authMethods: [
+          { id: 'cached_token', name: 'Cached token' },
+          { id: 'grok.com', name: 'Grok.com' },
+        ],
+      }
+    })
+    agent.on('authenticate', (message) => {
+      calls.push('authenticate')
+      expect(message.params).toEqual({ methodId: 'cached_token' })
+      return {}
+    })
+    agent.on('session/new', () => {
+      calls.push('session/new')
+      return { sessionId: 'sess-authenticated' }
+    })
+    const host = new AcpHost({
+      runtimeId: 'hermes',
+      clientName: 'test',
+      resolveProcessOptions: async () => ({
+        command: '/bin/agent',
+        args: [],
+        cwd: '/vault',
+      }),
+      createProcess: async () => agent,
+      selectAuthMethod: (init: InitializeResponse) =>
+        init.authMethods?.find((method) => method.id === 'cached_token')?.id,
+    })
+    const runtime = new AcpCliRuntime('hermes', {
+      cwd: '/vault',
+      resolveHost: async () => host,
+    })
+
+    await runtime.ensureReady({})
+
+    expect(calls).toEqual(['initialize', 'authenticate', 'session/new'])
+    await runtime.dispose()
+  })
+
+  it('rejects an auth method that the agent did not advertise and shuts down the process', async () => {
+    const agent = new FakeAcpAgent()
+    agent.on('initialize', () => ({
+      protocolVersion: 1,
+      agentCapabilities: { loadSession: true },
+      authMethods: [{ id: 'cached_token', name: 'Cached token' }],
+    }))
+    const host = new AcpHost({
+      runtimeId: 'hermes',
+      clientName: 'test',
+      resolveProcessOptions: async () => ({
+        command: '/bin/agent',
+        args: [],
+        cwd: '/vault',
+      }),
+      createProcess: async () => agent,
+      selectAuthMethod: () => 'not-advertised',
+    })
+
+    await expect(host.ensureReady()).rejects.toThrow(
+      'selected authentication method "not-advertised" was not advertised',
+    )
+    expect(agent.shutdownCalled).toBe(true)
+    expect(
+      agent.requests.some((request) => request.method === 'authenticate'),
+    ).toBe(false)
+  })
+
+  it('shuts down the process when authentication fails without creating a session', async () => {
+    const agent = new FakeAcpAgent()
+    agent.on('initialize', () => ({
+      protocolVersion: 1,
+      agentCapabilities: { loadSession: true },
+      authMethods: [{ id: 'cached_token', name: 'Cached token' }],
+    }))
+    agent.on('authenticate', () => {
+      throw new Error('cached login expired')
+    })
+    agent.on('session/new', () => ({ sessionId: 'must-not-run' }))
+    const host = new AcpHost({
+      runtimeId: 'hermes',
+      clientName: 'test',
+      resolveProcessOptions: async () => ({
+        command: '/bin/agent',
+        args: [],
+        cwd: '/vault',
+      }),
+      createProcess: async () => agent,
+      selectAuthMethod: () => 'cached_token',
+    })
+    const runtime = new AcpCliRuntime('hermes', {
+      cwd: '/vault',
+      resolveHost: async () => host,
+    })
+
+    await expect(runtime.ensureReady({})).rejects.toThrow(
+      'cached login expired',
+    )
+    expect(agent.shutdownCalled).toBe(true)
+    expect(
+      agent.requests.some((request) => request.method === 'session/new'),
+    ).toBe(false)
+  })
+
+  it('ignores a delayed exit from an auth-failed process after a retry connects', async () => {
+    const failedAgent = new FakeAcpAgent()
+    failedAgent.emitExitOnShutdown = false
+    failedAgent.on('initialize', () => ({
+      protocolVersion: 1,
+      agentCapabilities: { loadSession: true },
+      authMethods: [{ id: 'cached_token', name: 'Cached token' }],
+    }))
+    failedAgent.on('authenticate', () => {
+      throw new Error('cached login expired')
+    })
+
+    const connectedAgent = new FakeAcpAgent()
+    connectedAgent.on('initialize', () => ({
+      protocolVersion: 1,
+      agentCapabilities: { loadSession: true },
+      authMethods: [{ id: 'cached_token', name: 'Cached token' }],
+    }))
+    connectedAgent.on('authenticate', () => ({}))
+
+    let spawnCount = 0
+    const host = new AcpHost({
+      runtimeId: 'hermes',
+      clientName: 'test',
+      resolveProcessOptions: async () => ({
+        command: '/bin/agent',
+        args: [],
+        cwd: '/vault',
+      }),
+      createProcess: async () => {
+        spawnCount += 1
+        return spawnCount === 1 ? failedAgent : connectedAgent
+      },
+      selectAuthMethod: () => 'cached_token',
+    })
+
+    await expect(host.ensureReady()).rejects.toThrow('cached login expired')
+    await expect(host.ensureReady()).resolves.toBeUndefined()
+
+    failedAgent.emitExit()
+    await expect(host.ensureReady()).resolves.toBeUndefined()
+
+    expect(spawnCount).toBe(2)
+    await host.dispose()
+  })
+
   it('starts a fresh session and streams a completed turn', async () => {
     const agent = new FakeAcpAgent()
     let sessionId = ''
@@ -253,6 +412,102 @@ describe('AcpCliRuntime', () => {
           event.message.content === 'Hello!',
       ),
     ).toBe(true)
+    await runtime.dispose()
+  })
+
+  it('rejects image input when the ACP agent explicitly reports no image capability', async () => {
+    const agent = new FakeAcpAgent()
+    let promptCalled = false
+    agent.on('initialize', () => ({
+      protocolVersion: 1,
+      agentCapabilities: {
+        loadSession: true,
+        promptCapabilities: { image: false },
+      },
+    }))
+    agent.on('session/new', () => ({ sessionId: 'sess-no-images' }))
+    agent.on('session/prompt', () => {
+      promptCalled = true
+      return { stopReason: 'end_turn' }
+    })
+
+    const runtime = createRuntime(agent)
+    const events = collectEvents(runtime)
+    await runtime.ensureReady({})
+
+    await expect(
+      runtime.sendTurn({
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,QUJD' },
+          },
+        ],
+      }),
+    ).rejects.toThrow('does not support image input')
+    expect(promptCalled).toBe(false)
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: 'run_state', state: 'running' }),
+    )
+    await runtime.dispose()
+  })
+
+  it('requires an explicit ACP image capability before forwarding image blocks', async () => {
+    const agent = new FakeAcpAgent()
+    let promptCalled = false
+    agent.on('session/new', () => ({ sessionId: 'sess-no-image-capability' }))
+    agent.on('session/prompt', () => {
+      promptCalled = true
+      return { stopReason: 'end_turn' }
+    })
+
+    const runtime = createRuntime(agent)
+    await runtime.ensureReady({})
+
+    await expect(
+      runtime.sendTurn({
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,QUJD' },
+          },
+        ],
+      }),
+    ).rejects.toThrow('does not support image input')
+    expect(promptCalled).toBe(false)
+    await runtime.dispose()
+  })
+
+  it('forwards image blocks when the ACP agent explicitly supports them', async () => {
+    const agent = new FakeAcpAgent()
+    let prompt: unknown
+    agent.on('initialize', () => ({
+      protocolVersion: 1,
+      agentCapabilities: {
+        loadSession: true,
+        promptCapabilities: { image: true },
+      },
+    }))
+    agent.on('session/new', () => ({ sessionId: 'sess-images' }))
+    agent.on('session/prompt', (message) => {
+      prompt = message.params?.prompt
+      return { stopReason: 'end_turn' }
+    })
+
+    const runtime = createRuntime(agent)
+    await runtime.ensureReady({})
+    await runtime.sendTurn({
+      content: [
+        {
+          type: 'image_url',
+          image_url: { url: 'data:image/png;base64,QUJD' },
+        },
+      ],
+    })
+
+    expect(prompt).toEqual([
+      { type: 'image', mimeType: 'image/png', data: 'QUJD' },
+    ])
     await runtime.dispose()
   })
 

--- a/src/core/cli-runtime/acp/AcpCliRuntime.ts
+++ b/src/core/cli-runtime/acp/AcpCliRuntime.ts
@@ -271,6 +271,16 @@ export class AcpCliRuntime implements CliRuntime {
       )
     }
     const host = await this.getHost()
+    const prompt = toAcpPromptBlocks(input.content)
+    const containsImage = prompt.some((block) => block.type === 'image')
+    if (
+      containsImage &&
+      host.capabilities?.promptCapabilities?.image !== true
+    ) {
+      throw new Error(
+        `${this.runtimeId} ACP agent does not support image input.`,
+      )
+    }
     const sessionId = this.activeSessionRef.nativeSessionId
     this.cancelRequested = false
     this.aggregator.beginTurn()
@@ -281,7 +291,7 @@ export class AcpCliRuntime implements CliRuntime {
       const result = await host.call((connection) =>
         connection.prompt({
           sessionId,
-          prompt: toAcpPromptBlocks(input.content),
+          prompt,
         }),
       )
       this.turnInFlight = false

--- a/src/core/cli-runtime/acp/AcpCliRuntime.ts
+++ b/src/core/cli-runtime/acp/AcpCliRuntime.ts
@@ -9,6 +9,7 @@ import {
   type ToolCallResponse,
   ToolCallResponseStatus,
 } from '../../../types/tool-call.types'
+import { RUNTIME_CAPABILITIES } from '../capabilities'
 import type {
   CliApprovalResponse,
   CliQuestionResponse,
@@ -32,6 +33,7 @@ import {
   buildCancelledApprovalOutcome,
   buildPendingApprovalMessages,
   extractAcpSessionModelState,
+  isAcpImagePromptBlock,
   mapAcpTurnUsage,
   mapAcpUsageUpdate,
   resolveApprovalOptionId,
@@ -272,14 +274,18 @@ export class AcpCliRuntime implements CliRuntime {
     }
     const host = await this.getHost()
     const prompt = toAcpPromptBlocks(input.content)
-    const containsImage = prompt.some((block) => block.type === 'image')
+    // Runtimes that declare no image attachments (Grok) must not reach the
+    // agent with one, whatever the turn content picked up on the way here —
+    // the composer refusing the attachment is the user-facing half, this is
+    // the protocol edge. Scoped to that declaration rather than to what the
+    // agent advertised: ACP leaves `promptCapabilities` optional, so its
+    // absence is not a denial, and reading it as one would break every
+    // image-capable ACP runtime whose agent stays silent.
     if (
-      containsImage &&
-      host.capabilities?.promptCapabilities?.image !== true
+      !RUNTIME_CAPABILITIES[this.runtimeId].supportsImageAttachments &&
+      prompt.some(isAcpImagePromptBlock)
     ) {
-      throw new Error(
-        `${this.runtimeId} ACP agent does not support image input.`,
-      )
+      throw new Error(`${this.runtimeId} does not support image input.`)
     }
     const sessionId = this.activeSessionRef.nativeSessionId
     this.cancelRequested = false

--- a/src/core/cli-runtime/acp/agent-profile.ts
+++ b/src/core/cli-runtime/acp/agent-profile.ts
@@ -1,3 +1,5 @@
+import type { InitializeResponse } from '@agentclientprotocol/sdk'
+
 import type { CliRuntimeId } from '../types'
 
 export type AcpResolvedCommand = Readonly<{
@@ -26,6 +28,11 @@ export type AcpAgentProfile = Readonly<{
     env: NodeJS.ProcessEnv,
     cliPathOverride?: string,
   ): Promise<AcpResolvedCommand | null>
+  /**
+   * Optional authentication policy applied after ACP initialization and
+   * before the host exposes a usable connection.
+   */
+  selectAuthMethod?(init: InitializeResponse): string | undefined
   /**
    * Slash command text this agent understands as a manual-compaction
    * trigger (e.g. Hermes's `/compress`), sent as an ordinary

--- a/src/core/cli-runtime/acp/host.ts
+++ b/src/core/cli-runtime/acp/host.ts
@@ -5,6 +5,7 @@ import type {
   AgentCapabilities,
   Client,
   ClientSideConnection,
+  InitializeResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
   SessionUpdate,
@@ -34,6 +35,13 @@ export type AcpHostOptions = Readonly<{
   /** Re-resolved right before each spawn so a later install/path-override change is picked up. */
   resolveProcessOptions: () => Promise<Omit<AcpProcessOptions, 'runtimeId'>>
   createProcess?: (options: AcpProcessOptions) => Promise<AcpProcessLike>
+  /**
+   * Optional agent-specific authentication policy. Runs after initialize and
+   * before the connection is published or any session is created. Returning
+   * undefined skips authentication; a returned method is validated against
+   * the agent's advertised methods before it is sent.
+   */
+  selectAuthMethod?: (init: InitializeResponse) => string | undefined
 }>
 
 /**
@@ -138,6 +146,11 @@ export class AcpHost {
     }
     this.process = process
     process.onExit(() => {
+      // A failed connection shuts its process down before a retry can spawn.
+      // Some process implementations report that exit asynchronously, so an
+      // old callback can arrive after the retry has already published a new
+      // process. Only the currently-owned generation may invalidate the host.
+      if (this.process !== process) return
       const stderr = process.getStderrSnapshot()
       this.handleFatal(
         new Error(
@@ -164,6 +177,19 @@ export class AcpHost {
         clientInfo: { name: this.options.clientName, version: '1.0.0' },
       })
       if (this.disposed) throw new Error('ACP host is disposed.')
+      const authMethodId = this.options.selectAuthMethod?.(init)
+      if (authMethodId) {
+        const advertised = (init.authMethods ?? []).some(
+          (method) => method.id === authMethodId,
+        )
+        if (!advertised) {
+          throw new Error(
+            `${this.options.runtimeId} selected authentication method "${authMethodId}" was not advertised by the ACP agent.`,
+          )
+        }
+        await connection.authenticate({ methodId: authMethodId })
+        if (this.disposed) throw new Error('ACP host is disposed.')
+      }
       this.agentCapabilities = init.agentCapabilities
       this.connection = connection
       // A successful (re)connect supersedes any earlier fatal state.

--- a/src/core/cli-runtime/acp/mapping.ts
+++ b/src/core/cli-runtime/acp/mapping.ts
@@ -552,6 +552,16 @@ export const toAcpPromptBlocks = (
 }
 
 /**
+ * True for every block `toAcpPromptBlocks` produces from an `image_url`
+ * part. Only base64 data URLs become an `image` block — an http(s) or
+ * `app://` image becomes a `resource_link` named `image` — so a caller that
+ * must keep images away from an agent has to match both kinds.
+ */
+export const isAcpImagePromptBlock = (block: ContentBlock): boolean =>
+  block.type === 'image' ||
+  (block.type === 'resource_link' && block.name === 'image')
+
+/**
  * Maps our three-tier approval decision onto one of the `PermissionOption`s
  * the agent offered for this specific request:
  *  - `approve_once` -> the `allow_once` option

--- a/src/core/cli-runtime/capabilities.ts
+++ b/src/core/cli-runtime/capabilities.ts
@@ -12,6 +12,8 @@ import type { ChatRuntimeId, CliRuntimeId } from './types'
 export type ChatRuntimeCapabilities = Readonly<{
   /** Shift+Tab plan-mode shortcut and plan/agent mode switching (A20). */
   supportsPlanMode: boolean
+  /** Shows the YOLO auto-approval toggle for this runtime. */
+  showsYoloToggle: boolean
   /** Needs `warmConversationRuntime` before first use (A25, codex only). */
   needsWarmup: boolean
   /** Loads provider-native skills into the skills picker (A12). */
@@ -41,6 +43,8 @@ export type ChatRuntimeCapabilities = Readonly<{
   supportsReasoningSelect: boolean
   /** Main input skips its yolo-only image/model capability check (B1). */
   skipsImageModelCapabilityCheck: boolean
+  /** Main input accepts image attachments for this runtime. */
+  supportsImageAttachments: boolean
   /** Main input allows queueing a message while a run is in flight (B1). */
   supportsQueueWhileGenerating: boolean
 }>
@@ -51,6 +55,7 @@ export const RUNTIME_CAPABILITIES: Record<
 > = {
   yolo: {
     supportsPlanMode: false,
+    showsYoloToggle: true,
     needsWarmup: false,
     hasNativeSkills: false,
     hasNativeMcpPanel: false,
@@ -63,10 +68,12 @@ export const RUNTIME_CAPABILITIES: Record<
     supportsModelControl: true,
     supportsReasoningSelect: true,
     skipsImageModelCapabilityCheck: false,
+    supportsImageAttachments: true,
     supportsQueueWhileGenerating: true,
   },
   'claude-code': {
     supportsPlanMode: true,
+    showsYoloToggle: true,
     needsWarmup: false,
     hasNativeSkills: true,
     hasNativeMcpPanel: true,
@@ -79,10 +86,12 @@ export const RUNTIME_CAPABILITIES: Record<
     supportsModelControl: false,
     supportsReasoningSelect: false,
     skipsImageModelCapabilityCheck: true,
+    supportsImageAttachments: true,
     supportsQueueWhileGenerating: false,
   },
   codex: {
     supportsPlanMode: false,
+    showsYoloToggle: true,
     needsWarmup: true,
     hasNativeSkills: true,
     hasNativeMcpPanel: true,
@@ -95,10 +104,12 @@ export const RUNTIME_CAPABILITIES: Record<
     supportsModelControl: false,
     supportsReasoningSelect: false,
     skipsImageModelCapabilityCheck: true,
+    supportsImageAttachments: true,
     supportsQueueWhileGenerating: false,
   },
   hermes: {
     supportsPlanMode: false,
+    showsYoloToggle: true,
     needsWarmup: false,
     hasNativeSkills: false,
     hasNativeMcpPanel: false,
@@ -111,10 +122,12 @@ export const RUNTIME_CAPABILITIES: Record<
     supportsModelControl: false,
     supportsReasoningSelect: false,
     skipsImageModelCapabilityCheck: true,
+    supportsImageAttachments: true,
     supportsQueueWhileGenerating: false,
   },
   pi: {
     supportsPlanMode: false,
+    showsYoloToggle: true,
     needsWarmup: false,
     hasNativeSkills: false,
     hasNativeMcpPanel: false,
@@ -133,6 +146,25 @@ export const RUNTIME_CAPABILITIES: Record<
     supportsModelControl: false,
     supportsReasoningSelect: false,
     skipsImageModelCapabilityCheck: true,
+    supportsImageAttachments: true,
+    supportsQueueWhileGenerating: false,
+  },
+  grok: {
+    supportsPlanMode: false,
+    showsYoloToggle: false,
+    needsWarmup: false,
+    hasNativeSkills: false,
+    hasNativeMcpPanel: false,
+    hasPluginManagement: false,
+    hasAssistants: false,
+    supportsMessageRewrite: false,
+    supportsContextCompaction: false,
+    supportsVaultExport: false,
+    supportsSubagentWatch: false,
+    supportsModelControl: false,
+    supportsReasoningSelect: false,
+    skipsImageModelCapabilityCheck: true,
+    supportsImageAttachments: false,
     supportsQueueWhileGenerating: false,
   },
 }

--- a/src/core/cli-runtime/coordinator.test.ts
+++ b/src/core/cli-runtime/coordinator.test.ts
@@ -113,6 +113,7 @@ const runtimeHarness = () => {
   const codexRuntimes: TestRuntime[] = []
   const hermesRuntimes: TestRuntime[] = []
   const piRuntimes: TestRuntime[] = []
+  const grokRuntimes: TestRuntime[] = []
   const createClaudeRuntime = jest.fn(() => {
     const runtime = new TestRuntime('claude-code')
     claudeRuntimes.push(runtime)
@@ -133,21 +134,29 @@ const runtimeHarness = () => {
     piRuntimes.push(runtime)
     return runtime
   })
+  const createGrokRuntime = jest.fn(() => {
+    const runtime = new TestRuntime('grok')
+    grokRuntimes.push(runtime)
+    return runtime
+  })
   const factories: CliRuntimeFactories = {
     'claude-code': { create: createClaudeRuntime },
     codex: { create: createCodexRuntime },
     hermes: { create: createHermesRuntime },
     pi: { create: createPiRuntime },
+    grok: { create: createGrokRuntime },
   }
   return {
     claudeRuntimes,
     codexRuntimes,
     hermesRuntimes,
     piRuntimes,
+    grokRuntimes,
     createClaudeRuntime,
     createCodexRuntime,
     createHermesRuntime,
     createPiRuntime,
+    createGrokRuntime,
     factories,
   }
 }
@@ -251,6 +260,12 @@ describe('CLI runtime coordinator', () => {
     expect(scope.resolveRuntime('codex')).toBe(scope.resolveRuntime('codex'))
     expect(harness.createCodexRuntime).toHaveBeenCalledTimes(1)
     expect(harness.createCodexRuntime).toHaveBeenCalledWith({
+      app,
+      vaultPath: '/vault/current',
+    })
+    expect(scope.resolveRuntime('grok')).toBe(scope.resolveRuntime('grok'))
+    expect(harness.createGrokRuntime).toHaveBeenCalledTimes(1)
+    expect(harness.createGrokRuntime).toHaveBeenCalledWith({
       app,
       vaultPath: '/vault/current',
     })

--- a/src/core/cli-runtime/coordinator.ts
+++ b/src/core/cli-runtime/coordinator.ts
@@ -8,6 +8,7 @@ import { createCliChatRuntimeActions } from './cli-actions'
 import type { CodexRuntimeOptions } from './codex/factory'
 import { createCodexRuntimeFactory } from './codex/factory'
 import { CliConversationController } from './conversation-controller'
+import { createGrokRuntimeFactory } from './grok/factory'
 import { createHermesRuntimeFactory } from './hermes/factory'
 import { type HermesProfile, discoverHermesProfiles } from './hermes/profiles'
 import { loadLoginShellEnvironment } from './login-shell-env'
@@ -116,18 +117,20 @@ const isAbsoluteFileSystemPath = (path: string): boolean =>
 const defaultLoadRuntimeFactories = async (
   deps: CliRuntimeFactoriesLoaderDeps,
 ): Promise<CliRuntimeFactories> => {
-  const [claudeFactory, codexFactory, hermesFactory, piFactory] =
+  const [claudeFactory, codexFactory, hermesFactory, piFactory, grokFactory] =
     await Promise.all([
       createClaudeRuntimeFactory(deps),
       createCodexRuntimeFactory(deps),
       createHermesRuntimeFactory(deps),
       createPiRuntimeFactory(deps),
+      createGrokRuntimeFactory(deps),
     ])
   return {
     'claude-code': claudeFactory,
     codex: codexFactory,
     hermes: hermesFactory,
     pi: piFactory,
+    grok: grokFactory,
   }
 }
 

--- a/src/core/cli-runtime/environment-context.test.ts
+++ b/src/core/cli-runtime/environment-context.test.ts
@@ -45,6 +45,7 @@ describe('buildCliEnvironmentContext', () => {
     await expect(
       buildCliEnvironmentContext({
         app,
+        runtimeId: 'hermes',
         settings,
         currentFile,
         currentFileViewState: {
@@ -74,5 +75,30 @@ describe('buildCliEnvironmentContext', () => {
       type: 'browser-context',
       app,
     })
+  })
+
+  it('drops the auto-attached image for a runtime that takes no image input', async () => {
+    mockedRenderCurrentFilePointerInjection.mockResolvedValue({
+      role: 'user',
+      content: [
+        { type: 'image_url', image_url: { url: 'data:image/png;base64,QUJD' } },
+        { type: 'text', text: '# Current Context\nFile: Notes/diagram.png' },
+      ],
+    })
+    mockedRenderBrowserContextInjection.mockResolvedValue(null)
+    const currentFile = Object.assign(new TFile(), {
+      path: 'Notes/diagram.png',
+    })
+
+    await expect(
+      buildCliEnvironmentContext({
+        app: {} as App,
+        runtimeId: 'grok',
+        settings: parseYoloSettings({}),
+        currentFile,
+      }),
+    ).resolves.toEqual([
+      { type: 'text', text: '# Current Context\nFile: Notes/diagram.png' },
+    ])
   })
 })

--- a/src/core/cli-runtime/environment-context.ts
+++ b/src/core/cli-runtime/environment-context.ts
@@ -8,8 +8,12 @@ import {
   renderCurrentFilePointerInjection,
 } from '../../utils/chat/contextual-injections'
 
+import { RUNTIME_CAPABILITIES } from './capabilities'
+import type { CliRuntimeId } from './types'
+
 export type BuildCliEnvironmentContextInput = {
   app: App
+  runtimeId: CliRuntimeId
   settings: YoloSettings
   currentFile: TFile | null
   currentFileViewState?: CurrentFileViewState
@@ -30,6 +34,7 @@ const toContentParts = (message: RequestMessage | null): ContentPart[] => {
  */
 export const buildCliEnvironmentContext = async ({
   app,
+  runtimeId,
   settings,
   currentFile,
   currentFileViewState,
@@ -48,8 +53,16 @@ export const buildCliEnvironmentContext = async ({
     renderBrowserContextInjection({ type: 'browser-context', app }),
   ])
 
-  return [
+  const parts = [
     ...toContentParts(currentFileContext),
     ...toContentParts(browserContext),
   ]
+
+  // Viewing an image file makes the current-file pointer contribute the
+  // image itself. A runtime that takes no images would fail the whole turn
+  // over context the user never attached, so drop just that part — the
+  // pointer text naming the file still goes through.
+  return RUNTIME_CAPABILITIES[runtimeId].supportsImageAttachments
+    ? parts
+    : parts.filter((part) => part.type !== 'image_url')
 }

--- a/src/core/cli-runtime/grok/auth.test.ts
+++ b/src/core/cli-runtime/grok/auth.test.ts
@@ -24,10 +24,13 @@ describe('selectGrokSubscriptionAuthMethod', () => {
     ['interactive OAuth only', [method('grok.com')]],
     ['API key only', [method('xai.api_key')]],
     ['unknown methods', [method('future-auth')]],
-    ['no methods', []],
   ])('requires a prior grok login for %s', (_label, methods) => {
     expect(() => selectGrokSubscriptionAuthMethod(methods)).toThrow(
       'Run `grok login` (or `grok login --device-auth`) in a terminal, then retry.',
     )
+  })
+
+  it('skips authentication when the agent advertises no auth methods', () => {
+    expect(selectGrokSubscriptionAuthMethod([])).toBeUndefined()
   })
 })

--- a/src/core/cli-runtime/grok/auth.test.ts
+++ b/src/core/cli-runtime/grok/auth.test.ts
@@ -1,0 +1,33 @@
+import type { AuthMethod } from '@agentclientprotocol/sdk'
+
+import { selectGrokSubscriptionAuthMethod } from './auth'
+
+const method = (id: string): AuthMethod => ({ id, name: id })
+
+describe('selectGrokSubscriptionAuthMethod', () => {
+  it('selects the cached subscription token even when interactive OAuth is also advertised', () => {
+    expect(
+      selectGrokSubscriptionAuthMethod([
+        method('grok.com'),
+        method('cached_token'),
+      ]),
+    ).toBe('cached_token')
+  })
+
+  it('selects cached_token when it is the only supported method', () => {
+    expect(selectGrokSubscriptionAuthMethod([method('cached_token')])).toBe(
+      'cached_token',
+    )
+  })
+
+  it.each([
+    ['interactive OAuth only', [method('grok.com')]],
+    ['API key only', [method('xai.api_key')]],
+    ['unknown methods', [method('future-auth')]],
+    ['no methods', []],
+  ])('requires a prior grok login for %s', (_label, methods) => {
+    expect(() => selectGrokSubscriptionAuthMethod(methods)).toThrow(
+      'Run `grok login` (or `grok login --device-auth`) in a terminal, then retry.',
+    )
+  })
+})

--- a/src/core/cli-runtime/grok/auth.ts
+++ b/src/core/cli-runtime/grok/auth.ts
@@ -10,10 +10,17 @@ const LOGIN_REQUIRED_MESSAGE =
  * and UI lifecycle that this first integration deliberately does not claim
  * to support. `xai.api_key` is also excluded so choosing the subscription
  * runtime cannot silently consume separately billed API credits.
+ *
+ * An empty list is ACP's way of saying the agent needs no authentication at
+ * all, which `AcpHost` honours by skipping the `authenticate` call — so it
+ * returns undefined rather than sending an already signed-in user off to run
+ * `grok login` again. Only a non-empty list without `cached_token` means a
+ * login is genuinely missing.
  */
 export const selectGrokSubscriptionAuthMethod = (
   methods: readonly AuthMethod[],
-): AuthMethodId => {
+): AuthMethodId | undefined => {
+  if (methods.length === 0) return undefined
   if (methods.some((method) => method.id === 'cached_token')) {
     return 'cached_token'
   }

--- a/src/core/cli-runtime/grok/auth.ts
+++ b/src/core/cli-runtime/grok/auth.ts
@@ -1,0 +1,21 @@
+import type { AuthMethod, AuthMethodId } from '@agentclientprotocol/sdk'
+
+const LOGIN_REQUIRED_MESSAGE =
+  'Grok subscription authentication is not available. Run `grok login` (or `grok login --device-auth`) in a terminal, then retry.'
+
+/**
+ * Selects only Grok's device-local cached subscription credential.
+ *
+ * Interactive `grok.com` authentication requires extra ACP extension calls
+ * and UI lifecycle that this first integration deliberately does not claim
+ * to support. `xai.api_key` is also excluded so choosing the subscription
+ * runtime cannot silently consume separately billed API credits.
+ */
+export const selectGrokSubscriptionAuthMethod = (
+  methods: readonly AuthMethod[],
+): AuthMethodId => {
+  if (methods.some((method) => method.id === 'cached_token')) {
+    return 'cached_token'
+  }
+  throw new Error(LOGIN_REQUIRED_MESSAGE)
+}

--- a/src/core/cli-runtime/grok/factory.test.ts
+++ b/src/core/cli-runtime/grok/factory.test.ts
@@ -1,0 +1,156 @@
+import type { App } from 'obsidian'
+
+import { getCliPathOverride } from '../cli-path-override'
+import { loadLoginShellEnvironment } from '../login-shell-env'
+
+import { createGrokRuntimeFactory } from './factory'
+import { resolveGrokCommand } from './resolve-command'
+
+jest.mock('../cli-path-override', () => ({
+  getCliPathOverride: jest.fn(() => '/configured/grok'),
+}))
+jest.mock('../login-shell-env', () => ({
+  loadLoginShellEnvironment: jest.fn(async () => ({ PATH: '/usr/bin' })),
+}))
+jest.mock('./resolve-command', () => ({
+  resolveGrokCommand: jest.fn(async () => ({
+    command: '/bin/grok',
+    args: [
+      '--no-auto-update',
+      '--permission-mode',
+      'default',
+      'agent',
+      '--no-leader',
+      'stdio',
+    ],
+  })),
+}))
+
+type HostPoolInstance = {
+  createOptions: (key: string) => unknown
+  acquire: jest.Mock
+  release: jest.Mock
+  dispose: jest.Mock
+}
+const hostPoolInstances: HostPoolInstance[] = []
+const AcpHostPoolMock = jest.fn(function (
+  this: HostPoolInstance,
+  createOptions: (key: string) => unknown,
+) {
+  this.createOptions = createOptions
+  this.acquire = jest.fn(async (key: string) => ({ __hostFor: key }))
+  this.release = jest.fn()
+  this.dispose = jest.fn(async () => undefined)
+  hostPoolInstances.push(this)
+})
+jest.mock('../acp/host', () => ({
+  get AcpHostPool() {
+    return AcpHostPoolMock
+  },
+}))
+
+const AcpCliRuntimeMock = jest.fn(function (
+  this: { runtimeId: string; options: unknown },
+  runtimeId: string,
+  options: unknown,
+) {
+  this.runtimeId = runtimeId
+  this.options = options
+})
+jest.mock('../acp/AcpCliRuntime', () => ({
+  get AcpCliRuntime() {
+    return AcpCliRuntimeMock
+  },
+}))
+
+const app = {} as App
+
+type CapturedRuntimeOptions = {
+  cwd: string
+  resolveHost: () => Promise<unknown>
+  releaseHost: () => void
+}
+
+describe('createGrokRuntimeFactory', () => {
+  beforeEach(() => {
+    hostPoolInstances.length = 0
+    AcpHostPoolMock.mockClear()
+    AcpCliRuntimeMock.mockClear()
+    jest.mocked(getCliPathOverride).mockClear()
+    jest.mocked(loadLoginShellEnvironment).mockClear()
+    jest.mocked(resolveGrokCommand).mockClear()
+  })
+
+  it('resolves the official ACP command for the vault on every host spawn', async () => {
+    await createGrokRuntimeFactory({ app, vaultPath: '/vault' })
+    const pool = hostPoolInstances[0]
+    const hostOptions = pool.createOptions('default') as {
+      runtimeId: string
+      clientName: string
+      resolveProcessOptions: () => Promise<unknown>
+      selectAuthMethod: (init: {
+        authMethods?: Array<{ id: string; name: string }>
+      }) => string
+    }
+
+    await expect(hostOptions.resolveProcessOptions()).resolves.toEqual({
+      command: '/bin/grok',
+      args: [
+        '--no-auto-update',
+        '--permission-mode',
+        'default',
+        'agent',
+        '--no-leader',
+        'stdio',
+      ],
+      cwd: '/vault',
+      env: { XAI_API_KEY: '', GROK_API_KEY: '' },
+    })
+    expect(hostOptions.runtimeId).toBe('grok')
+    expect(hostOptions.clientName).toBe('obsidian-yolo')
+    expect(jest.mocked(getCliPathOverride)).toHaveBeenCalledWith(app, 'grok')
+    expect(jest.mocked(resolveGrokCommand)).toHaveBeenCalledWith(
+      { PATH: '/usr/bin' },
+      process.platform,
+      '/configured/grok',
+    )
+    expect(
+      hostOptions.selectAuthMethod({
+        authMethods: [{ id: 'cached_token', name: 'Cached token' }],
+      }),
+    ).toBe('cached_token')
+  })
+
+  it('creates a Grok runtime backed by one acquired host and releases it on dispose', async () => {
+    const factory = await createGrokRuntimeFactory({
+      app,
+      vaultPath: '/vault',
+    })
+    const pool = hostPoolInstances[0]
+
+    factory.create({ app, vaultPath: '/vault' })
+    const [runtimeId, options] = AcpCliRuntimeMock.mock.calls[0] as unknown as [
+      string,
+      CapturedRuntimeOptions,
+    ]
+    expect(runtimeId).toBe('grok')
+    expect(options.cwd).toBe('/vault')
+    expect(await options.resolveHost()).toEqual({ __hostFor: 'default' })
+    expect(await options.resolveHost()).toEqual({ __hostFor: 'default' })
+    expect(pool.acquire).toHaveBeenCalledTimes(1)
+
+    options.releaseHost()
+    options.releaseHost()
+    expect(pool.release).toHaveBeenCalledTimes(1)
+    expect(pool.release).toHaveBeenCalledWith('default')
+  })
+
+  it('disposes the shared host pool', async () => {
+    const factory = await createGrokRuntimeFactory({
+      app,
+      vaultPath: '/vault',
+    })
+    await factory.dispose?.()
+    expect(hostPoolInstances[0].dispose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/core/cli-runtime/grok/factory.ts
+++ b/src/core/cli-runtime/grok/factory.ts
@@ -1,0 +1,71 @@
+import { getCliPathOverride } from '../cli-path-override'
+import { loadLoginShellEnvironment } from '../login-shell-env'
+import type { CliRuntimeFactory, CliRuntimeFactoryDeps } from '../types'
+
+import { grokAgentProfile } from './profile'
+import { resolveGrokCommand } from './resolve-command'
+
+export type GrokRuntimeFactoryDeps = CliRuntimeFactoryDeps
+
+const HOST_KEY = 'default'
+const NOT_FOUND_MESSAGE =
+  'Grok CLI was not found on this device. Install Grok Build (https://docs.x.ai/build), or set a custom CLI path in Settings → Agent, then retry.'
+
+/** Build a subscription-backed Grok runtime over the official CLI's ACP server. */
+export const createGrokRuntimeFactory = async (
+  deps: GrokRuntimeFactoryDeps,
+): Promise<CliRuntimeFactory> => {
+  const { AcpCliRuntime } = await import('../acp/AcpCliRuntime')
+  const { AcpHostPool } = await import('../acp/host')
+
+  const resolveProcessOptions = async () => {
+    const env = (await loadLoginShellEnvironment()) as NodeJS.ProcessEnv
+    const cliPathOverride = getCliPathOverride(deps.app, 'grok')
+    const resolved = await resolveGrokCommand(
+      env,
+      process.platform,
+      cliPathOverride,
+    )
+    if (!resolved) throw new Error(NOT_FOUND_MESSAGE)
+    return {
+      command: resolved.command,
+      args: resolved.args,
+      cwd: deps.vaultPath,
+      // This runtime is subscription-only. Explicitly shadow ambient API-key
+      // variables so the child process cannot switch to separately billed API
+      // authentication behind the user's cached-token selection.
+      env: { XAI_API_KEY: '', GROK_API_KEY: '' },
+    }
+  }
+
+  const hostPool = new AcpHostPool(() => ({
+    runtimeId: 'grok',
+    clientName: 'obsidian-yolo',
+    resolveProcessOptions,
+    selectAuthMethod: grokAgentProfile.selectAuthMethod,
+  }))
+
+  return {
+    create: (createDeps) => {
+      let hostPromise: ReturnType<typeof hostPool.acquire> | null = null
+      let acquired = false
+      return new AcpCliRuntime('grok', {
+        cwd: createDeps.vaultPath,
+        resolveHost: () => {
+          if (!hostPromise) {
+            acquired = true
+            hostPromise = hostPool.acquire(HOST_KEY)
+          }
+          return hostPromise
+        },
+        releaseHost: () => {
+          if (!acquired) return
+          acquired = false
+          hostPromise = null
+          hostPool.release(HOST_KEY)
+        },
+      })
+    },
+    dispose: () => hostPool.dispose(),
+  }
+}

--- a/src/core/cli-runtime/grok/index.ts
+++ b/src/core/cli-runtime/grok/index.ts
@@ -1,0 +1,4 @@
+export * from './auth'
+export * from './factory'
+export * from './profile'
+export * from './resolve-command'

--- a/src/core/cli-runtime/grok/profile.test.ts
+++ b/src/core/cli-runtime/grok/profile.test.ts
@@ -1,0 +1,45 @@
+import { grokAgentProfile } from './profile'
+import { resolveGrokCommand } from './resolve-command'
+
+jest.mock('./resolve-command', () => ({
+  resolveGrokCommand: jest.fn(async () => ({
+    command: '/bin/grok',
+    args: [
+      '--no-auto-update',
+      '--permission-mode',
+      'default',
+      'agent',
+      '--no-leader',
+      'stdio',
+    ],
+  })),
+}))
+
+const mockedResolveGrokCommand = jest.mocked(resolveGrokCommand)
+
+describe('grokAgentProfile', () => {
+  it('identifies Grok and delegates command resolution', async () => {
+    await expect(
+      grokAgentProfile.resolveCommand({ PATH: '/usr/bin' }, '/configured/grok'),
+    ).resolves.toMatchObject({ command: '/bin/grok' })
+    expect(grokAgentProfile.runtimeId).toBe('grok')
+    expect(grokAgentProfile.displayName).toBe('Grok')
+    expect(mockedResolveGrokCommand).toHaveBeenCalledWith(
+      { PATH: '/usr/bin' },
+      process.platform,
+      '/configured/grok',
+    )
+  })
+
+  it('selects only cached subscription authentication', () => {
+    expect(
+      grokAgentProfile.selectAuthMethod?.({
+        protocolVersion: 1,
+        authMethods: [
+          { id: 'grok.com', name: 'Grok.com' },
+          { id: 'cached_token', name: 'Cached token' },
+        ],
+      }),
+    ).toBe('cached_token')
+  })
+})

--- a/src/core/cli-runtime/grok/profile.ts
+++ b/src/core/cli-runtime/grok/profile.ts
@@ -1,0 +1,18 @@
+import type { AcpAgentProfile } from '../acp/agent-profile'
+
+import { selectGrokSubscriptionAuthMethod } from './auth'
+import { resolveGrokCommand } from './resolve-command'
+
+/**
+ * Official Grok Build ACP profile. Authentication stays inside the signed
+ * CLI: YOLO requests only the already cached subscription credential and
+ * never reads or persists Grok's token files itself.
+ */
+export const grokAgentProfile: AcpAgentProfile = {
+  runtimeId: 'grok',
+  displayName: 'Grok',
+  resolveCommand: (env, cliPathOverride) =>
+    resolveGrokCommand(env, process.platform, cliPathOverride),
+  selectAuthMethod: (init) =>
+    selectGrokSubscriptionAuthMethod(init.authMethods ?? []),
+}

--- a/src/core/cli-runtime/grok/resolve-command.test.ts
+++ b/src/core/cli-runtime/grok/resolve-command.test.ts
@@ -1,0 +1,173 @@
+/* eslint-disable import/no-nodejs-modules -- exercises the desktop-only Grok executable discovery boundary */
+import { access } from 'node:fs/promises'
+/* eslint-enable import/no-nodejs-modules */
+
+import { findGrokExecutable, resolveGrokCommand } from './resolve-command'
+
+jest.mock('node:fs/promises', () => ({
+  access: jest.fn(),
+  constants: { X_OK: 1 },
+}))
+
+const mockedAccess = jest.mocked(access)
+
+describe('Grok executable discovery', () => {
+  beforeEach(() => mockedAccess.mockRejectedValue(new Error('ENOENT')))
+
+  it('prefers Grok from PATH', async () => {
+    mockedAccess.mockImplementation(async (candidate) => {
+      if (String(candidate) === '/custom/bin/grok') return
+      throw new Error('ENOENT')
+    })
+
+    await expect(
+      findGrokExecutable(
+        { PATH: '/custom/bin:/usr/bin', HOME: '/home/me' },
+        'linux',
+      ),
+    ).resolves.toBe('/custom/bin/grok')
+  })
+
+  it('finds the official per-user install and launches an isolated ACP process in ask-first mode', async () => {
+    mockedAccess.mockImplementation(async (candidate) => {
+      if (String(candidate) === '/home/me/.grok/bin/grok') return
+      throw new Error('ENOENT')
+    })
+
+    await expect(
+      resolveGrokCommand({ PATH: '/usr/bin', HOME: '/home/me' }, 'linux'),
+    ).resolves.toEqual({
+      command: '/home/me/.grok/bin/grok',
+      args: [
+        '--no-auto-update',
+        '--permission-mode',
+        'default',
+        'agent',
+        '--no-leader',
+        'stdio',
+      ],
+    })
+  })
+
+  it('honors the official GROK_HOME installation override before the default home', async () => {
+    mockedAccess.mockImplementation(async (candidate) => {
+      if (
+        String(candidate) === '/custom/grok-home/bin/grok' ||
+        String(candidate) === '/usr/bin/grok'
+      )
+        return
+      throw new Error('ENOENT')
+    })
+
+    await expect(
+      findGrokExecutable(
+        {
+          PATH: '/usr/bin',
+          HOME: '/home/me',
+          GROK_HOME: '/custom/grok-home',
+        },
+        'linux',
+      ),
+    ).resolves.toBe('/custom/grok-home/bin/grok')
+  })
+
+  it('prefers an existing configured path and expands a Unix home shortcut', async () => {
+    mockedAccess.mockImplementation(async (candidate) => {
+      if (String(candidate) === '/home/me/bin/grok') return
+      throw new Error('ENOENT')
+    })
+
+    await expect(
+      resolveGrokCommand(
+        { PATH: '/usr/bin', HOME: '/home/me' },
+        'linux',
+        '~/bin/grok',
+      ),
+    ).resolves.toEqual({
+      command: '/home/me/bin/grok',
+      args: [
+        '--no-auto-update',
+        '--permission-mode',
+        'default',
+        'agent',
+        '--no-leader',
+        'stdio',
+      ],
+    })
+  })
+
+  it('falls back to auto-detection when a configured path is stale', async () => {
+    mockedAccess.mockImplementation(async (candidate) => {
+      if (String(candidate) === '/home/me/.grok/bin/grok') return
+      throw new Error('ENOENT')
+    })
+
+    await expect(
+      resolveGrokCommand(
+        { PATH: '/usr/bin', HOME: '/home/me' },
+        'linux',
+        '/stale/grok',
+      ),
+    ).resolves.toMatchObject({ command: '/home/me/.grok/bin/grok' })
+  })
+
+  it('probes the official per-user Windows install using USERPROFILE before a Git-Bash HOME', async () => {
+    mockedAccess.mockImplementation(async (candidate) => {
+      if (String(candidate) === 'C:\\Users\\me\\.grok\\bin\\grok.exe') return
+      throw new Error('ENOENT')
+    })
+
+    await expect(
+      findGrokExecutable(
+        {
+          PATH: '',
+          HOME: '/c/Users/me',
+          USERPROFILE: 'C:\\Users\\me',
+        },
+        'win32',
+      ),
+    ).resolves.toBe('C:\\Users\\me\\.grok\\bin\\grok.exe')
+  })
+
+  it('rewrites a Windows extensionless override to a spawnable wrapper', async () => {
+    mockedAccess.mockImplementation(async (candidate) => {
+      const value = String(candidate)
+      if (value === 'C:\\tools\\grok' || value === 'C:\\tools\\grok.cmd') return
+      throw new Error('ENOENT')
+    })
+
+    await expect(
+      resolveGrokCommand(
+        { USERPROFILE: 'C:\\Users\\me' },
+        'win32',
+        'C:\\tools\\grok',
+      ),
+    ).resolves.toMatchObject({ command: 'C:\\tools\\grok.cmd' })
+  })
+
+  it('expands a Windows home-relative override against USERPROFILE', async () => {
+    mockedAccess.mockImplementation(async (candidate) => {
+      if (String(candidate) === 'C:\\Users\\me\\custom\\grok.cmd') return
+      throw new Error('ENOENT')
+    })
+
+    await expect(
+      resolveGrokCommand(
+        {
+          HOME: '/c/Users/me',
+          USERPROFILE: 'C:\\Users\\me',
+        },
+        'win32',
+        '~/custom/grok',
+      ),
+    ).resolves.toMatchObject({
+      command: 'C:\\Users\\me\\custom\\grok.cmd',
+    })
+  })
+
+  it('returns null when Grok cannot be found', async () => {
+    await expect(
+      resolveGrokCommand({ PATH: '/usr/bin', HOME: '/home/me' }, 'linux'),
+    ).resolves.toBeNull()
+  })
+})

--- a/src/core/cli-runtime/grok/resolve-command.ts
+++ b/src/core/cli-runtime/grok/resolve-command.ts
@@ -1,0 +1,152 @@
+/* eslint-disable import/no-nodejs-modules -- loaded only inside the desktop CLI runtime boundary */
+import { access, constants } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import * as path from 'node:path'
+/* eslint-enable import/no-nodejs-modules */
+
+import type { AcpResolvedCommand } from '../acp/agent-profile'
+import { resolveWindowsSpawnablePath } from '../windows-spawn'
+
+const existingFile = async (candidate: string): Promise<boolean> => {
+  try {
+    await access(candidate, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const unique = (values: string[], platform: NodeJS.Platform): string[] => {
+  const seen = new Set<string>()
+  return values.filter((value) => {
+    if (!value) return false
+    const key = platform === 'win32' ? value.toLowerCase() : value
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+const firstEnvironmentValue = (
+  env: NodeJS.ProcessEnv,
+  ...keys: string[]
+): string | undefined => {
+  for (const key of keys) {
+    const value = env[key]
+    if (value) return value
+  }
+  return undefined
+}
+
+const cleanEnvironmentPath = (value: string): string =>
+  value.trim().replace(/^"|"$/g, '')
+
+const resolveUserHome = (
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string =>
+  cleanEnvironmentPath(
+    (platform === 'win32'
+      ? firstEnvironmentValue(env, 'USERPROFILE', 'HOME')
+      : firstEnvironmentValue(env, 'HOME', 'USERPROFILE')) ?? homedir(),
+  )
+
+const expandHomePath = (
+  value: string,
+  home: string,
+  platform: NodeJS.Platform,
+): string => {
+  if (value === '~') return home
+  if (value.startsWith('~/')) {
+    return platform === 'win32'
+      ? path.win32.join(home, value.slice(2))
+      : path.join(home, value.slice(2))
+  }
+  return value
+}
+
+const resolveConfiguredExecutable = async (
+  configuredPath: string | undefined,
+  home: string,
+  platform: NodeJS.Platform,
+): Promise<string | null> => {
+  const trimmed = configuredPath ? cleanEnvironmentPath(configuredPath) : ''
+  if (!trimmed) return null
+  const expanded = expandHomePath(trimmed, home, platform)
+  return resolveWindowsSpawnablePath(expanded, existingFile, platform)
+}
+
+export const findGrokExecutable = async (
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): Promise<string | null> => {
+  const home = resolveUserHome(env, platform)
+  const configuredGrokHome = firstEnvironmentValue(env, 'GROK_HOME')
+  const grokHome = configuredGrokHome
+    ? expandHomePath(cleanEnvironmentPath(configuredGrokHome), home, platform)
+    : ''
+  const delimiter = platform === 'win32' ? ';' : ':'
+  const pathEntries = (firstEnvironmentValue(env, 'PATH', 'Path', 'path') ?? '')
+    .split(delimiter)
+    .map(cleanEnvironmentPath)
+    .filter(Boolean)
+  const grokHomeEntries = grokHome
+    ? [
+        platform === 'win32'
+          ? path.win32.join(grokHome, 'bin')
+          : path.join(grokHome, 'bin'),
+      ]
+    : []
+  const commonEntries =
+    platform === 'win32'
+      ? [home ? path.win32.join(home, '.grok', 'bin') : '']
+      : [
+          path.join(home, '.grok', 'bin'),
+          path.join(home, '.local', 'bin'),
+          '/usr/local/bin',
+          '/opt/homebrew/bin',
+          '/usr/bin',
+        ]
+  const names =
+    platform === 'win32'
+      ? ['grok.exe', 'grok.cmd', 'grok.bat', 'grok']
+      : ['grok']
+
+  for (const directory of unique(
+    [...grokHomeEntries, ...pathEntries, ...commonEntries],
+    platform,
+  )) {
+    for (const name of names) {
+      const candidate =
+        platform === 'win32'
+          ? path.win32.join(directory, name)
+          : path.join(directory, name)
+      if (await existingFile(candidate)) return candidate
+    }
+  }
+  return null
+}
+
+/** Resolve the official Grok CLI and launch a dedicated, ask-first ACP server. */
+export const resolveGrokCommand = async (
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+  cliPathOverride?: string,
+): Promise<AcpResolvedCommand | null> => {
+  const home = resolveUserHome(env, platform)
+  const command =
+    (await resolveConfiguredExecutable(cliPathOverride, home, platform)) ??
+    (await findGrokExecutable(env, platform))
+  if (!command) return null
+  return {
+    command,
+    args: [
+      '--no-auto-update',
+      '--permission-mode',
+      'default',
+      'agent',
+      '--no-leader',
+      'stdio',
+    ],
+  }
+}

--- a/src/core/cli-runtime/model-catalog-store.test.ts
+++ b/src/core/cli-runtime/model-catalog-store.test.ts
@@ -1,0 +1,63 @@
+import type { App } from 'obsidian'
+
+import { VaultCliModelCatalogStore } from './model-catalog-store'
+
+const createMemoryApp = () => {
+  const files = new Map<string, string>()
+  const directories = new Set<string>()
+  const adapter = {
+    exists: jest.fn(
+      async (path: string) => files.has(path) || directories.has(path),
+    ),
+    mkdir: jest.fn(async (path: string) => {
+      directories.add(path)
+    }),
+    read: jest.fn(async (path: string) => {
+      const value = files.get(path)
+      if (value === undefined) throw new Error(`Missing file: ${path}`)
+      return value
+    }),
+    write: jest.fn(async (path: string, content: string) => {
+      files.set(path, content)
+    }),
+  }
+  return { app: { vault: { adapter } } as unknown as App }
+}
+
+describe('VaultCliModelCatalogStore', () => {
+  it('round-trips a Grok ACP model catalog', async () => {
+    const { app } = createMemoryApp()
+    const store = new VaultCliModelCatalogStore(app, () => null)
+    await store.write(
+      new Map([
+        [
+          'grok',
+          [
+            {
+              id: 'grok-4.6',
+              label: 'Grok 4.6',
+              reasoningEfforts: [],
+              isDefault: true,
+            },
+          ],
+        ],
+      ]),
+    )
+
+    await expect(store.read()).resolves.toEqual(
+      new Map([
+        [
+          'grok',
+          [
+            {
+              id: 'grok-4.6',
+              label: 'Grok 4.6',
+              reasoningEfforts: [],
+              isDefault: true,
+            },
+          ],
+        ],
+      ]),
+    )
+  })
+})

--- a/src/core/cli-runtime/model-catalog-store.ts
+++ b/src/core/cli-runtime/model-catalog-store.ts
@@ -28,6 +28,7 @@ const documentSchema = z.object({
     codex: z.array(modelSchema).optional(),
     hermes: z.array(modelSchema).optional(),
     pi: z.array(modelSchema).optional(),
+    grok: z.array(modelSchema).optional(),
   }),
 })
 

--- a/src/core/cli-runtime/registry.test.ts
+++ b/src/core/cli-runtime/registry.test.ts
@@ -18,21 +18,40 @@ describe('CLI runtime registry', () => {
   it('resolves a descriptor by id', () => {
     expect(getCliRuntimeDescriptor('claude-code').id).toBe('claude-code')
     expect(getCliRuntimeDescriptor('codex').id).toBe('codex')
+    expect(getCliRuntimeDescriptor('grok')).toMatchObject({
+      id: 'grok',
+      icon: { provider: 'xai' },
+    })
   })
 
-  it('gives every descriptor a label, description, and icon', () => {
+  it('gives every descriptor a label, fallback, description, and icon', () => {
     for (const descriptor of CLI_RUNTIME_DESCRIPTORS) {
       expect(descriptor.labelKey.length).toBeGreaterThan(0)
+      expect(descriptor.defaultLabel.length).toBeGreaterThan(0)
       expect(descriptor.descriptionKey.length).toBeGreaterThan(0)
       expect(descriptor.icon.src.length).toBeGreaterThan(0)
       expect(descriptor.icon.provider.length).toBeGreaterThan(0)
     }
   })
 
-  it('only gives Claude Code a short label — Codex has no shorter form', () => {
+  it('only gives Claude Code a short label — other runtimes use their full labels', () => {
     expect(getCliRuntimeDescriptor('claude-code').shortLabelKey).toBe(
       'sidebar.runtimeSelector.claudeCodeShortLabel',
     )
     expect(getCliRuntimeDescriptor('codex').shortLabelKey).toBeUndefined()
+    expect(getCliRuntimeDescriptor('grok').shortLabelKey).toBeUndefined()
+  })
+
+  it('hides the YOLO toggle only for the pinned ask-first Grok runtime', () => {
+    expect(RUNTIME_CAPABILITIES['claude-code'].showsYoloToggle).toBe(true)
+    expect(RUNTIME_CAPABILITIES.codex.showsYoloToggle).toBe(true)
+    expect(RUNTIME_CAPABILITIES.pi.showsYoloToggle).toBe(true)
+    expect(RUNTIME_CAPABILITIES.hermes.showsYoloToggle).toBe(true)
+    expect(RUNTIME_CAPABILITIES.grok.showsYoloToggle).toBe(false)
+  })
+
+  it('declares the known Grok ACP image-input limitation', () => {
+    expect(RUNTIME_CAPABILITIES.grok.supportsImageAttachments).toBe(false)
+    expect(RUNTIME_CAPABILITIES.hermes.supportsImageAttachments).toBe(true)
   })
 })

--- a/src/core/cli-runtime/registry.ts
+++ b/src/core/cli-runtime/registry.ts
@@ -2,6 +2,7 @@ import anthropicLogo from '../../assets/provider-icons/anthropic.svg'
 import hermesLogo from '../../assets/provider-icons/hermes.svg'
 import openaiLogo from '../../assets/provider-icons/openai.svg'
 import piLogo from '../../assets/provider-icons/pi.svg'
+import xaiLogo from '../../assets/provider-icons/xai.svg'
 
 import { RUNTIME_CAPABILITIES } from './capabilities'
 import type { ChatRuntimeCapabilities } from './capabilities'
@@ -20,6 +21,8 @@ import type { CliRuntimeId } from './types'
  */
 export type CliRuntimeDescriptor = Readonly<{
   id: CliRuntimeId
+  /** Stable English fallback for call sites where a locale key is absent. */
+  defaultLabel: string
   /** i18n key, e.g. `sidebar.runtimeSelector.claudeCodeLabel`. */
   labelKey: string
   /**
@@ -37,6 +40,7 @@ const DESCRIPTORS_BY_ID: Readonly<Record<CliRuntimeId, CliRuntimeDescriptor>> =
   {
     'claude-code': {
       id: 'claude-code',
+      defaultLabel: 'Claude Code',
       labelKey: 'sidebar.runtimeSelector.claudeCodeLabel',
       shortLabelKey: 'sidebar.runtimeSelector.claudeCodeShortLabel',
       descriptionKey: 'sidebar.runtimeSelector.claudeCodeDescription',
@@ -45,6 +49,7 @@ const DESCRIPTORS_BY_ID: Readonly<Record<CliRuntimeId, CliRuntimeDescriptor>> =
     },
     codex: {
       id: 'codex',
+      defaultLabel: 'Codex',
       labelKey: 'sidebar.runtimeSelector.codexLabel',
       descriptionKey: 'sidebar.runtimeSelector.codexDescription',
       icon: { src: openaiLogo, provider: 'openai' },
@@ -52,6 +57,7 @@ const DESCRIPTORS_BY_ID: Readonly<Record<CliRuntimeId, CliRuntimeDescriptor>> =
     },
     hermes: {
       id: 'hermes',
+      defaultLabel: 'Hermes',
       labelKey: 'sidebar.runtimeSelector.hermesLabel',
       descriptionKey: 'sidebar.runtimeSelector.hermesDescription',
       icon: { src: hermesLogo, provider: 'hermes' },
@@ -59,10 +65,19 @@ const DESCRIPTORS_BY_ID: Readonly<Record<CliRuntimeId, CliRuntimeDescriptor>> =
     },
     pi: {
       id: 'pi',
+      defaultLabel: 'Pi',
       labelKey: 'sidebar.runtimeSelector.piLabel',
       descriptionKey: 'sidebar.runtimeSelector.piDescription',
       icon: { src: piLogo, provider: 'pi' },
       capabilities: RUNTIME_CAPABILITIES.pi,
+    },
+    grok: {
+      id: 'grok',
+      defaultLabel: 'Grok',
+      labelKey: 'sidebar.runtimeSelector.grokLabel',
+      descriptionKey: 'sidebar.runtimeSelector.grokDescription',
+      icon: { src: xaiLogo, provider: 'xai' },
+      capabilities: RUNTIME_CAPABILITIES.grok,
     },
   }
 

--- a/src/core/cli-runtime/session-index.test.ts
+++ b/src/core/cli-runtime/session-index.test.ts
@@ -14,6 +14,12 @@ describe('CLI session index contract', () => {
         nativeSessionId: 'thread/with spaces',
       }),
     ).toBe('codex:thread%2Fwith%20spaces')
+    expect(
+      getCliSessionIndexKey({
+        runtimeId: 'grok',
+        nativeSessionId: 'session/with spaces',
+      }),
+    ).toBe('grok:session%2Fwith%20spaces')
   })
 
   it('keeps paths as mutable hints outside the stable key', () => {

--- a/src/core/cli-runtime/types.ts
+++ b/src/core/cli-runtime/types.ts
@@ -16,7 +16,13 @@ import type { CliChatMode } from './permission-profile'
  * never drift; adding a runtime means adding one entry here (plus a
  * `CliRuntimeDescriptor` in `registry.ts` and a factory in `coordinator.ts`).
  */
-export const CLI_RUNTIME_IDS = ['claude-code', 'codex', 'hermes', 'pi'] as const
+export const CLI_RUNTIME_IDS = [
+  'claude-code',
+  'codex',
+  'hermes',
+  'pi',
+  'grok',
+] as const
 export type CliRuntimeId = (typeof CLI_RUNTIME_IDS)[number]
 export type ChatRuntimeId = 'yolo' | CliRuntimeId
 

--- a/src/database/json/chat/types.ts
+++ b/src/database/json/chat/types.ts
@@ -10,7 +10,7 @@ export const CHAT_SCHEMA_VERSION = 1
 export type ChatConversationOrigin = 'user' | 'external-agent'
 
 export type ChatConversationCliSession = {
-  runtimeId: 'claude-code' | 'codex' | 'hermes' | 'pi'
+  runtimeId: 'claude-code' | 'codex' | 'hermes' | 'pi' | 'grok'
   nativeSessionId: string
   sessionPathHint?: string
   /** Hermes profile this session lives under (see `CliSessionRef.profileId`). */

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -81,6 +81,8 @@ export const en: TranslationKeys = {
       hermesDescription: 'Hermes on this device',
       piLabel: 'Pi',
       piDescription: 'Pi on this device',
+      grokLabel: 'Grok',
+      grokDescription: 'Grok Build on this device',
     },
     chatList: {
       searchPlaceholder: 'Search conversations',
@@ -774,6 +776,9 @@ export const en: TranslationKeys = {
       piCliPathName: 'Pi CLI path',
       piCliPathDesc:
         'Custom path to the pi executable — paste the output of "which pi" ("where pi" on Windows). Leave empty to auto-detect. Stored on this device only.',
+      grokCliPathName: 'Grok CLI path',
+      grokCliPathDesc:
+        'Custom path to the grok executable — paste the output of "which grok" ("where grok" on Windows). Leave empty to auto-detect. Stored on this device only.',
       cliPathMissing:
         'This path does not exist on this device; auto-detection will be used instead.',
       autoContextCompactionBlockTitle: 'Context compaction',
@@ -1955,6 +1960,7 @@ export const en: TranslationKeys = {
     dropFilesHint: 'Drop to add to the conversation',
     imageUnsupportedByModel:
       'This model has not declared image support. Enable the "Vision" input modality in the model settings to attach images.',
+    imageUnsupportedByRuntime: 'This CLI runtime does not accept image input.',
     unsupportedFileType: 'Unsupported file type: {names}',
     processImagesFailed: 'Failed to process uploaded images',
     readPdfFailed: 'Failed to read PDF "{name}": {error}',
@@ -2034,7 +2040,7 @@ export const en: TranslationKeys = {
     cliSurface: {
       emptyTitle: 'Use CLI Agent',
       emptyDescription:
-        'Connect Claude Code or Codex to run complex tasks on this device.',
+        'Connect a supported CLI agent to run complex tasks on this device.',
       emptyUserMessage: 'Empty message',
       error: 'CLI session error: {message}',
       runtimeError: 'Could not start the CLI runtime: {message}',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -98,6 +98,8 @@ export const it: DeepPartial<TranslationKeys> = {
       hermesDescription: 'Hermes su questo dispositivo',
       piLabel: 'Pi',
       piDescription: 'Pi su questo dispositivo',
+      grokLabel: 'Grok',
+      grokDescription: 'Grok Build su questo dispositivo',
     },
     chatList: {
       searchPlaceholder: 'Cerca conversazioni',
@@ -777,6 +779,9 @@ export const it: DeepPartial<TranslationKeys> = {
       piCliPathName: 'Percorso CLI di Pi',
       piCliPathDesc:
         'Percorso personalizzato dell\'eseguibile pi — incolla l\'output di "which pi" ("where pi" su Windows). Lascia vuoto per il rilevamento automatico. Salvato solo su questo dispositivo.',
+      grokCliPathName: 'Percorso CLI di Grok',
+      grokCliPathDesc:
+        'Percorso personalizzato dell\'eseguibile grok — incolla l\'output di "which grok" ("where grok" su Windows). Lascia vuoto per il rilevamento automatico. Salvato solo su questo dispositivo.',
       cliPathMissing:
         'Questo percorso non esiste su questo dispositivo; verrà usato il rilevamento automatico.',
       autoContextCompactionBlockTitle: 'Compattazione contesto',
@@ -1806,6 +1811,8 @@ export const it: DeepPartial<TranslationKeys> = {
     dropFilesHint: 'Rilascia per aggiungere alla conversazione',
     imageUnsupportedByModel:
       'Questo modello non dichiara il supporto alle immagini. Abilita la modalità di input "Vision" nelle impostazioni del modello per allegare immagini.',
+    imageUnsupportedByRuntime:
+      'Questo runtime CLI non accetta input di immagini.',
     unsupportedFileType: 'Tipo di file non supportato: {names}',
     processImagesFailed: 'Impossibile elaborare le immagini caricate',
     readPdfFailed: 'Impossibile leggere il PDF "{name}": {error}',
@@ -1883,7 +1890,7 @@ export const it: DeepPartial<TranslationKeys> = {
     cliSurface: {
       emptyTitle: 'Usa CLI Agent',
       emptyDescription:
-        'Collega Claude Code o Codex per eseguire attività complesse su questo dispositivo.',
+        'Collega un agent CLI supportato per eseguire attività complesse su questo dispositivo.',
       emptyUserMessage: 'Messaggio vuoto',
       error: 'Errore della sessione CLI: {message}',
       runtimeError: 'Impossibile avviare il runtime CLI: {message}',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -81,6 +81,8 @@ export const zh: TranslationKeys = {
       hermesDescription: '本机 Hermes 运行时',
       piLabel: 'Pi',
       piDescription: '本机 Pi 运行时',
+      grokLabel: 'Grok',
+      grokDescription: '本机 Grok Build 运行时',
     },
     chatList: {
       searchPlaceholder: '搜索聊天记录',
@@ -719,6 +721,9 @@ export const zh: TranslationKeys = {
       piCliPathName: 'Pi CLI 路径',
       piCliPathDesc:
         '自定义 pi 可执行文件路径，可粘贴 which pi（Windows 为 where pi）的输出。留空则自动检测；仅保存在本设备，不随库同步。',
+      grokCliPathName: 'Grok CLI 路径',
+      grokCliPathDesc:
+        '自定义 grok 可执行文件路径，可粘贴 which grok（Windows 为 where grok）的输出。留空则自动检测；仅保存在本设备，不随库同步。',
       cliPathMissing: '该路径在本设备上不存在，将回退到自动检测。',
       autoContextCompactionBlockTitle: '上下文压缩',
       autoContextCompaction: '自动压缩上下文',
@@ -1859,6 +1864,7 @@ export const zh: TranslationKeys = {
     dropFilesHint: '松开以添加到对话',
     imageUnsupportedByModel:
       '当前模型未声明支持图片输入；请在模型设置里开启「图片」模态后再上传。',
+    imageUnsupportedByRuntime: '当前 CLI 运行时不接受图片输入。',
     unsupportedFileType: '不支持的文件类型：{names}',
     processImagesFailed: '处理上传图片失败',
     readPdfFailed: '读取 PDF「{name}」失败：{error}',
@@ -1932,7 +1938,7 @@ export const zh: TranslationKeys = {
     },
     cliSurface: {
       emptyTitle: '使用 CLI Agent',
-      emptyDescription: '连接 Claude Code 或 Codex，直接在本机执行复杂任务',
+      emptyDescription: '连接受支持的 CLI Agent，直接在本机执行复杂任务',
       emptyUserMessage: '空消息',
       error: 'CLI 会话出错：{message}',
       runtimeError: '无法启动 CLI 运行时：{message}',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -90,6 +90,8 @@ export type TranslationKeys = {
       hermesDescription: string
       piLabel: string
       piDescription: string
+      grokLabel: string
+      grokDescription: string
     }
     chatList?: {
       searchPlaceholder?: string
@@ -583,6 +585,8 @@ export type TranslationKeys = {
       hermesCliPathDesc?: string
       piCliPathName?: string
       piCliPathDesc?: string
+      grokCliPathName?: string
+      grokCliPathDesc?: string
       cliPathMissing?: string
       autoContextCompactionBlockTitle?: string
       autoContextCompaction?: string
@@ -1701,6 +1705,7 @@ export type TranslationKeys = {
     uploadFile?: string
     dropFilesHint?: string
     imageUnsupportedByModel?: string
+    imageUnsupportedByRuntime?: string
     unsupportedFileType?: string
     processImagesFailed?: string
     readPdfFailed?: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -1915,10 +1915,7 @@ export default class YoloPlugin extends Plugin {
     }
 
     const descriptor = getCliRuntimeDescriptor(runtimeId)
-    const fullLabel = this.t(
-      descriptor.labelKey,
-      runtimeId === 'claude-code' ? 'Claude Code' : 'Codex',
-    )
+    const fullLabel = this.t(descriptor.labelKey, descriptor.defaultLabel)
     badge.classList.add(`yolo-runtime-badge--${runtimeId}`)
     badge.setText(
       descriptor.shortLabelKey

--- a/src/settings/schema/settings.test.ts
+++ b/src/settings/schema/settings.test.ts
@@ -138,13 +138,19 @@ describe('parseYoloSettings', () => {
       chatOptions: {
         includeCurrentFileContent: true,
         lastChatSurface: 'chat',
-        lastCliRuntimeId: 'codex',
+        lastCliRuntimeId: 'grok',
+        cliModelIdByRuntime: { grok: 'grok-4.6' },
+        cliChatModeByRuntime: { grok: 'agent' },
+        cliAgentYoloEnabledByRuntime: { grok: false },
       },
     })
 
     expect(result.chatOptions).toMatchObject({
       lastChatSurface: 'chat',
-      lastCliRuntimeId: 'codex',
+      lastCliRuntimeId: 'grok',
+      cliModelIdByRuntime: { grok: 'grok-4.6' },
+      cliChatModeByRuntime: { grok: 'agent' },
+      cliAgentYoloEnabledByRuntime: { grok: false },
     })
   })
 

--- a/src/styles/chat/input.css
+++ b/src/styles/chat/input.css
@@ -124,7 +124,8 @@ button.yolo-runtime-selector:disabled {
   user-select: none;
 }
 
-body.theme-dark .yolo-runtime-selector__provider-logo[data-provider='openai'] {
+body.theme-dark .yolo-runtime-selector__provider-logo[data-provider='openai'],
+body.theme-dark .yolo-runtime-selector__provider-logo[data-provider='xai'] {
   filter: invert(1);
 }
 

--- a/src/styles/chat/runtime-badge.css
+++ b/src/styles/chat/runtime-badge.css
@@ -1,5 +1,5 @@
 /*
- * Short CLI runtime marker (CC / Codex / Hermes / Pi).
+ * Short CLI runtime marker (CC / Codex / Hermes / Pi / Grok).
  *
  * Shared by every surface that attributes a conversation or a live run to its
  * runtime — the chat list popover and the background activity status panel.
@@ -34,4 +34,9 @@
 .yolo-runtime-badge--pi {
   background: color-mix(in srgb, var(--color-purple) 14%, transparent);
   color: color-mix(in srgb, var(--color-purple) 82%, var(--text-normal));
+}
+
+.yolo-runtime-badge--grok {
+  background: color-mix(in srgb, var(--text-normal) 10%, transparent);
+  color: var(--text-normal);
 }

--- a/src/types/conversation-settings.types.ts
+++ b/src/types/conversation-settings.types.ts
@@ -11,6 +11,7 @@ export type ConversationOverrideSettings = {
     codex?: 'agent' | 'plan' | null
     hermes?: 'agent' | 'plan' | null
     pi?: 'agent' | 'plan' | null
+    grok?: 'agent' | 'plan' | null
   } | null
   /** Per-conversation CLI YOLO flag, keyed like settings `cliAgentYoloEnabledByRuntime`. */
   cliAgentYoloEnabledByRuntime?: {
@@ -18,6 +19,7 @@ export type ConversationOverrideSettings = {
     codex?: boolean | null
     hermes?: boolean | null
     pi?: boolean | null
+    grok?: boolean | null
   } | null
   temperature?: number | null
   top_p?: number | null

--- a/src/types/tool-call.types.ts
+++ b/src/types/tool-call.types.ts
@@ -149,7 +149,7 @@ export type CliToolCallCapability =
  * replaces the provider-native arguments.
  */
 export type CliToolCallMetadata = {
-  runtimeId: 'claude-code' | 'codex' | 'hermes' | 'pi'
+  runtimeId: 'claude-code' | 'codex' | 'hermes' | 'pi' | 'grok'
   eventType: string
   name: string
   namespace?: string


### PR DESCRIPTION
## Summary

Adds a desktop-only Grok Build runtime through the official ACP stdio interface. It reuses CLI-owned cached subscription authentication, adds runtime selection/path configuration, model switching and session resume, and keeps the existing xAI API-key provider unchanged.

## Linked issue / discussion

Refs #590 — pending maintainer alignment before this draft is marked ready.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs / comments
- [ ] 🎨 Style / CSS only
- [ ] 🧪 Tests only
- [ ] 🔧 Build / tooling / chore

## Size

- [ ] S (< 100 lines)
- [ ] M (100–500 lines)
- [x] L (500–2,000 lines)
- [ ] XL (> 2,000 lines)

## AI assistance disclosure

- [ ] No AI-generated code in this PR
- [x] AI was used to write part or all of this PR

If you checked the second box, please confirm:

- [x] I understand what changed and why, and I can explain any part of the diff if asked during review.

## Why this approach

xAI does not document third-party OAuth client registration for direct inference, while Grok Build officially exposes ACP for IDE integrations. This keeps credentials inside the official CLI, accepts only its advertised `cached_token`, shadows ambient API-key variables, and starts a dedicated ask-first process without leader sharing. The main compatibility risk is a future Grok CLI change to its authentication methods, launch flags, or ACP capabilities.

## Screenshots / recordings

- TODO before marking ready: attach the Grok runtime-selector screenshot.
- TODO before marking ready: attach the Settings → Agent Grok CLI-path screenshot.

## Pre-submit checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/Lapis0x0/obsidian-yolo/blob/main/CONTRIBUTING.md)
- [x] `npm run type:check` passes
- [x] `npm run lint:check` passes (or `npm run lint:fix` was run)
- [x] `npm test` passes
  - 500 suites and 4,679 tests passed.
- [x] I tested this manually in Obsidian
  - Obsidian 1.13.7 in a disposable vault verified the Grok selector and CLI-path setting, cached-subscription Grok 4.6 response, read-only vault access, one-time approval before a single-file write, Grok 4.5 switching, plugin reload with same-native-session resume, and pasted-image rejection.
- [x] CSS validation: I edited `src/styles/**` and ran `npm run styles:build` through `npm run build`.
  - Root `styles.css` is gitignored and untracked on current `main`, so generated output was verified locally rather than committed.

Additional validation: `npm run deps:check`, `git diff --check`, and `npm run build` pass.
